### PR TITLE
feat: price MCP tool schemas in --explain and surface domain allowlists

### DIFF
--- a/docs/trust-and-data-boundaries.md
+++ b/docs/trust-and-data-boundaries.md
@@ -9,6 +9,13 @@ shell commands you configure. Treat them as trusted executable code. Runner comm
 process environment and operating-system privileges; their logs may contain command output and
 secrets. MCP credentials may live in the system keyring or private configuration files.
 
+`doompi --explain` is included in this. To report what MCP tool schemas cost in context it starts
+each configured stdio server, asks it for its tool list, and stops it again. The servers run with
+the same privileges a session gives them, so a command you would not want executed should not be
+configured. Results are cached under `~/.pi/.doom/mcp-schema-cache` and keyed on the server
+command, arguments, and environment, so a server is only started again when that descriptor
+changes. Use `--no-mcp` to inspect a selection without starting anything.
+
 ## Approval prompts in compatibility mode
 
 `doompi compat <codex|claude|antigravity>` resolves the DoomPi matrix and then launches a third-party

--- a/packages/core/doompi-config/src/adapters/init.ts
+++ b/packages/core/doompi-config/src/adapters/init.ts
@@ -152,6 +152,15 @@ domains:
   #       mcp: true
   #   # Set false only when this domain should omit shared .claude/skills.
   #   sharedSkills: false
+  #   # Domain mcp is an allowlist over servers configured elsewhere, not a
+  #   # request to start new ones. Listing servers here drops the tool schemas
+  #   # of the ones left out, usually the largest context saving a domain can
+  #   # make. Run doompi --explain to see the token cost before and after.
+  #   # Filtering applies only when every selected domain declares mcp, so a
+  #   # selection mixing this with a domain that omits it stays unfiltered.
+  #   mcp:
+  #     servers: [code-intel]
+  #     proxy: [repository-search]
 # Select it with doompi --domains development, or add it to defaultDomains.
 #
 # Aliases let one selection enable multiple domains. Replace the empty mapping

--- a/packages/core/doompi-config/tests/init.test.ts
+++ b/packages/core/doompi-config/tests/init.test.ts
@@ -118,6 +118,30 @@ describe('initializeGlobalDoomConfig', () => {
     });
   });
 
+  it('offers the domain mcp allowlist as an example that parses when uncommented', () => {
+    const template = DOOM_CONFIG_TEMPLATES['domains.yaml'];
+    const lines = template.split('\n');
+    const start = lines.findIndex((line) => line.startsWith('  # development:'));
+    const end = lines.findIndex((line) => line.includes('proxy: [repository-search]'));
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    // Only the development block is uncommented: the surrounding prose comments
+    // are not YAML and would not parse.
+    const uncommented = ['domains:', ...lines.slice(start, end + 1).map((line) => line.replace('# ', ''))].join('\n');
+
+    expect(parseYaml(uncommented)).toMatchObject({
+      domains: {
+        development: {
+          sharedSkills: false,
+          plugins: ['development', { name: 'remote-review', mcp: true }],
+          mcp: { servers: ['code-intel'], proxy: ['repository-search'] },
+        },
+      },
+    });
+  });
+
   it('documents how to discover, override, and select profiles', () => {
     const template = DOOM_CONFIG_TEMPLATES['profiles.yaml'];
 

--- a/packages/core/doompi-domain/src/prompts/doompi-author-domain/SKILL.md
+++ b/packages/core/doompi-domain/src/prompts/doompi-author-domain/SKILL.md
@@ -11,6 +11,8 @@ Before editing, read both `~/.pi/.doom/domains.yaml` and the repository's `.doom
 
 Use the smallest source form that preserves intent. Pin Git sources with `sha` and npm sources with an exact `version` when reproducibility matters. Use a domain plugin mapping only when the domain needs resource filters or must disable plugin hooks or MCP.
 
-After editing, validate the intended selection with `doompi --domains <name[,name...]> --explain`, then run `doompi sync --check`. Run mutating `doompi sync` only when the user intends to materialize or refresh synchronized artifacts.
+Give a domain an `mcp.servers` allowlist when its work does not need every configured server. Tool schemas are always-on context, so this is usually the largest saving a domain can make, and it is worth more than trimming skills. Filtering activates only when every selected domain declares `mcp`, so migrate the domains that get selected together or the selection stays unfiltered.
+
+After editing, validate the intended selection with `doompi --domains <name[,name...]> --explain` and compare the reported context cost against the previous selection, then run `doompi sync --check`. Run mutating `doompi sync` only when the user intends to materialize or refresh synchronized artifacts.
 
 Read [references/domains-contract.md](references/domains-contract.md) for the complete schema, precedence rules, source forms, filters, and verification checks.

--- a/packages/core/doompi/src/adapters/mcpSchemaCost.ts
+++ b/packages/core/doompi/src/adapters/mcpSchemaCost.ts
@@ -1,0 +1,191 @@
+import { spawn } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CACHE_DIRECTORY = 'mcp-schema-cache';
+const CACHE_VERSION = 1;
+const PROTOCOL_VERSION = '2024-11-05';
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+interface StdioServer {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+export interface McpServerCost {
+  name: string;
+  tokens: number;
+  toolCount: number;
+  /** Read from the on-disk snapshot rather than a fresh handshake. */
+  cached: boolean;
+  /** Why this server could not be priced. Set only when tokens is 0. */
+  unavailable?: string;
+}
+
+export interface McpSchemaCost {
+  servers: McpServerCost[];
+  totalTokens: number;
+}
+
+export interface McpSchemaCostOptions {
+  /** The resolved MCP config Pi will load. */
+  configPath: string;
+  homeDoomDirectory: string;
+  cwd: string;
+  environment: NodeJS.ProcessEnv;
+  countTokens: (text: string) => number;
+  timeoutMs?: number;
+}
+
+function asStdioServer(value: unknown): StdioServer | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.command !== 'string' || !record.command) return undefined;
+  const args = Array.isArray(record.args) ? record.args.filter((arg): arg is string => typeof arg === 'string') : [];
+  const env =
+    typeof record.env === 'object' && record.env !== null
+      ? Object.fromEntries(
+          Object.entries(record.env as Record<string, unknown>).filter(
+            (entry): entry is [string, string] => typeof entry[1] === 'string',
+          ),
+        )
+      : undefined;
+  return { command: record.command, args, ...(env ? { env } : {}) };
+}
+
+function cachePath(server: StdioServer, homeDoomDirectory: string): string {
+  const env = Object.entries(server.env ?? {}).sort(([left], [right]) => left.localeCompare(right));
+  const identity = [CACHE_VERSION, server.command, server.args, env];
+  const digest = crypto.createHash('sha256').update(JSON.stringify(identity)).digest('hex');
+  return path.join(homeDoomDirectory, CACHE_DIRECTORY, `${digest}.json`);
+}
+
+function readCache(file: string): { tokens: number; toolCount: number } | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8')) as unknown;
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    const { tokens, toolCount } = parsed as Record<string, unknown>;
+    if (typeof tokens !== 'number' || typeof toolCount !== 'number') return undefined;
+    return { tokens, toolCount };
+  } catch {
+    return undefined;
+  }
+}
+
+function writeCache(file: string, value: { tokens: number; toolCount: number }): void {
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(value), { mode: 0o600 });
+  } catch {
+    // A cache that cannot be written only costs the next run a handshake.
+  }
+}
+
+/**
+ * Runs the MCP initialize/tools handshake and returns the advertised tools.
+ *
+ * The server is a configured executable, so this trusts it the same way a
+ * session does, but it is killed as soon as the tool list arrives rather than
+ * being left running.
+ */
+function listTools(server: StdioServer, options: McpSchemaCostOptions): Promise<unknown[]> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(server.command, server.args, {
+      cwd: options.cwd,
+      env: { ...options.environment, ...server.env },
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+
+    let settled = false;
+    const finish = (outcome: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill();
+      outcome();
+    };
+
+    const timer = setTimeout(
+      () => finish(() => reject(new Error('timed out'))),
+      options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
+
+    const send = (message: unknown): void => {
+      if (!child.stdin.destroyed) child.stdin.write(`${JSON.stringify(message)}\n`);
+    };
+
+    let buffer = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let message: { id?: number; result?: { tools?: unknown[] } };
+        try {
+          message = JSON.parse(line) as typeof message;
+        } catch {
+          continue;
+        }
+        if (message.id === 1) {
+          send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+          send({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+        }
+        if (message.id === 2) finish(() => resolve(message.result?.tools ?? []));
+      }
+    });
+
+    child.on('error', (error) => finish(() => reject(error)));
+    child.on('exit', () => finish(() => reject(new Error('server exited before reporting tools'))));
+
+    send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'doompi-explain', version: '1' },
+      },
+    });
+  });
+}
+
+async function priceServer(name: string, configured: unknown, options: McpSchemaCostOptions): Promise<McpServerCost> {
+  const server = asStdioServer(configured);
+  if (!server) return { name, tokens: 0, toolCount: 0, cached: false, unavailable: 'not a stdio server' };
+
+  const file = cachePath(server, options.homeDoomDirectory);
+  const hit = readCache(file);
+  if (hit) return { name, tokens: hit.tokens, toolCount: hit.toolCount, cached: true };
+
+  try {
+    const tools = await listTools(server, options);
+    const value = { tokens: options.countTokens(JSON.stringify(tools)), toolCount: tools.length };
+    writeCache(file, value);
+    return { name, ...value, cached: false };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { name, tokens: 0, toolCount: 0, cached: false, unavailable: detail };
+  }
+}
+
+/**
+ * Prices the tool schemas every configured MCP server puts in the system
+ * prompt.
+ *
+ * Servers only report their tools once connected, so this spawns each one and
+ * snapshots the result under the home Doom directory. Handshakes run in
+ * parallel and the snapshot is keyed on the server descriptor, so a changed
+ * command or pinned version re-prices and everything else stays instant.
+ */
+export async function priceMcpToolSchemas(options: McpSchemaCostOptions): Promise<McpSchemaCost> {
+  const parsed = JSON.parse(fs.readFileSync(options.configPath, 'utf8')) as {
+    mcpServers?: Record<string, unknown>;
+  };
+  const entries = Object.entries(parsed.mcpServers ?? {});
+  const servers = await Promise.all(entries.map(([name, configured]) => priceServer(name, configured, options)));
+  return { servers, totalTokens: servers.reduce((total, server) => total + server.tokens, 0) };
+}

--- a/packages/core/doompi/src/commands/explainCommand.ts
+++ b/packages/core/doompi/src/commands/explainCommand.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { buildPersonaPrompt } from '@agimon-ai/doompi-config';
+import { buildPersonaPrompt, globalDoomConfigDirectory } from '@agimon-ai/doompi-config';
 import type { HarnessContext } from '../adapters/harnessContext';
+import { type McpServerCost, priceMcpToolSchemas } from '../adapters/mcpSchemaCost.ts';
 import { buildSkillCatalog, counter } from '@agimon-ai/doompi-skill/catalog';
 import type { HarnessOptions } from '../types/interfaces/harness';
 import { BaseCommand } from './baseCommand.ts';
@@ -9,10 +10,9 @@ import { BaseCommand } from './baseCommand.ts';
 /**
  * What the selection costs before the first prompt, in tokens.
  *
- * MCP tool schemas are deliberately absent: they come from the servers at
- * connect time, and pricing them here would mean spawning every configured
- * server and running a handshake on a command that is meant to be instant.
- * `startupTokens` is therefore a floor, not a total, and the rendering says so.
+ * Every figure is an estimate of what the provider will be sent, not a billed
+ * total: skills are counted from files on disk and MCP tools from the schemas
+ * their servers advertise, both with the same tokenizer.
  */
 export interface MatrixCost {
   /** The always-on skill block Pi puts in the system prompt. */
@@ -21,6 +21,9 @@ export interface MatrixCost {
   skillBodyTokens: number;
   /** The persona prompt, when a profile selected one. */
   personaTokens: number;
+  /** Always-on tool schemas, per configured MCP server. */
+  mcpServers: McpServerCost[];
+  mcpToolTokens: number;
 }
 
 export interface MatrixExplanation {
@@ -111,21 +114,37 @@ function tokenLine(label: string, tokens: number, note = ''): string {
 /**
  * The bill, rendered last so the sections above keep their order.
  *
- * Every figure is derived from files on disk, so two runs of the same selection
- * print the same numbers and a reader can reproduce them without trusting this
- * output.
+ * Skill and persona figures are derived from files on disk and MCP figures
+ * from a cached handshake, so two runs of the same selection print the same
+ * numbers and a reader can reproduce them without trusting this output.
  */
 function renderCost(cost: MatrixCost): string {
-  const startup = cost.skillPromptTokens + cost.personaTokens;
+  const startup = cost.skillPromptTokens + cost.personaTokens + cost.mcpToolTokens;
+  const unpriced = cost.mcpServers.filter((server) => server.unavailable);
   return [
     '\ncontext cost (tokens)\n',
     tokenLine('skills prompt', cost.skillPromptTokens, 'always on'),
     tokenLine('persona', cost.personaTokens, 'always on'),
+    tokenLine('mcp tools', cost.mcpToolTokens, mcpNote(cost.mcpServers)),
     tokenLine('startup total', startup),
     tokenLine('skill bodies', cost.skillBodyTokens, 'read on demand'),
-    '\n  Excludes MCP tool schemas, which the servers only report once connected,\n',
-    '  and skills contributed by extensions, which register after startup.\n',
+    ...cost.mcpServers.filter((server) => !server.unavailable).map(serverLine),
+    unpriced.length > 0
+      ? `\n  Not priced: ${unpriced.map((server) => `${server.name} (${server.unavailable})`).join(', ')}\n`
+      : '',
+    '\n  Excludes skills contributed by extensions, which register after startup.\n',
   ].join('');
+}
+
+function mcpNote(servers: McpServerCost[]): string {
+  const priced = servers.filter((server) => !server.unavailable);
+  if (priced.length === 0) return 'always on';
+  const tools = priced.reduce((total, server) => total + server.toolCount, 0);
+  return `always on, ${tools} tools from ${priced.length} server${priced.length === 1 ? '' : 's'}`;
+}
+
+function serverLine(server: McpServerCost): string {
+  return tokenLine(`  ${server.name}`, server.tokens, server.cached ? 'cached' : 'measured now');
 }
 
 /** Prints the fully resolved matrix instead of launching Pi. */
@@ -137,7 +156,7 @@ export class ExplainCommand extends BaseCommand {
   }
 
   /**
-   * Prices the selection from files on disk.
+   * Prices the selection from files on disk and configured MCP servers.
    *
    * `extensionSources` is empty because extensions publish their skill
    * directories over the session event bus, which has not started here. The
@@ -157,10 +176,21 @@ export class ExplainCommand extends BaseCommand {
       const persona = context.personaDirectory
         ? buildPersonaPrompt(context.personaRoot ?? options.repoRoot, context.personaDirectory)
         : undefined;
+      const mcp = resources.mcpConfigPath
+        ? await priceMcpToolSchemas({
+            configPath: resources.mcpConfigPath,
+            homeDoomDirectory: globalDoomConfigDirectory(),
+            cwd: options.repoRoot,
+            environment: context.environment,
+            countTokens,
+          })
+        : { servers: [], totalTokens: 0 };
       return {
         skillPromptTokens: catalog.promptTokens,
         skillBodyTokens: catalog.bodyTokens,
         personaTokens: persona ? countTokens(persona) : 0,
+        mcpServers: mcp.servers,
+        mcpToolTokens: mcp.totalTokens,
       };
     } catch (error) {
       // Pricing reads the skill files, so an unreadable one must not take the

--- a/packages/core/doompi/tests/adapters/mcpSchemaCost.test.ts
+++ b/packages/core/doompi/tests/adapters/mcpSchemaCost.test.ts
@@ -1,0 +1,178 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { priceMcpToolSchemas } from '../../src/adapters/mcpSchemaCost.ts';
+
+const TOOLS = [{ name: 'search', description: 'Find things', inputSchema: { type: 'object' } }];
+
+/** A server that completes the handshake and reports one tool. */
+const RESPONSIVE = `
+let buffer = '';
+process.stdin.on('data', (chunk) => {
+  buffer += chunk.toString();
+  const lines = buffer.split('\\n');
+  buffer = lines.pop() ?? '';
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const message = JSON.parse(line);
+    if (message.id === 1) process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} }) + '\\n');
+    if (message.method === 'tools/list') {
+      process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: 2, result: { tools: ${JSON.stringify(TOOLS)} } }) + '\\n');
+    }
+  }
+});
+`;
+
+/** A server that connects and then never answers. */
+const SILENT = `process.stdin.resume();`;
+
+let root: string;
+let home: string;
+
+function workspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'doom-mcp-cost-'));
+}
+
+function writeConfig(servers: Record<string, unknown>): string {
+  const configPath = path.join(root, 'mcp.json');
+  fs.writeFileSync(configPath, JSON.stringify({ mcpServers: servers }));
+  return configPath;
+}
+
+function scriptServer(source: string): Record<string, unknown> {
+  const file = path.join(root, `server-${Math.random().toString(36).slice(2)}.mjs`);
+  fs.writeFileSync(file, source);
+  return { command: process.execPath, args: [file] };
+}
+
+function price(configPath: string, timeoutMs = 10_000): ReturnType<typeof priceMcpToolSchemas> {
+  return priceMcpToolSchemas({
+    configPath,
+    homeDoomDirectory: home,
+    cwd: root,
+    environment: process.env,
+    countTokens: (text) => text.length,
+    timeoutMs,
+  });
+}
+
+beforeEach(() => {
+  root = workspace();
+  home = workspace();
+});
+
+describe('priceMcpToolSchemas', () => {
+  it('prices a stdio server from a real handshake and snapshots the result', async () => {
+    const configPath = writeConfig({ docs: scriptServer(RESPONSIVE) });
+
+    const first = await price(configPath);
+
+    expect(first.servers).toHaveLength(1);
+    expect(first.servers[0]).toMatchObject({ name: 'docs', toolCount: 1, cached: false });
+    expect(first.servers[0].tokens).toBe(JSON.stringify(TOOLS).length);
+    expect(first.totalTokens).toBe(first.servers[0].tokens);
+
+    const second = await price(configPath);
+
+    expect(second.servers[0]).toMatchObject({ tokens: first.servers[0].tokens, cached: true });
+  });
+
+  it('reuses the snapshot when only the server name changes, and re-prices when the command does', async () => {
+    const server = scriptServer(RESPONSIVE);
+    await price(writeConfig({ docs: server }));
+
+    const renamed = await price(writeConfig({ handbook: server }));
+    expect(renamed.servers[0]).toMatchObject({ name: 'handbook', cached: true });
+
+    const rearmed = await price(writeConfig({ docs: { ...server, args: [...(server.args as string[]), '--v2'] } }));
+    expect(rearmed.servers[0].cached).toBe(false);
+  });
+
+  it('sums every configured server', async () => {
+    const configPath = writeConfig({ a: scriptServer(RESPONSIVE), b: scriptServer(RESPONSIVE) });
+
+    const cost = await price(configPath);
+
+    expect(cost.servers).toHaveLength(2);
+    expect(cost.totalTokens).toBe(cost.servers[0].tokens + cost.servers[1].tokens);
+  });
+
+  it('names a server it cannot spawn rather than failing the whole report', async () => {
+    const configPath = writeConfig({
+      good: scriptServer(RESPONSIVE),
+      missing: { command: path.join(root, 'does-not-exist'), args: [] },
+    });
+
+    const cost = await price(configPath);
+    const missing = cost.servers.find((server) => server.name === 'missing');
+
+    expect(missing).toMatchObject({ tokens: 0, toolCount: 0 });
+    expect(missing?.unavailable).toBeTruthy();
+    expect(cost.totalTokens).toBeGreaterThan(0);
+  });
+
+  it('times out a server that never reports its tools', async () => {
+    const configPath = writeConfig({ silent: scriptServer(SILENT) });
+
+    const cost = await price(configPath, 150);
+
+    expect(cost.servers[0]).toMatchObject({ tokens: 0, unavailable: 'timed out' });
+  });
+
+  it('reports a server that exits before answering', async () => {
+    const configPath = writeConfig({ quitter: scriptServer('process.exit(0);') });
+
+    const cost = await price(configPath);
+
+    expect(cost.servers[0].unavailable).toBe('server exited before reporting tools');
+  });
+
+  it('skips servers that are not stdio', async () => {
+    const configPath = writeConfig({ remote: { url: 'https://example.invalid/mcp' }, broken: 'nonsense' });
+
+    const cost = await price(configPath);
+
+    expect(cost.servers.map((server) => server.unavailable)).toEqual(['not a stdio server', 'not a stdio server']);
+    expect(cost.totalTokens).toBe(0);
+  });
+
+  it('re-measures when the snapshot on disk is unreadable', async () => {
+    const configPath = writeConfig({ docs: scriptServer(RESPONSIVE) });
+    await price(configPath);
+
+    const cacheDirectory = path.join(home, 'mcp-schema-cache');
+    for (const entry of fs.readdirSync(cacheDirectory)) {
+      fs.writeFileSync(path.join(cacheDirectory, entry), 'not json');
+    }
+
+    const cost = await price(configPath);
+
+    expect(cost.servers[0]).toMatchObject({ toolCount: 1, cached: false });
+  });
+
+  it('still reports a figure when the snapshot cannot be written', async () => {
+    const configPath = writeConfig({ docs: scriptServer(RESPONSIVE) });
+    fs.writeFileSync(path.join(home, 'mcp-schema-cache'), 'blocked');
+
+    const cost = await price(configPath);
+
+    expect(cost.servers[0]).toMatchObject({ toolCount: 1, cached: false });
+    expect(cost.totalTokens).toBeGreaterThan(0);
+  });
+
+  it('passes configured env to the server and keys the snapshot on it', async () => {
+    const echo = scriptServer(RESPONSIVE);
+    await price(writeConfig({ docs: { ...echo, env: { TOKEN: 'a' } } }));
+
+    const changed = await price(writeConfig({ docs: { ...echo, env: { TOKEN: 'b' } } }));
+
+    expect(changed.servers[0].cached).toBe(false);
+  });
+
+  it('treats a config with no servers as free', async () => {
+    const cost = await price(writeConfig({}));
+
+    expect(cost).toEqual({ servers: [], totalTokens: 0 });
+  });
+});

--- a/packages/core/doompi/tests/commands/explainAndEmit.test.ts
+++ b/packages/core/doompi/tests/commands/explainAndEmit.test.ts
@@ -94,19 +94,48 @@ describe('explainMatrix', () => {
     expect(output).toContain('agents: 3');
   });
 
-  it('prices the selection and names what the figure leaves out', () => {
+  it('prices the selection including mcp tool schemas', () => {
     const output = explainMatrix(
-      baseExplanation({ cost: { skillPromptTokens: 3_772, skillBodyTokens: 54_145, personaTokens: 228 } }),
+      baseExplanation({
+        cost: {
+          skillPromptTokens: 3_772,
+          skillBodyTokens: 54_145,
+          personaTokens: 228,
+          mcpToolTokens: 5_385,
+          mcpServers: [{ name: 'scaffold-mcp', tokens: 5_385, toolCount: 8, cached: true }],
+        },
+      }),
     );
 
     expect(output).toContain('context cost (tokens)');
     expect(output).toContain('skills prompt');
     expect(output).toContain('3,772');
-    // Startup is the always-on pair, not the bodies, which are read on demand.
+    expect(output).toContain('8 tools from 1 server');
+    expect(output).toContain('scaffold-mcp');
+    expect(output).toContain('cached');
+    // Startup is the always-on trio, not the bodies, which are read on demand.
     expect(output).toContain('startup total');
-    expect(output).toContain('4,000');
+    expect(output).toContain('9,385');
     expect(output).toContain('54,145');
-    expect(output).toContain('Excludes MCP tool schemas');
+    expect(output).toContain('Excludes skills contributed by extensions');
+  });
+
+  it('names servers it could not price instead of dropping them silently', () => {
+    const output = explainMatrix(
+      baseExplanation({
+        cost: {
+          skillPromptTokens: 100,
+          skillBodyTokens: 0,
+          personaTokens: 0,
+          mcpToolTokens: 0,
+          mcpServers: [
+            { name: 'remote-api', tokens: 0, toolCount: 0, cached: false, unavailable: 'not a stdio server' },
+          ],
+        },
+      }),
+    );
+
+    expect(output).toContain('Not priced: remote-api (not a stdio server)');
   });
 
   it('omits the cost section when nothing priced the selection', () => {

--- a/packages/default/doompi-mcp/src/prompts/doompi-use-mcp/SKILL.md
+++ b/packages/default/doompi-mcp/src/prompts/doompi-use-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doompi-use-mcp
-description: Use Doom Pi MCP to inspect domain-scoped servers, authenticate, reload configuration, and troubleshoot tool availability.
+description: Use Doom Pi MCP to inspect domain-scoped servers, authenticate, reload configuration, measure what server tool schemas cost in context, and troubleshoot tool availability.
 ---
 
 # Use Doom Pi MCP
@@ -15,6 +15,16 @@ Use MCP when a task depends on a configured external server, proxy upstream, or 
 - Run `/mcp reload` after changing MCP configuration.
 
 Interactive status and browser-assisted authentication require a TUI. In a headless session, open a reported authorization URL manually.
+
+## Measure and reduce what servers cost
+
+Every connected server puts its full tool schema in the system prompt on every request, so a server that is irrelevant to the task still competes for context and still offers the model tools it could pick by mistake.
+
+- Run `doompi --explain` to see the per-server token cost. Figures are measured from a real handshake and cached, so the first run for a new server descriptor is slower than later ones.
+- Compare selections with `doompi --domains <name[,name...]> --explain` to see what a narrower domain actually saves.
+- Reduce the cost by giving domains an `mcp.servers` allowlist in `.doom/domains.yaml` rather than by deleting servers from `.mcp.json`, which keeps them available to other domains.
+
+Filtering activates only when every selected domain declares `mcp`. A selection that mixes an allowlisted domain with one that omits `mcp` stays unfiltered, which is the usual reason an expected saving does not appear.
 
 ## Troubleshoot missing tools
 


### PR DESCRIPTION
## What this changes

`doompi --explain` now reports what each configured MCP server's tool schemas cost in context, folded into the startup total, instead of excluding them. The seeded `domains.yaml` shows the domain-level `mcp` allowlist that reduces that cost, and the MCP and domain Help topics cover it.

## Why

MCP tool schemas are always-on context, but `--explain` could not price them, so the largest saving a domain can make was invisible. Measured on this repository: one server (`scaffold-mcp`, 8 tools) costs 4,758 tokens against 929 for the entire skills prompt with every domain loaded. Composing domains was saving 497 tokens of skills while leaving 4,758 tokens of tool schemas untouched.

The allowlist that fixes this was already implemented and documented in `docs/configuration.md`, but it never appeared in the `domains.yaml` that `doompi init` seeds, so a new user had no path to it. The only `mcp:` key in the seeded file was the plugin-level `mcp: true` toggle, which is a different key with a different meaning.

Verified end to end with a temporary `lean` domain: 5,190 startup tokens unfiltered versus 432 with an allowlist, a 92% drop, now visible in the cost report.

## Checks

Run these locally before asking for review. CI runs the same set.

- [x] `pnpm lint:vibe --preflight-only`
- [x] Affected Nx targets pass: `lint`, `typecheck`, `build`, `test`
- [x] `pnpm fmt:check`
- [ ] Packed-install system tests, if this is a release change: `pnpm nx run-many -t test-system`

`test` passes for `doompi` (712 tests). `doompi-mcp/tests/extension.test.ts` (17) and two `doompi-config` lifecycle suites (5) fail with `The composed Doom Cordis host is unavailable`, confirmed pre-existing on a clean `main` by stashing. Not a release change, so system tests were not run.

## Scope

- [x] Package boundaries are respected (`packages/core`, `packages/default`, `packages/minor`, `layers/`, `packages/tooling`)
- [x] Doom-to-Doom dependencies stay `workspace:*`
- [x] Package exports, Pi entries, resources, runtime ordering, and RMUX LFS payloads are preserved
- [x] No unrelated changes bundled in

No new dependencies. Process spawning lives in an adapter (`packages/core/doompi/src/adapters/mcpSchemaCost.ts`) because `service-boundary` bars `node:*` from services.

## Risk

**This changes what DoomPi executes on a user's machine.** `--explain` previously wrote a temporary `mcp.json` but never ran a server. To price tool schemas it now starts each configured stdio server, performs the `initialize` and `tools/list` handshake, and kills it. Worth a second look at:

- Servers run with the same privileges a session gives them. `docs/trust-and-data-boundaries.md` is updated to say so.
- Results are cached under `~/.pi/.doom/mcp-schema-cache`, keyed on command, args, and env, mode `0600`. Measured cost is 1.28s cold and 0.47s warm on one server.
- Handshakes run in parallel with a 10s per-server timeout. Failures are reported as `Not priced: <name> (<reason>)` rather than failing the command.
- `--no-mcp` skips it entirely. Verified: no cache directory is created.

Token figures are estimates from `JSON.stringify` of the advertised tool list, counted with the same tokenizer as skills. Exact provider serialization differs, so treat them as order-of-magnitude comparisons between selections, not billed totals.
