### PR TITLE
chore(root): add community health files for public release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# Every pull request requests a review from the maintainer.
+#
+# The ruleset on `main` does not require an approval, so this auto-requests
+# rather than blocks. Paths that can execute code on the self-hosted runner or
+# publish to npm are listed explicitly so they stay visible in the review queue.
+
+* @vuongngo
+
+# CI, release automation, and anything that touches the self-hosted runner.
+/.github/                        @vuongngo
+/.github/workflows/              @vuongngo
+/scripts/                        @vuongngo
+
+# Supply-chain surface: lockfile, workspace layout, and native payload fetching.
+/pnpm-lock.yaml                  @vuongngo
+/pnpm-workspace.yaml             @vuongngo
+/scripts/fetch-runner-binaries.mjs @vuongngo
+
+# Security and contribution policy.
+/SECURITY.md                     @vuongngo
+/CODE_OF_CONDUCT.md              @vuongngo
+/CONTRIBUTING.md                 @vuongngo

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: Bug report
+description: Something in DoomPi behaves differently than documented.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        DoomPi is alpha software. Before filing, please confirm you are on the
+        latest published alpha, since earlier alphas are not patched retroactively.
+
+
+        If this is a security problem, do not file it here. Use private
+        vulnerability reporting instead (see SECURITY.md).
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you observed, and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: >-
+        The smallest set of steps that reproduces this. Include the command you
+        ran and the relevant part of your DoomPi configuration.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: DoomPi version
+      description: "Output of `doompi --version`, or the published alpha you installed."
+      placeholder: 0.0.1-alpha.x
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Linux
+        - Windows (WSL)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: node
+    attributes:
+      label: Node and package manager versions
+      placeholder: "node 22.22.1, pnpm 9.x"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output
+      description: >-
+        Error output or logs. Please redact tokens, absolute paths you would
+        rather not share, and anything else sensitive.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/AgiFlow/doompi/security/advisories/new
+    about: >-
+      Do not open a public issue for a security problem. Use private vulnerability
+      reporting so only the maintainers can read it. See SECURITY.md for scope.
+  - name: Read the docs first
+    url: https://github.com/AgiFlow/doompi/tree/main/docs
+    about: >-
+      Architecture, configuration, and the trust and data boundaries that explain
+      what DoomPi executes on your machine.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Propose a change to what DoomPi does.
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: >-
+        What are you trying to do that DoomPi makes hard today? Describe the
+        situation, not the solution you have in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you would like instead
+      description: >-
+        The simplest change that would solve it. DoomPi favours the minimum
+        thing that works over a general abstraction.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area does this touch
+      options:
+        - "Runtime foundations (packages/core)"
+        - "Default distribution features (packages/default)"
+        - "Optional modes (packages/minor)"
+        - "Selectable extensions (layers)"
+        - "Development tooling (packages/tooling)"
+        - "Docs"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: >-
+        Including any existing DoomPi feature, extension, or configuration you
+        tried first. Reuse before rebuilding.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## What this changes
+
+<!-- One or two sentences. What behaviour is different after this merges? -->
+
+## Why
+
+<!-- The problem being solved. Link the issue if there is one: Closes #123 -->
+
+## Checks
+
+Run these locally before asking for review. CI runs the same set.
+
+- [ ] `pnpm lint:vibe --preflight-only`
+- [ ] Affected Nx targets pass: `lint`, `typecheck`, `build`, `test`
+- [ ] `pnpm fmt:check`
+- [ ] Packed-install system tests, if this is a release change: `pnpm nx run-many -t test-system`
+
+## Scope
+
+- [ ] Package boundaries are respected (`packages/core`, `packages/default`, `packages/minor`, `layers/`, `packages/tooling`)
+- [ ] Doom-to-Doom dependencies stay `workspace:*`
+- [ ] Package exports, Pi entries, resources, runtime ordering, and RMUX LFS payloads are preserved
+- [ ] No unrelated changes bundled in
+
+## Risk
+
+<!--
+Anything a reviewer should look at twice: a new dependency, a change to the
+release workflows, anything that runs on the self-hosted runner, a change to
+what DoomPi executes on a user's machine, or a change to the trust boundary
+documented in docs/trust-and-data-boundaries.md. Write "none" if there is none.
+-->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot keeps the workspace lockfile and the pinned action SHAs current.
+#
+# Updates are grouped so a routine week is a couple of pull requests rather than
+# forty. Each one still has to pass the full `quality` job before it can merge.
+version: 2
+
+updates:
+  # The pnpm workspace resolves every package from the root lockfile, so a
+  # single root entry covers all of `packages/`, `layers/`, and `plugins/`.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+    groups:
+      production-minor-and-patch:
+        dependency-type: production
+        update-types: [minor, patch]
+      development-minor-and-patch:
+        dependency-type: development
+        update-types: [minor, patch]
+    ignore:
+      # Node itself is pinned by the workflows and .nvmrc, not by Dependabot.
+      - dependency-name: "@types/node"
+        update-types: [version-update:semver-major]
+    commit-message:
+      prefix: "chore(root)"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci(root)"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**vuongngo.pd@gmail.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+Note: this address is for conduct reports. Security vulnerabilities go through
+private vulnerability reporting instead, as described in [SECURITY.md](SECURITY.md).
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,11 @@
 Thanks for helping improve DoomPi. The project is still alpha, so focused changes with clear tests
 are easier to review and safer to release.
 
+By participating in this project you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Found a security problem? Do not open a public issue. Follow [SECURITY.md](SECURITY.md) and use
+GitHub's private vulnerability reporting, which keeps the report visible only to the maintainers.
+
 ## Requirements
 
 - Node.js 22.22.1
@@ -84,6 +89,10 @@ Run the additional checks that match the change:
 
 On a pull request, CI runs formatting, the workspace audit, generated hook settings, builds, examples,
 lint, Vibe-Lint, type-checking, and unit tests on a GitHub-hosted runner.
+
+Pull requests from forks always run on a GitHub-hosted runner, never on the project's self-hosted
+machine. If this is your first contribution, a maintainer has to approve the workflow run before CI
+starts, so expect a delay before any results appear.
 
 The serial packed-install system tests run after merge, on push to `main`. They pack and install all
 40 packages for real and assert startup latency percentiles, which are not meaningful on a shared


### PR DESCRIPTION
## What this changes

Adds the contributor-facing files this repository needs before it becomes public, and updates `CONTRIBUTING.md` for an external audience.

| File | Purpose |
| --- | --- |
| `.github/dependabot.yml` | Weekly updates for the pnpm workspace lockfile and the pinned action SHAs, grouped so a routine week is a couple of PRs rather than forty |
| `.github/CODEOWNERS` | Auto-requests review, and keeps CI, release, and supply-chain paths visible in the queue |
| `.github/PULL_REQUEST_TEMPLATE.md` | The local checks CI will run anyway, plus the package boundary rules |
| `.github/ISSUE_TEMPLATE/*` | Bug and feature forms, blank issues disabled, security routed to private reporting |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1, conduct reports kept separate from security reports |

`CONTRIBUTING.md` gains three things: a Code of Conduct link, a pointer sending security problems to private vulnerability reporting instead of public issues, and a note that fork PRs run on GitHub-hosted runners after maintainer approval.

## Why

Groundwork for flipping this repository public. Companion GitHub-side settings (rulesets on `main` and tags, Dependabot alerts, restricted Actions allowlist, `npm-release` environment) were applied directly and are not part of this diff.

## Checks

- [x] `pnpm fmt:check` passes on all 1810 files
- [x] `pnpm lint:vibe --preflight-only` reports no violations across 1522 package files
- [x] All four YAML files parse
- [x] `pnpm vibe-lint check --rules-only` on the touched paths resolves only TypeScript rules, so nothing here is governed
- [ ] `quality` CI job, which this PR is partly here to exercise

No TypeScript changed, so no Nx `lint`/`typecheck`/`build`/`test` target is affected.

## Scope

- [x] No package boundaries touched
- [x] No dependency changes, so no `workspace:*` implications
- [x] Package exports, Pi entries, resources, runtime ordering, and RMUX LFS payloads untouched
- [x] No unrelated changes bundled in

## Risk

Low. Documentation and repository metadata only, no runtime or build code.

Two things worth a second look:

1. `.github/dependabot.yml` deliberately omits Dependabot's `include: scope`. With `prefix: "chore(root)"` it would emit `chore(root)(deps):`, which is malformed and fails the `scope-enum` rule in `.commitlintrc.mjs`. Messages stay `chore(root): ...` and `ci(root): ...`.
2. `CODEOWNERS` lists `@vuongngo` only. `@raulmunif` is in the org but is not listed, matching the single-maintainer statement in `SECURITY.md`. Say the word and I will add them.
