### PR TITLE
fix(root): release the web packages with the alpha group

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -81,6 +81,7 @@ jobs:
         if: env.RELEASE_PROJECTS != ''
         run: |
           set -euo pipefail
+          pnpm audit:workspace
           pnpm fmt:check
           pnpm nx run-many -t build --parallel=3
           pnpm examples:check

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Validate the release commit
         run: |
           set -euo pipefail
+          pnpm audit:workspace
           pnpm fmt:check
           pnpm nx run-many -t build --parallel=3
           pnpm examples:check

--- a/nx.json
+++ b/nx.json
@@ -88,6 +88,9 @@
           "@agimon-ai/doompi-ui",
           "@agimon-ai/doompi-user-feedback",
           "@agimon-ai/doompi-voice",
+          "@agimon-ai/doompi-web",
+          "@agimon-ai/doompi-web-components",
+          "@agimon-ai/doompi-web-contracts",
           "@agimon-ai/doompi-workflow",
           "@agimon-ai/vibe-lint-plugin-doom-extension",
           "@agimon-ai/vibe-lint-plugin-doom-web"

--- a/scripts/audit-workspace.mjs
+++ b/scripts/audit-workspace.mjs
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -32,11 +31,11 @@ const toolingPackageName = '@agimon-ai/vibe-lint-plugin-doom-extension';
 // Rule plugins that govern a stack still in development are legal workspace
 // targets even when the package audit scans only runtime package groups.
 const additionalToolingPackageNames = ['@agimon-ai/vibe-lint-plugin-doom-web'];
-const unreleasedOwnedPackageNames = new Set([
-  '@agimon-ai/doompi-web',
-  '@agimon-ai/doompi-web-components',
-  '@agimon-ai/doompi-web-contracts',
-]);
+// Owned packages that are deliberately kept off the registry. A name here must
+// never be a runtime dependency of a released package: the release publishes
+// the resolved `workspace:*` version, so a released package that points at an
+// unreleased one ships a dependency npm cannot install.
+const unreleasedOwnedPackageNames = new Set([]);
 const vibeLintVersion = '0.0.1-alpha.29';
 
 function readJson(file) {
@@ -207,6 +206,16 @@ if (releaseProjects.length !== releasedNames.size || new Set(releaseProjects).si
 for (const name of releasedNames) if (!releaseProjects.includes(name)) fail(`Release group is missing ${name}`);
 for (const name of releaseProjects)
   if (!releasedNames.has(name)) fail(`Release group includes non-owned package ${name}`);
+for (const { manifest } of packageRecords) {
+  if (!releasedNames.has(manifest.name)) continue;
+  for (const section of runtimeDependencySections) {
+    for (const name of Object.keys(manifest[section] ?? {})) {
+      if (ownedNames.has(name) && !releasedNames.has(name)) {
+        fail(`${manifest.name} is released but depends on the unreleased ${name} through ${section}`);
+      }
+    }
+  }
+}
 
 const pluginsRoot = path.join(root, 'plugins');
 const examplePlugins = fs


### PR DESCRIPTION
The alpha release group listed 43 of the 46 workspace packages, so nx release publish skipped @agimon-ai/doompi-web, doompi-web-components, and doompi-web-contracts while the publish workflow still waited for all 46 on the alpha tag. The wait step failed on every run, and the packages that did publish pinned resolved workspace versions that were never on the registry, which left the alpha tag uninstallable.

Add the three packages to the release group, empty the unreleased allowlist, and fail the audit when a released package depends on an unreleased one. Run the audit inside both release workflows so the same drift is caught before anything reaches npm.
