### PR TITLE
docs: audit documentation and strengthen release security

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -49,10 +50,13 @@ jobs:
           git config user.email "doompi-release-bot@users.noreply.github.com"
 
       - name: Sync the release base branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           test "${GITHUB_REF_TYPE}" = "branch"
-          git fetch origin "${GITHUB_REF_NAME}"
+          # shellcheck disable=SC2016 # GH_TOKEN expands inside Git's credential-helper shell.
+          git -c credential.helper='!f() { echo "username=x-access-token"; echo "password=${GH_TOKEN}"; }; f' fetch origin "${GITHUB_REF_NAME}"
           git rebase "origin/${GITHUB_REF_NAME}"
 
       - name: Select the projects to release
@@ -97,13 +101,16 @@ jobs:
 
       - name: Cut the release branch
         if: env.RELEASE_PROJECTS != '' && !inputs.dry_run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           RELEASE_BRANCH="release/alpha-${GITHUB_RUN_ID}"
           git switch -c "${RELEASE_BRANCH}"
           pnpm nx release prerelease --preid alpha --projects "${RELEASE_PROJECTS}" --skip-publish
           test -n "$(git log --format=%H "origin/${GITHUB_REF_NAME}..HEAD")"
-          git push origin "${RELEASE_BRANCH}"
+          # shellcheck disable=SC2016 # GH_TOKEN expands inside Git's credential-helper shell.
+          git -c credential.helper='!f() { echo "username=x-access-token"; echo "password=${GH_TOKEN}"; }; f' push origin "${RELEASE_BRANCH}"
           echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> "${GITHUB_ENV}"
 
       - name: Open the release pull request

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,7 +14,9 @@ concurrency:
 
 jobs:
   publish:
-    if: "${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, 'chore(release): publish') }}"
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, 'chore(release): publish'))
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment:
@@ -24,6 +26,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -131,6 +134,8 @@ jobs:
           exit 1
 
       - name: Tag the published versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           readonly TAGS_FILE="${RUNNER_TEMP}/doompi-release-tags.txt"
@@ -154,7 +159,8 @@ jobs:
           while IFS= read -r TAG; do
             PUSH_REFS+=("refs/tags/${TAG}")
           done < "${TAGS_FILE}"
-          git push --atomic origin "${PUSH_REFS[@]}"
+          # shellcheck disable=SC2016 # GH_TOKEN expands inside Git's credential-helper shell.
+          git -c credential.helper='!f() { echo "username=x-access-token"; echo "password=${GH_TOKEN}"; }; f' push --atomic origin "${PUSH_REFS[@]}"
 
       - name: Promote the published versions to latest
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,83 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out materialized package snapshot
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Reject vulnerable dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+
+  codeql:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - name: Check out materialized package snapshot
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Analyze JavaScript and TypeScript
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+
+  dependency-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out materialized package snapshot
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.22.1
+          cache: pnpm
+
+      - name: Reject known high-severity production vulnerabilities
+        run: pnpm audit --prod --audit-level high
+
+      - name: Install dependencies without lifecycle scripts
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Verify registry signatures during burn-in
+        continue-on-error: true
+        run: pnpm audit signatures

--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ not. Use it as-is, build your own config on top, or raid it for parts.
 
 ## Contents
 
-| Guide                                                          | What it covers                                                               |
-| -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| [Getting started](docs/getting-started.md)                     | Installation, requirements, DPI, sync storage, and permanent Pi registration |
-| [Concepts](docs/concepts.md)                                   | Major modes, minor modes, domains, profiles, and context costs               |
-| [Automation](docs/automation.md)                               | Autopilot, workflows, native plugin examples, and loops                      |
-| [Features](docs/features.md)                                   | The complete DoomPi package and capability catalog                           |
-| [Configuration](docs/configuration.md)                         | The four YAML files, merge rules, examples, and matrix checks                |
-| [Security model](docs/securities.md)                           | Threat model, remote-access boundaries, containment, and known limits        |
-| [Trust and data boundaries](docs/trust-and-data-boundaries.md) | Executable inputs, credentials, model calls, voice, and telemetry            |
-| [CLI reference](docs/cli-reference.md)                         | Commands, options, troubleshooting, and direct package use                   |
-| [Architecture](docs/architecture.md)                           | Package composition, lifecycle ownership, and isolation                      |
-| [Development](docs/development.md)                             | Workspace commands and maintainer release order                              |
-| [Contributing](CONTRIBUTING.md)                                | Local setup, repository boundaries, checks, commits, and pull requests       |
+| Guide                                                          | What it covers                                                                     |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [Getting started](docs/getting-started.md)                     | Installation, requirements, DPI, sync storage, and Pi registration                 |
+| [Concepts](docs/concepts.md)                                   | Major modes, minor modes, domains, profiles, and context costs                     |
+| [Automation](docs/automation.md)                               | Workflows, native plugin examples, and loops                                       |
+| [Features](docs/features.md)                                   | Fixed host packages, selectable features, and capability contracts                 |
+| [Configuration](docs/configuration.md)                         | The four YAML files, field-specific merge rules, examples, and matrix checks       |
+| [Security model](docs/securities.md)                           | Threat model, remote-access boundaries, containment, and known limits              |
+| [Trust and data boundaries](docs/trust-and-data-boundaries.md) | Executable inputs, credentials, model calls, voice, native binaries, and telemetry |
+| [CLI reference](docs/cli-reference.md)                         | Commands, options, exact effects, and direct package use                           |
+| [Architecture](docs/architecture.md)                           | Package composition, lifecycle ownership, transitions, and isolation               |
+| [Development](docs/development.md)                             | Workspace commands and maintainer release flow                                     |
+| [Contributing](CONTRIBUTING.md)                                | Local setup, repository boundaries, checks, commits, and pull requests             |
 
 ## Install
 
@@ -81,9 +81,7 @@ dpi sync
 dpi
 ```
 
-`dpi init` creates this repository's `.doom` configuration, `dpi sync` synchronizes the configured
-package matrix, and `dpi` runs the isolated experiment. Your existing `pi` setup remains available
-for comparison.
+`dpi init` creates this repository's `.doom` configuration. `dpi sync` installs required configured packages and writes synchronized state without persisting a Pi settings overlay. `dpi` runs the pinned Pi version with that in-memory overlay. Your existing `pi` setup remains available for comparison.
 
 See [Getting started](docs/getting-started.md) for worktree storage, permanent registration, and
 per-run matrix flags.
@@ -112,16 +110,9 @@ a perfectly good profile.
 
 See [Concepts](docs/concepts.md) for discovery, caching, merge behavior, and examples.
 
-## What this buys you
+## Why scope the session
 
-Every tool schema and skill name competes for the same context. Loading less has two immediate
-effects:
-
-1. You spend fewer tokens before the work begins.
-2. The model has fewer plausible-but-wrong tools and skills to choose from.
-
-The savings get larger when each workflow job starts with its own config instead of inheriting the
-last job's toolbox.
+Every tool schema and skill name consumes context and gives the model another possible choice. A smaller composition uses fewer tokens before work starts and reduces the number of irrelevant tools the model can select. Workflow jobs can choose their own composition instead of inheriting the previous job's toolbox.
 
 ### Copilot
 
@@ -171,12 +162,15 @@ model calls, voice, and telemetry behavior.
 
 ## CLI reference
 
-| Command                       | What it does                                                                   |
-| ----------------------------- | ------------------------------------------------------------------------------ |
-| `dpi init`, `dpi sync`, `dpi` | Creates, synchronizes, and runs the repository-scoped comparison setup         |
-| `doompi init`, `doompi sync`  | Seeds personal config, builds synchronized state, and registers DoomPi with Pi |
-| `doompi sync --check`         | Reports stale synchronized state or a required migration                       |
-| `doompi --explain`            | Prints the resolved matrix and estimated prompt cost without launching Pi      |
+| Command               | Effect                                                                                                |
+| --------------------- | ----------------------------------------------------------------------------------------------------- |
+| `dpi init`            | Creates missing repository `.doom` files without changing Pi settings.                                |
+| `dpi sync`            | Installs required packages and builds synchronized DPI state without persisting its settings overlay. |
+| `dpi`                 | Runs the pinned Pi version with the DPI settings overlay.                                             |
+| `doompi init`         | Seeds personal config, writes integration resources, and registers them in Pi user settings.          |
+| `doompi sync`         | Rebuilds synchronized state and refreshes Pi integration.                                             |
+| `doompi sync --check` | Checks drift and exits non-zero without writing when state is stale.                                  |
+| `doompi --explain`    | Prints the resolved matrix and estimated prompt cost without launching Pi.                            |
 
 See the [CLI reference](docs/cli-reference.md) for more commands, options, and direct-use guidance.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,10 @@
 # DoomPi architecture
 
-DoomPi turns configuration into an ordered set of standard Pi extension factories. Pi owns the extension runner, registration API, reload, and module replacement. DoomPi owns configuration resolution, composed factory loading, runtime artifacts, composition identity, and transition coordination.
+[Back to DoomPi](../README.md)
 
-This document describes the current system boundaries and the rules contributors must preserve.
+DoomPi resolves configuration into an ordered set of standard Pi extension factories. Pi owns the extension runner, registration API, reload, and module replacement. DoomPi owns configuration resolution, composed factory loading, runtime artifacts, composition identity, and transition coordination.
+
+This document defines the current boundaries and contributor invariants.
 
 ## System model
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -11,9 +11,7 @@ Together they can dispatch structured jobs from one live session.
 
 ### Workflows
 
-GitHub Actions already has a decent vocabulary for long jobs, so DoomPi reuses it. Each job
-declares the DoomPi session it wants. Here, implementation gets development tools; an
-article waits for it and gets focused blog-writing context:
+Workflow mode uses GitHub Actions-style jobs. Each step launches the DoomPi session declared by its `interactiveRun`. In this example, the article job waits for implementation and uses a different domain:
 
 ```yaml
 on:
@@ -91,10 +89,7 @@ pnpm exec workflow-mcp run-workflow automations/workflows/blog-writing.workflow.
   --dry-run --skip-launch --prompt "Write a practical guide to scoped agent tooling"
 ```
 
-Real runs delegate to tmux by default and accept `WORKFLOW_LAUNCHER=cmux`. Development runs do
-not create branches, commits, or pushes. Blog runs leave review-ready Markdown, sources, and a
-publication checklist in the workflow run directory without writing into a site or calling a CMS.
-These examples live in the source repository and are not part of the published npm tarball.
+Real runs delegate to tmux by default; set `WORKFLOW_LAUNCHER=cmux` to use cmux. Development workflows do not create branches, commits, or pushes. Blog workflows leave Markdown, sources, and a publication checklist in the workflow run directory. They do not write into a site or call a CMS. These examples are source-repository fixtures and are not included in the published npm package.
 
 ### Loop
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,35 +2,63 @@
 
 [Back to DoomPi](../README.md)
 
-| Command or option                            | What it does                                                                     |
-| -------------------------------------------- | -------------------------------------------------------------------------------- |
-| `dpi init`, `dpi sync`, `dpi`                | Creates, synchronizes, and runs the repository-scoped comparison setup           |
-| `doompi init`, `doompi sync`                 | Seeds personal config, builds synchronized state, and registers DoomPi with Pi   |
-| `doompi sync --check`                        | Exits non-zero when synchronized state is stale or legacy state needs migration  |
-| `doompi compat <codex\|claude\|antigravity>` | Resolves the selected matrix and launches the compatibility adapter              |
-| `--skip-permissions`                         | Compat only. Disables the launched frontend's approval prompts for that run      |
-| `doom-runner`                                | Inspects and controls supervised Runner processes and logs                       |
-| `--explain`                                  | Prints the resolved matrix and estimated prompt cost without launching Pi        |
-| `--emit-mcp <dir>`, `--no-mcp`               | Writes the resolved MCP config or disables MCP for one run                       |
-| `--cwd <path>`, `--auto-stop`                | Chooses the working directory or exits after an interactive agent settles        |
-| `--sandbox`                                  | Runs the whole session in a container, terminal attached; accepted by `dpi` too  |
-| `--` and remaining arguments                 | Forwards provider or Pi arguments unchanged where the selected command allows it |
+## Setup commands
 
-`doompi compat` leaves the third-party frontend's own approval behavior alone unless you pass
-`--skip-permissions`, which maps to `--dangerously-skip-permissions` for Claude and Antigravity and
-to `--yolo` for Codex. Runs that bypass print a warning to stderr. See
-[Trust and data boundaries](trust-and-data-boundaries.md#approval-prompts-in-compatibility-mode).
+| Command               | Effect                                                                                                                                                                                                   |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dpi init`            | Creates missing `.doom` files in the current repository. It does not change Pi settings.                                                                                                                 |
+| `dpi init --force`    | Replaces the repository's four `.doom` files with the current templates.                                                                                                                                 |
+| `dpi sync`            | Installs required configured packages, builds synchronized state, and prepares DPI's in-memory Pi settings overlay. It does not persist that overlay.                                                    |
+| `dpi`                 | Runs the pinned Pi version with the synchronized DPI overlay. Other arguments pass to Pi, except `--sandbox`, which DoomPi handles.                                                                      |
+| `doompi init`         | Creates missing files in `~/.pi/.doom`, writes the DoomPi extension alias and theme, and registers both in Pi user settings.                                                                             |
+| `doompi init --force` | Replaces the four personal `.doom` files, then refreshes the Pi integration resources.                                                                                                                   |
+| `doompi sync`         | Installs required configured packages, rebuilds synchronized state, refreshes the extension alias and theme, and updates Pi user settings.                                                               |
+| `doompi sync --check` | Checks package resolution, configuration drift, synchronized artifacts, the alias, the theme, and Pi settings without writing. It exits non-zero when anything is stale or legacy state needs migration. |
+
+Both sync commands accept the matrix options below. `doompi sync` stores generated state under `~/.pi/.doom/sync` in a repository- and worktree-specific namespace. It does not remove old generated directories automatically.
+
+## Compatibility mode
+
+```bash
+doompi compat <codex|claude|antigravity> [matrix options] [provider arguments]
+```
+
+Compatibility mode resolves the selected DoomPi matrix, then launches the named frontend. It consumes `--major-mode`, `--domains`, `--domain`, `--profile`, and `--skip-permissions`. Other arguments pass through unchanged. Put `--` before a provider-native option whose name collides with a DoomPi matrix option.
+
+`--skip-permissions` disables the frontend's approval prompts for that run. It maps to `--dangerously-skip-permissions` for Claude and Antigravity, and `--yolo` for Codex. DoomPi prints a warning to stderr whenever it enables a bypass. See [Approval prompts in compatibility mode](trust-and-data-boundaries.md#approval-prompts-in-compatibility-mode).
+
+## Launch options
+
+| Option                      | Effect                                                                                                                                    |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `--major-mode <name>`       | Selects one major mode from `.doom/modes.yaml`.                                                                                           |
+| `--domains <names>`         | Selects comma-separated content domains. `--domain` is also accepted.                                                                     |
+| `--no-domains`              | Loads no content domains. It cannot be combined with `--domains`.                                                                         |
+| `--profile <name>`          | Selects a persona and environment profile.                                                                                                |
+| `--explain`                 | Resolves the matrix, prints its contents and estimated prompt cost, then exits. MCP schema inspection may start configured stdio servers. |
+| `--emit-mcp <dir>`          | Writes the resolved MCP configuration to a directory, then exits. MCP must be enabled.                                                    |
+| `--mcp`, `--no-mcp`         | Enables or disables MCP configuration for this run. Use `--no-mcp` with `--explain` to avoid starting MCP servers.                        |
+| `--agents`, `--no-agents`   | Enables or disables spawnable agent resources.                                                                                            |
+| `--hooks`, `--no-hooks`     | Enables or disables repository and plugin hooks.                                                                                          |
+| `--plugin-dir <path>`       | Loads an explicit plugin directory. Repeat the option to load more than one.                                                              |
+| `--add-dir <path>`          | Adds an accessible directory. Repeat the option to add more than one.                                                                     |
+| `--cwd <path>`              | Runs Pi in that directory. `--cd` is also accepted.                                                                                       |
+| `--preset <name>`           | Selects `default`, `kimi`, or `ollama` provider normalization.                                                                            |
+| `--automation`              | Adds Pi print mode, JSON output, and project approval unless already supplied.                                                            |
+| `--auto-stop`               | Exits an interactive Pi session after the agent settles. It is rejected in print and JSON modes.                                          |
+| `--sandbox`                 | Runs the session through the sandbox harness exported by a selected layer. `dpi` accepts this option too.                                 |
+| `--allow-protected-writes`  | Allows writes to repository paths that DoomPi otherwise protects.                                                                         |
+| `--mute`                    | Disables DoomPi notifications for this run.                                                                                               |
+| `--output-format vibe-lint` | Reads one vibe-lint request from stdin and writes one JSON response.                                                                      |
+| `-h`, `--help`              | Prints DoomPi harness help without resolving the repository.                                                                              |
+| `-v`, `--version`           | Prints the DoomPi package version.                                                                                                        |
+
+DoomPi forwards remaining launch arguments to Pi. `--explain` is not a no-execution security boundary: it starts each allowed stdio MCP server when it must inspect tool schemas. See [Executable inputs](trust-and-data-boundaries.md#executable-inputs).
 
 ## Troubleshooting and direct use
 
-- Run `doompi sync --check` to detect drift or missing configured packages, and `doompi sync`
-  to install them and rebuild synchronized state.
-- If RMUX is unavailable on a supported target, Runner reports the fallback it uses. Linux native
-  artifacts require a compatible loader and libc environment.
-- Leader menus and overlays require Pi's interactive TUI. Commands and tools remain the interface
-  for JSON, RPC, and other headless sessions where the owning package supports them.
-- Install a directly loaded Pi subsystem with `pi install npm:@agimon-ai/<package>`. Library consumers
-  use `npm install`; native RMUX artifacts are selected by Runner and should not be installed directly.
-  The root `doom-runner` command delegates to Runner from the active repository and asks you to add
-  Runner to `modes.yaml` when it is absent. The distribution remains the supported way to get the
-  coordinated defaults.
+- Run `doompi sync --check` to identify drift or missing configured packages. Run `doompi sync` to install required packages and rebuild state.
+- Runner tries bundled RMUX, `rmux` on `PATH`, then `tmux` on `PATH`. If none is available, non-interactive commands use a supervised subprocess and interactive commands are rejected. Linux native artifacts require a compatible loader and libc environment.
+- Leader menus and overlays require Pi's interactive TUI. Commands and tools remain available in JSON, RPC, and other headless sessions when the owning package supports them.
+- Install a directly loaded Pi subsystem with `pi install npm:@agimon-ai/<package>`. Library consumers use `npm install`. Do not install native RMUX or RTK packages directly.
+- The root `doom-runner` command delegates to Runner from the active repository. If Runner is not selected, it asks you to add `@agimon-ai/doompi-runner` to `modes.yaml`.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -81,23 +81,12 @@ Repository discoveries replace same-named home discoveries. Explicit entries ove
 discovery and can add string environment defaults; repository entries replace matching home
 entries. Select one at launch with `--profile editor` or switch with `/profile`.
 
-## What this buys you
+## Why scope the session
 
-Every tool schema and skill name competes for the same context. Loading less has two
-immediate effects:
-
-1. You spend fewer tokens before the work begins.
-2. The model has fewer plausible-but-wrong tools and skills to choose from.
-
-The savings get larger when each workflow job starts with its own config instead of
-inheriting the last job's toolbox.
+Every tool schema and skill name consumes context and gives the model another possible choice. A smaller composition uses fewer tokens before work starts and reduces the number of irrelevant tools the model can select. Workflow jobs can choose their own composition instead of inheriting the previous job's toolbox.
 
 ### Copilot
 
-I got tired of remembering slash commands, so `SPC` is the map. It opens only when the
-draft is empty; a space in the middle of a prompt remains a space. Press it, read the
-choices, then press the next key.
+Press `SPC` on an empty draft to open the Leader map. A space typed inside a prompt remains a space. The map shows only commands contributed by the active composition.
 
-When the keyboard is the wrong tool, autonomous Voice mode keeps the conversation going.
-You can talk to the agent while doing the chores instead of carrying a laptop around the
-house, and the primary agent can speak its own opening, milestone, and final updates.
+Autonomous Voice mode keeps the session available when typing is impractical. The primary agent can narrate its opening, meaningful milestones, and final answer, subject to the configured capture, transcription, model, and speech engines.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,11 +9,41 @@ DoomPi reads four configuration files:
 - `domains.yaml` catalogs plugins and sets session access.
 - `profiles.yaml` supplies persona files and environment defaults.
 
-Each matrix file has two optional layers: personal defaults in `~/.pi/.doom/` and repository
-overrides in `<repository>/.doom/`. DoomPi loads both. Unique named entries from either layer
-remain available; a same-named repository entry replaces the complete personal entry. Plugin
-and profile roots from both layers are retained. Relative paths in personal config resolve
-from `~/.pi/.doom/`; relative paths in repository config resolve from the repository root.
+DoomPi reads personal defaults from `~/.pi/.doom/` and repository settings from `<repository>/.doom/`. Relative personal paths resolve from `~/.pi/.doom/`; relative repository paths resolve from the repository root. Merge behavior depends on the file and field, so the sections below state it explicitly.
+
+## `config.yaml`: set runtime policy
+
+`config.yaml` accepts only `projectTrust`, `modes.planning`, `editor`, `voice`, and `selection`. Unknown keys and invalid values stop configuration loading.
+
+```yaml
+projectTrust: ask
+
+modes:
+  planning:
+    main:
+      model: openai/gpt-5.4
+      thinking: high
+    subagents:
+      model: openai/gpt-5.4-mini
+      thinking: medium
+    plansDirectory: .doom/plans
+
+editor:
+  command: code
+
+voice:
+  engine: auto
+  language: en
+
+selection:
+  majorMode: copilot
+  domains: [development]
+  profile: reviewer
+```
+
+`projectTrust` accepts `ask`, `always`, or `never`. It is repository policy: an absent repository value becomes `ask` instead of inheriting the personal value. `editor.command` is personal, so a repository editor value does not replace it. Planning fields and ordinary Voice fields merge, with repository values winning. `voice.autoCapture` is personal-only and is rejected in repository configuration.
+
+Planning `thinking` accepts `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. `plansDirectory` may be absolute, use `~`, or be relative to the repository. `selection` supplies default axis values; it does not define modes, domains, or profiles. When repository `selection` exists, include every personal axis that should remain selected because omitted axes are not inherited.
 
 ## `modes.yaml`: choose behavior
 
@@ -75,12 +105,7 @@ majorMode:
     layers: [team, review]
 ```
 
-Order matters: DoomPi assembles `default.packages` first, then the selected layers and their
-packages from left to right. Put settings under the package that consumes them; a layer is
-composition, not a mystery bag of shared configuration. Home and repository `layers` and
-`majorMode` records merge by name, with the repository definition winning a collision. If both
-sources declare `default`, the repository block replaces the personal block as one whole package
-list.
+Order matters. DoomPi activates `default.packages` first, then each selected layer from left to right. Put settings under the package that consumes them. Home and repository `layers` and `majorMode` records merge by name, with the repository definition replacing a collision. If both sources declare `default`, the repository block replaces the complete personal default. A repository entry set to `null` removes the matching layer or major mode.
 
 Configurations created before the hashline tools were split may contain only `doompi-edit`.
 Replace that entry with the ordered `doompi-read`, `doompi-grep`, and `doompi-edit` trio. Init
@@ -174,16 +199,13 @@ catalog empty is valid; no profile remains a first-class choice.
 
 ## Check the matrix before launch
 
-The fastest configuration debugger is the one that does not start a model:
+Resolve configuration before starting a model:
 
 ```bash
 doompi --major-mode copilot --domains work --profile release-writer --explain
+doompi --major-mode copilot --domains work --no-mcp --explain
 dpi sync
 doompi sync --check
 ```
 
-`--explain` prints the resolved mode, domains, profile, plugins, skills, agents, MCP boundary,
-and estimated prompt cost. `dpi sync` resolves the repository configuration and synchronizes
-DPI without registering it in normal Pi settings. `doompi sync --check` turns drift into a
-non-zero exit code for CI. If the explanation is surprising, fix the YAML before paying a model
-to be surprised with you.
+`--explain` prints the resolved mode, domains, profile, plugins, skills, agents, MCP boundary, and estimated prompt cost. It may start configured stdio MCP servers to inspect their tool schemas; add `--no-mcp` to prevent that execution. `dpi sync` synchronizes repository state without persisting a Pi settings overlay. `doompi sync --check` reports drift with a non-zero exit code and does not modify the repository.

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 [Back to DoomPi](../README.md)
 
-Run these commands from the repository root.
+Run these commands from the repository root:
 
 ```bash
 pnpm install
@@ -14,21 +14,21 @@ pnpm nx typecheck @agimon-ai/doompi
 pnpm nx lint @agimon-ai/doompi
 ```
 
+`pnpm build` builds every workspace project through Nx. The four targeted commands then build, test, type-check, and lint the root runtime package.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for repository boundaries, required checks, commit rules, and pull-request guidance.
+
+## Maintainer release flow
+
+DoomPi uses the independent `alpha` release group in `nx.json`. Do not hand-publish a short package subset: the group includes the root runtime, fixed core, selectable features, clients, native Runner payloads, web packages, and repository-owned lint plugins. Workspace dependencies determine the build graph, and the release workflow publishes the selected versions under the `alpha` tag.
+
+The release-cut workflow selects affected release projects, runs the full candidate validation, and previews or writes the prerelease versions. After the release pull request merges, the publish workflow:
+
+1. verifies Runner payloads;
+2. runs the workspace audit, build, examples check, lint, architecture preflight, typecheck, tests, and packed-install system tests;
+3. publishes versions missing from npm with `pnpm nx release publish`; and
+4. waits for every version before creating tags.
+
+Generated changelogs remain owned by Nx release tooling. See `.github/workflows/release-cut.yml` and `.github/workflows/release-publish.yml` for the executable contract.
+
 DoomPi is maintained by [Agimon](https://agimon.ai/about).
-
-## Maintainer release order
-
-Publish [`@agimon-ai/doompi-extension-contracts`][pkg-doompi-extension-contracts] and
-[`@agimon-ai/doompi-hashline`][pkg-doompi-hashline] first, then
-[`@agimon-ai/doompi-help`][pkg-doompi-help], and only then the
-[`@agimon-ai/doompi`][pkg-doompi] runtime that consumes them. Generated changelogs remain owned
-by the release tooling.
-
-The deploy workflow blocks publishing unless the deterministic DoomPi architecture sweep and the
-packed-install system tests both pass. This keeps the shared Cordis host contract and independently
-loaded extension graph inside the same release boundary as the packages that consume them.
-
-[pkg-doompi]: https://www.npmjs.com/package/@agimon-ai/doompi
-[pkg-doompi-hashline]: https://www.npmjs.com/package/@agimon-ai/doompi-hashline
-[pkg-doompi-help]: https://www.npmjs.com/package/@agimon-ai/doompi-help
-[pkg-doompi-extension-contracts]: https://www.npmjs.com/package/@agimon-ai/doompi-extension-contracts

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,18 +11,23 @@ at a time. Selectable packages are not runtime dependencies of the root package 
 
 ### Configuration and composition
 
-[`@agimon-ai/doompi`][pkg-doompi] is both an extension and the command-line config compiler.
-`dpi init` creates repository config for an isolated experiment, while `doompi init` creates the
-personal config and registers the permanent Pi integration. The sync commands resolve every major
-mode and domain into a distribution Pi can load quickly.
+[`@agimon-ai/doompi`][pkg-doompi] is both a Pi extension and the command-line configuration compiler. `dpi init` creates repository config for an isolated experiment. `doompi init` creates personal config and writes the extension alias, theme, and Pi user settings. Sync installs required configured packages, stages the selected domain resources, and precompiles supported major-mode compositions.
 
-### Supporting packages
+### Fixed host packages
 
-[`@agimon-ai/doompi-config`][pkg-doompi-config] resolves the four YAML files and exposes the
-configuration API. [`@agimon-ai/doompi-domain`][pkg-doompi-domain] owns domain selection, plugin
-materialization, resource staging, and MCP scoping.
-[`@agimon-ai/doompi-extension-contracts`][pkg-doompi-extension-contracts] contains the shared
-Cordis service and event contracts used by extension authors.
+The root package carries the fixed host foundation:
+
+- [`@agimon-ai/doompi-config`][pkg-doompi-config] validates `config.yaml` and publishes selection state.
+- [`@agimon-ai/doompi-domain`][pkg-doompi-domain], [`@agimon-ai/doompi-major-mode`][pkg-doompi-major-mode], and [`@agimon-ai/doompi-profile`][pkg-doompi-profile] own the three selection axes and their transitions.
+- [`@agimon-ai/doompi-skill`][pkg-doompi-skill] builds the session skill catalog and deferred skill browser.
+- [`@agimon-ai/doompi-cache`][pkg-doompi-cache] applies provider prompt-cache policy and deterministic routing.
+- [`@agimon-ai/doompi-autostop`][pkg-doompi-autostop] shuts down an interactive automation session after the agent settles when `--auto-stop` is active.
+- [`@agimon-ai/doompi-notification`][pkg-doompi-notification] owns desktop notifications and the terminal-tab title. `--mute` disables it for one launch.
+- [`@agimon-ai/doompi-extension-contracts`][pkg-doompi-extension-contracts] defines the shared Cordis services, events, lifecycle host, and serialization contracts.
+- [`@agimon-ai/doompi-ui`][pkg-doompi-ui] provides the shared TUI and Leader services.
+- [`@agimon-ai/doompi-telemetry`][pkg-doompi-telemetry] is the library-level telemetry adapter. It sends nothing unless an OTLP endpoint is configured or discovered.
+
+These packages are not selected through `default.packages`. Selectable packages stay outside the root package's private dependency closure.
 [`@agimon-ai/doompi-hashline`][pkg-doompi-hashline] binds edits to the content the model actually
 saw. For writable UTF-8 files, [`@agimon-ai/doompi-read`][pkg-doompi-read] and
 [`@agimon-ai/doompi-grep`][pkg-doompi-grep] attach an eight-character base64url SHA-256 prefix for
@@ -36,9 +41,7 @@ anchors against the current content, rejects stale or overlapping edits, and app
 against the original snapshot. The model receives the protocol metadata, while DoomPi's renderers
 hide it from people and keep the usual syntax-highlighted read, grep, and diff views.
 
-[`@agimon-ai/doompi-file-edit`][pkg-doompi-file-edit] opens files in the configured editor and
-keeps the edit timeline. [`@agimon-ai/doompi-log`][pkg-doompi-log] collects session events, while
-[`@agimon-ai/doompi-telemetry`][pkg-doompi-telemetry] is the library-level telemetry adapter.
+[`@agimon-ai/doompi-file-edit`][pkg-doompi-file-edit] opens files in the configured editor and keeps the edit timeline. [`@agimon-ai/doompi-hook`][pkg-doompi-hook] runs configured repository and plugin hooks with Claude-Code-compatible events; `--no-hooks` disables them for one launch. [`@agimon-ai/doompi-log`][pkg-doompi-log] collects session events.
 
 Runner selects matching RMUX and RTK native artifacts automatically. Do not install them directly.
 The packages cover macOS and Linux on arm64 and x64 for both [RMUX][pkg-rmux-darwin-arm64] and
@@ -75,10 +78,7 @@ generated mode gets it. Short commands still return inline; commands that pass t
 threshold of 60 seconds by default move into the background with durable logs. Use
 `background: true` for an immediate detached run or `interactive: true` when the command needs
 terminal input. Runner IDs and complete raw logs remain available to the current session through
-Runner Space at `SPC r l` or the `doom-runner` CLI. Platform-specific RMUX binaries are selected
-automatically; non-interactive commands use a supervised subprocess fallback when RMUX is absent,
-while interactive commands require RMUX. For conservatively recognized single commands, Runner
-passes the completed raw log through the matching RTK stdin filter before returning bounded output.
+Runner Space at `SPC r l` or the `doom-runner` CLI. Runner tries the bundled RMUX binary, `rmux` on `PATH`, then `tmux` on `PATH`. If none is available, non-interactive commands use a supervised subprocess and interactive commands are rejected. For conservatively recognized single commands, Runner passes the completed raw log through the matching RTK stdin filter before returning bounded output.
 Compound shell commands, pipelines, incompatible formats, and unsupported commands keep bounded raw
 output. Remove Runner from `default.packages` to keep Pi's `bash`, or add it to a named layer when only
 selected modes should replace `bash`.
@@ -200,10 +200,17 @@ progress narration. External task, workflow, and user-feedback narration remains
 available, and the same model continues to provide bounded command correction.
 
 [pkg-doompi]: https://www.npmjs.com/package/@agimon-ai/doompi
-[pkg-doompi-ui]: https://www.npmjs.com/package/@agimon-ai/doompi-ui
+[pkg-doompi-autostop]: https://www.npmjs.com/package/@agimon-ai/doompi-autostop
+[pkg-doompi-cache]: https://www.npmjs.com/package/@agimon-ai/doompi-cache
 [pkg-doompi-config]: https://www.npmjs.com/package/@agimon-ai/doompi-config
 [pkg-doompi-domain]: https://www.npmjs.com/package/@agimon-ai/doompi-domain
+[pkg-doompi-major-mode]: https://www.npmjs.com/package/@agimon-ai/doompi-major-mode
+[pkg-doompi-notification]: https://www.npmjs.com/package/@agimon-ai/doompi-notification
+[pkg-doompi-profile]: https://www.npmjs.com/package/@agimon-ai/doompi-profile
+[pkg-doompi-skill]: https://www.npmjs.com/package/@agimon-ai/doompi-skill
+[pkg-doompi-ui]: https://www.npmjs.com/package/@agimon-ai/doompi-ui
 [pkg-doompi-hashline]: https://www.npmjs.com/package/@agimon-ai/doompi-hashline
+[pkg-doompi-hook]: https://www.npmjs.com/package/@agimon-ai/doompi-hook
 [pkg-doompi-read]: https://www.npmjs.com/package/@agimon-ai/doompi-read
 [pkg-doompi-grep]: https://www.npmjs.com/package/@agimon-ai/doompi-grep
 [pkg-doompi-edit]: https://www.npmjs.com/package/@agimon-ai/doompi-edit

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,20 +29,17 @@ releases.
 before registering anything in Pi's settings:
 
 ```bash
-dpi init                                   # create this repository's .doom configuration
-dpi sync                                   # resolve and synchronize the DoomPi experiment
-dpi                                        # run the DoomPi experiment
-pi                                         # run your existing Pi setup for comparison
+dpi init    # create missing .doom files in this repository
+dpi sync    # install required packages and build synchronized DPI state
+dpi         # run the pinned Pi version with DPI's in-memory settings overlay
+pi          # run your existing Pi setup for comparison
 ```
 
 `dpi init` creates `.doom/config.yaml`, `.doom/modes.yaml`, `.doom/domains.yaml`, and
 `.doom/profiles.yaml` in the current repository. It preserves existing files unless you pass
 `--force` and does not create or change `.pi/settings.json`.
 
-`dpi sync` installs missing configured feature packages, writes DoomPi's generated state,
-package alias, and theme resource, but it does not register DoomPi in either normal Pi
-settings file. It prepares every declared layer so switching modes does not depend on the
-root package's dependency closure.
+`dpi sync` installs missing required feature packages, writes generated state, and refreshes the extension alias and theme. It does not persist DPI's settings overlay in either Pi settings file. Sync provisions every declared layer, so switching to a prepared mode does not depend on the root package's private dependencies.
 
 ### Sync storage and worktrees
 
@@ -59,9 +56,9 @@ When you are comfortable with DoomPi and no longer need the side-by-side experim
 it for normal Pi:
 
 ```bash
-doompi init                                  # seed ~/.pi/.doom and Pi integration resources
-doompi sync                                  # register DoomPi in normal Pi settings
-pi                                           # DoomPi now starts through the regular Pi command
+doompi init    # seed ~/.pi/.doom and register the extension alias and theme
+doompi sync    # build synchronized state and refresh Pi integration
+pi             # start DoomPi through the regular Pi command
 ```
 
 `doompi` remains available as an explicit harness when you want per-run matrix flags:

--- a/docs/securities.md
+++ b/docs/securities.md
@@ -2,19 +2,11 @@
 
 [Back to DoomPi](../README.md)
 
-This is the reasoning: what DoomPi assumes, what each boundary is for, and what is deliberately left
-open. [Trust and data boundaries](trust-and-data-boundaries.md) is the inventory that sits beside it,
-covering what DoomPi does with your credentials, your commands, and your data. Read that one to
-answer "what happens to my key". Read this one to answer "why is that safe, and when is it not".
+This document explains DoomPi's threat model, remote-access controls, containment boundary, and known limits. [Trust and data boundaries](trust-and-data-boundaries.md) inventories what happens to credentials, commands, model traffic, and telemetry.
 
 ## The premise
 
-An agent holds a shell. Every control below exists because that one sentence is true and cannot be
-made false without making DoomPi useless.
-
-So the question is never "can the agent run code". It is "who can ask it to, and how much of this
-machine is in reach when they do". Two answers, and they are independent: authentication decides
-who, containment decides how much. Turning one on does not turn on the other.
+A DoomPi agent has a shell. Security controls therefore answer two separate questions: who may ask the agent to act, and what the agent can reach. Authentication controls the first. Containment controls the second. Enabling either one does not enable the other.
 
 ## Threat model
 
@@ -134,10 +126,7 @@ the browser refuses the cookie unless it is `Secure`, `Path=/`, and `Domain`-les
 subdomain can read or overwrite it. `Secure` is a constant in the code rather than derived, because
 `cloudflared` forwards plaintext and `x-forwarded-proto` is attacker-controllable.
 
-Idle and absolute expiry are a single switch, off by default, with a thirty day ceiling on the
-cookie when it is off so a session cannot outlive the laptop. Devices can be revoked one at a time,
-and switching remote access off revokes all of them, closes every remote socket, and forgets every
-pairing.
+Session expiry is off by default. While it is off, the server accepts a paired session until the device is revoked or remote access is disabled; the browser cookie still has a thirty-day ceiling. When expiry is enabled, the configured idle and absolute limits both apply. Disabling remote access revokes every device, closes remote sockets, and clears pending pairing state.
 
 ### Passkeys
 
@@ -252,16 +241,15 @@ cannot see them. A container that fails to start rolls back to the host cockpit,
 
 ## Defaults
 
-Every switch below is off until someone turns it on, and each was chosen so that an install that
-never opens the settings dialog is the safe one.
+Remote access, tunnel auto-close, session expiry, and containment are opt-in. Host approval is always required for a new pairing.
 
-| Setting           | Default | Why                                                            |
-| ----------------- | ------- | -------------------------------------------------------------- |
-| Remote access     | off     | Nothing is reachable beyond loopback until it is asked for     |
-| Tunnel auto-close | off     | Opt-in, because a forgotten tunnel is the common failure       |
-| Session expiry    | off     | Opt-in, with a thirty day cookie ceiling regardless            |
-| Container         | off     | Requires a container engine and a deliberate workspace list    |
-| Host approval     | always  | Not a setting. Scanning a code never pairs a device on its own |
+| Setting           | Default | Why                                                                                                   |
+| ----------------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| Remote access     | off     | Nothing is reachable beyond loopback until it is enabled                                              |
+| Tunnel auto-close | off     | A tunnel remains open until closed or the hub restarts                                                |
+| Session expiry    | off     | Server sessions remain valid until revocation or remote shutdown; the cookie has a thirty-day ceiling |
+| Container         | off     | Containment requires a container engine and an explicit workspace list                                |
+| Host approval     | always  | Scanning a code creates a request; it never pairs a device by itself                                  |
 
 ## What an attacker still gets
 

--- a/docs/trust-and-data-boundaries.md
+++ b/docs/trust-and-data-boundaries.md
@@ -2,9 +2,7 @@
 
 [Back to DoomPi](../README.md)
 
-This is the inventory: what DoomPi does with your credentials, your commands, and your data. The
-[Security model](securities.md) is the reasoning beside it, covering the threat model, the boundaries
-that guard a cockpit reachable from a phone, and what is deliberately left open.
+This document inventories what DoomPi does with executable configuration, credentials, commands, model traffic, native binaries, voice data, and telemetry. The [Security model](securities.md) explains the threat model and the boundaries around a cockpit reachable from another device.
 
 ## Executable inputs
 
@@ -127,9 +125,7 @@ command that can expose panes over a public tunnel with pairing codes; **DoomPi 
 and no DoomPi code path passes `web-share`, `--web-port`, or `--frontend-url`. DoomPi Runner uses
 RMUX for session and pane supervision and RTK for log processing, nothing else.
 
-Where no compatible RMUX binary exists, the runner supervises panes with `tmux` from PATH instead.
-That is the host's own tmux rather than a bundled binary, so it runs with the same privileges as
-any other command the runner starts.
+Runner tries the bundled RMUX binary, `rmux` on `PATH`, then `tmux` on `PATH`. PATH binaries run with the same privileges as every other command Runner starts. If no multiplexer is available, non-interactive commands can use the supervised subprocess fallback; interactive commands cannot start.
 
 RTK has its own upstream telemetry, documented at
 [rtk-ai/rtk TELEMETRY.md](https://github.com/rtk-ai/rtk/blob/master/docs/TELEMETRY.md). It is

--- a/layers/ask-user/doompi-user-feedback/README.md
+++ b/layers/ask-user/doompi-user-feedback/README.md
@@ -1,12 +1,10 @@
 # @agimon-ai/doompi-user-feedback
 
-Structured user questions that wait for an answer in interactive Pi sessions, with an autonomous
-Voice handoff.
+Ask structured questions in interactive Pi sessions, including sessions using autonomous Voice.
 
 Part of the [DoomPi distribution](https://www.npmjs.com/package/@agimon-ai/doompi).
 
-The `ask_user_question` tool presents concrete options instead of asking the model to continue on a
-guess.
+The `ask_user_question` tool presents concrete options and waits for the user to choose. It does not let the model guess.
 
 > **Alpha:** tool and Voice-handoff contracts may change between releases.
 

--- a/layers/sandbox/doompi-sandbox/README.md
+++ b/layers/sandbox/doompi-sandbox/README.md
@@ -1,8 +1,8 @@
 # @agimon-ai/doompi-sandbox
 
-Container sandbox for DoomPi launches: the agent, extensions, and tools run inside Docker or Podman while the terminal stays on the host
+Run the DoomPi agent, extensions, and tools in a container while keeping the terminal on the host.
 
-This package is a composable [DoomPi](https://www.npmjs.com/package/@agimon-ai/doompi) subsystem. Use it with the distribution or install it independently in [Pi](https://www.npmjs.com/package/@earendil-works/pi-coding-agent).
+Part of the [DoomPi distribution](https://www.npmjs.com/package/@agimon-ai/doompi). You can also install it directly in [Pi](https://www.npmjs.com/package/@earendil-works/pi-coding-agent).
 
 ## Requirements
 
@@ -18,7 +18,7 @@ pi install npm:@agimon-ai/doompi-sandbox
 
 The package declares its Pi extension entry, so Pi loads it after installation. DoomPi users can include the package through their normal profile and domain composition instead.
 
-## Enabling it
+## Enable the sandbox
 
 This layer is still in development, so `doompi init` does not add it to any mode. Opt in by hand:
 name it as a layer in `.doom/modes.yaml`, then list that layer on the mode you want it in.
@@ -123,7 +123,7 @@ so. A second concurrent sandbox therefore starts normally but cannot complete a 
 that bind an ephemeral callback port instead of a fixed one, OpenRouter among them, cannot be
 published ahead of the flow and are not covered.
 
-## Terminal behaviour
+## Terminal behavior
 
 The session is Pi's own TUI running inside the container, attached straight to your terminal: the
 launch passes `-i`, adds `-t` when the host session has one, and inherits stdio. Nothing proxies or

--- a/layers/task/doompi-task/README.md
+++ b/layers/task/doompi-task/README.md
@@ -1,13 +1,10 @@
 # @agimon-ai/doompi-task
 
-A persistent, dependency-aware task graph for Pi, with an optional delegation bridge to DoomPi
-Team.
+Track persistent, dependency-aware tasks in Pi and optionally delegate them through DoomPi Team.
 
 Part of the [DoomPi distribution](https://www.npmjs.com/package/@agimon-ai/doompi).
 
-Task owns task records and `tasks.json`. Team owns agents and runs. Loading both lets Task delegate
-pending work through Team's session-bound `doom/delegation` Cordis service; it does not merge their
-persistence.
+Task owns task records and `tasks.json`. Team owns agents and runs. When both are loaded, Task delegates pending work through Team without merging their stored state.
 
 > **Alpha:** task and delegation contracts may change between releases.
 

--- a/layers/team/doompi-team/README.md
+++ b/layers/team/doompi-team/README.md
@@ -1,7 +1,6 @@
 # @agimon-ai/doompi-team
 
-An asynchronous subagent runtime for Pi: agent discovery, background runs, membership, intercom,
-and model and tool policy.
+Discover agents, run them in the background, exchange messages, and enforce model and tool policy.
 
 Part of the [DoomPi distribution](https://www.npmjs.com/package/@agimon-ai/doompi).
 
@@ -55,14 +54,15 @@ Slash commands include:
 /run
 /parallel
 /subagents-doctor
+/subagents-steer <run-id> <message>
 /subagents-stop
 /subagents-list
 /subagents-fleet
 ```
 
-Use `/run` for one agent, `/parallel` for several, `/subagents-doctor` for diagnostics,
-`/subagents-stop` to stop work, `/subagents-list` for available agents, and `/subagents-fleet` for
-current runs.
+Use `/run` for one agent and `/parallel` for several. `/subagents-doctor` reports diagnostics,
+`/subagents-steer` sends guidance to a running agent, and `/subagents-stop` requests a stop.
+`/subagents-list` shows available agents, and `/subagents-fleet` shows current runs.
 
 The `subagent` tool exposes `agents`, `run`, `status`, `steer`, `stop`, `suspended`, and `restore`.
 The `intercom` tool exposes `members`, `send`, `ask`, `pending`, and `reply`.

--- a/packages/clients/doompi-server/README.md
+++ b/packages/clients/doompi-server/README.md
@@ -1,21 +1,19 @@
 # @agimon-ai/doompi-server
 
-Headless DoomPi session server: supervises a Pi RPC agent behind an authenticated unix socket so clients can attach and reattach
+Headless DoomPi session server. It supervises a Pi RPC agent behind an authenticated Unix socket so clients can attach and reattach.
 
 This package is a composable [DoomPi](https://www.npmjs.com/package/@agimon-ai/doompi) subsystem.
 It is the serving core the web, desktop, and mobile clients attach to. It registers no Pi
 extension and adds nothing to an interactive session.
 
-## Enabling it
+## How it runs
 
-This package is still in development, so `doompi init` does not reference it and there is nothing
-to add to `.doom/modes.yaml`: it registers no Pi extension and is not part of a mode. It is a
-standalone executable you run yourself, as shown under Run below.
+`doompi-server` is a standalone process, not a Pi extension. Do not add it to `.doom/modes.yaml`. `doompi init` does not configure it.
 
 ## Requirements
 
 - Node.js 22.19.0 or newer
-- `@agimon-ai/doompi` on PATH, which the server supervises
+- A runnable DoomPi agent. The server checks the working directory's installation, `DOOMPI_AGENT_COMMAND`, then `doompi` on `PATH`.
 
 ## Install
 
@@ -32,18 +30,13 @@ chmod 600 /run/doompi/token
 doompi-server --listen /run/doompi/session.sock --auth-token-file /run/doompi/token -- --major-mode copilot
 ```
 
-The server starts `doompi --mode rpc` with the arguments after `--`, then publishes that session
-on the socket. The socket is created owner-only, under a umask so the mode is atomic rather than
-applied after the fact.
+The server starts `doompi --mode rpc` with the arguments after `--`, then publishes the session on the socket. It creates the socket with owner-only access under a restrictive umask.
 
 The session gets an identity at spawn: the server mints a session id (or takes `--session-id`) and
 passes it to Pi together with the `--name` you gave it, so the cockpit knows the session before its
 first frame.
 
-The agent binary resolves per working directory: a repository that pins its own
-`@agimon-ai/doompi` in node_modules runs that exact version (mirroring how launcher scripts
-resolve the repo-local CLI), `DOOMPI_AGENT_COMMAND` overrides the lookup with a binary or a
-`.mjs` path, and the `doompi` on PATH is the fallback.
+The agent command resolves for each working directory. A repository-local `@agimon-ai/doompi` takes precedence, `DOOMPI_AGENT_COMMAND` can name a binary or `.mjs` file, and `doompi` on `PATH` is the fallback.
 
 ## Major-mode relaunches
 
@@ -105,11 +98,9 @@ the session. The buffer is bounded and reports how many frames it had to drop.
 
 ## Current limits
 
-- The executable itself is not covered end to end; the supervisor, socket, handshake, and replay
-  paths are.
-- Transport is a unix socket only. Remote access means tunnelling it, for example over SSH.
-- One agent per server process. Serving several sessions means several servers, which the registry
-  and the cockpit hub present as one working set.
+- The executable itself is not covered end to end. Tests cover the supervisor, socket, handshake, and replay paths.
+- Transport uses a Unix socket only. Tunnel it, for example over SSH, for remote access.
+- Each server process runs one agent. Run several servers for several sessions; the registry and cockpit hub present them as one set.
 
 ## Public API
 

--- a/packages/clients/doompi-web/README.md
+++ b/packages/clients/doompi-web/README.md
@@ -1,22 +1,18 @@
 # @agimon-ai/doompi-web
 
-Web cockpit for DoomPi: a multi-session hub that serves the browser console, discovers every
-running [doompi-server](https://www.npmjs.com/package/@agimon-ai/doompi-server) through the session
-registry, and multiplexes their authenticated sockets behind one page connection
+Web cockpit for DoomPi. It discovers running [doompi-server](https://www.npmjs.com/package/@agimon-ai/doompi-server) sessions, multiplexes their authenticated sockets, and serves them through one browser connection.
 
 This package is a composable [DoomPi](https://www.npmjs.com/package/@agimon-ai/doompi) subsystem.
 It registers no Pi extension and adds nothing to an interactive session.
 
-## Enabling it
+## How it runs
 
-This package is still in development, so `doompi init` does not reference it and there is nothing
-to add to `.doom/modes.yaml`. It is a standalone executable you run yourself, as shown under Run
-below, or the process `doompi-server --web` starts for you.
+`doompi-web` is a standalone process, not a Pi extension. Do not add it to `.doom/modes.yaml`. Run it directly, or start it through `doompi-server --web`.
 
 ## Requirements
 
 - Node.js 22.19.0 or newer
-- Running `doompi-server` processes registering their session sockets
+- `doompi-server` sessions to attach to. The cockpit can start them itself.
 
 ## Install
 
@@ -30,25 +26,17 @@ npm install -g @agimon-ai/doompi-web
 doompi-web
 ```
 
-Then open `http://127.0.0.1:7433`. That is the whole command: no flag is required, and every one
-below is an override. `doompi-web` is the hub. It watches the session registry (`~/.doompi/run` by
-default), attaches to every registered session, shows them all in the rail, and can start new ones
-from the page. Sessions it starts run the `doompi-server` and the agent from this installation, so
-the cockpit and the sessions it creates are always the same build.
+Open `http://127.0.0.1:7433`. With no flags, the hub watches `~/.doompi/run`, attaches to registered sessions, and can start new sessions from the page. Sessions started by the cockpit use the server and agent from the same installation.
 
-Running it twice is not an error. The second one finds the first over the port, prints its URL, and
-exits, because one hub already serves every session.
+If a hub already answers on the port, a second `doompi-web` process prints its URL and exits.
 
-Working on this repository, one command builds what it needs and starts it:
+To run this repository's build:
 
 ```bash
 pnpm cockpit
 ```
 
-Nx caches the build, so a warm run is effectively just the hub. Sessions created from the page run
-this checkout's builds, which matters: a session on some other `doompi` is a different composition,
-and its extensions, commands, and minor modes are not the ones being edited here, so a change looks
-like it did nothing.
+The command builds the required packages and starts the hub on port 7433. Sessions created from the page use this checkout's builds.
 
 | Flag              | Default         | Meaning                                          |
 | ----------------- | --------------- | ------------------------------------------------ |
@@ -60,9 +48,7 @@ like it did nothing.
 | `--state-dir`     | `~/.doompi/web` | Remote-access settings and the tunnel pid file   |
 | `--cloudflared`   | from `PATH`     | Tunnel binary (also `DOOMPI_CLOUDFLARED`)        |
 
-Installing this package gives you `doompi-web` and nothing else. For a session server you run
-yourself, install [doompi-server](https://www.npmjs.com/package/@agimon-ai/doompi-server); the hub
-does not need it on PATH to create sessions.
+Install [doompi-server](https://www.npmjs.com/package/@agimon-ai/doompi-server) when you also want to run a session server directly. The hub does not require `doompi-server` on `PATH` to create sessions.
 
 ## Security
 

--- a/packages/core/doompi-cache/README.md
+++ b/packages/core/doompi-cache/README.md
@@ -1,35 +1,50 @@
 # @agimon-ai/doompi-cache
 
-Provider prompt cache policy and deterministic routing for DoomPi
+Provider prompt-cache policy and deterministic routing for DoomPi.
 
-This package is a composable [DoomPi](https://www.npmjs.com/package/@agimon-ai/doompi) subsystem. Use it with the distribution or install it independently in [Pi](https://www.npmjs.com/package/@earendil-works/pi-coding-agent).
+DoomPi loads this package as fixed core. It derives stable provider cache keys from the active
+session composition and applies them only to supported provider requests. The package can also run
+as a standalone [Pi](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) extension.
+
+> **Alpha:** cache routing and provider integration may change between releases.
 
 ## Requirements
 
 - Node.js 22.19.0 or newer
-- `@earendil-works/pi-coding-agent` 0.84.3
+- Pi 0.84.3 for standalone extension use
 
 ## Install
+
+A DoomPi installation already includes this package. Do not add it to `.doom/modes.yaml`.
+
+To load it directly in Pi:
 
 ```bash
 pi install npm:@agimon-ai/doompi-cache
 ```
 
-The package declares its Pi extension entry, so Pi loads it after installation. DoomPi users can include the package through their normal profile and domain composition instead.
+Pi reads the extension entry from `package.json.pi.extensions` and loads it after installation.
 
 ## Package behavior
 
-DoomPi derives an opaque provider cache key from stable model-visible state, including the composition fingerprint, ordered domains, profile, persona, active minor modes, effective model, and child prompt projection. Returning to equivalent state restores the same key, but provider expiry or eviction can still make that namespace cold.
+DoomPi derives an opaque provider cache key from stable model-visible state: the composition
+fingerprint, ordered domains, profile, persona, active minor modes, effective model, and child prompt
+projection. Returning to equivalent state restores the same key. Provider expiry or eviction can
+still make the cache cold.
 
-The Pi extension rewrites only a nonblank cache key already emitted for an allowlisted OpenAI-family wire API. It preserves supported retention and provider cache markers, avoids adding unsupported fields to proxies, and reports only provider-observed token usage. Telemetry always reports current provider residency as `unknown`.
+The Pi extension rewrites only a nonblank cache key already emitted for an allowlisted OpenAI-family
+wire API. It preserves supported retention and provider cache markers, does not add unsupported
+fields to proxies, and reports only provider-observed token usage. Telemetry reports current
+provider residency as `unknown`.
 
 ## Help
 
-The published package includes `llms.txt` and the package-owned `src/prompts/doompi-use-cache/SKILL.md`. When the DoomPi Help minor mode is active, the extension contributes `doompi-use-cache` to its live Help catalog. The contribution follows Help provider replacement and is withdrawn when the extension shuts down.
+The published package includes `llms.txt` and `src/prompts/doompi-use-cache/SKILL.md`. While DoomPi
+Help is active, the extension adds `doompi-use-cache` to the live Help catalog. The contribution
+follows Help provider replacement and is removed when the extension shuts down.
 
-Help remains optional. Loading the standalone Pi extension does not require DoomPi Help or any other DoomPi runtime service.
-
-To add another package-owned Help prompt, use the `scaffold-doom-prompt` feature with a `doompi-author-*` or `doompi-use-*` name and a concise description. Then link the generated `SKILL.md` from `llms.txt` and register a matching descriptor through the optional `DOOM_HELP_SERVICE` injection in the Pi adapter. Keep prompts as published resources under `src/prompts`; do not export them or copy them into `dist`.
+Help is optional. The standalone Pi extension does not require DoomPi Help or another DoomPi runtime
+service.
 
 ## Public API
 
@@ -46,7 +61,8 @@ import {
 } from '@agimon-ai/doompi-cache/env';
 ```
 
-The Pi host entry is available at `@agimon-ai/doompi-cache/extensions/pi`. The root API has no import-time extension side effects.
+The Pi host entry is `@agimon-ai/doompi-cache/extensions/pi`. Importing the root API does not install
+the extension.
 
 ## Development
 
@@ -59,7 +75,8 @@ pnpm exec vibe-lint check .
 npm pack --dry-run
 ```
 
-The official OpenAI canary is opt-in and reports provider `cached_tokens` without treating a cold result as a deterministic failure:
+The live OpenAI canary is opt-in. It reports provider `cached_tokens`; a cold result does not fail
+the test deterministically:
 
 ```bash
 DOOMPI_CACHE_LIVE_OPENAI=1 \

--- a/packages/core/doompi-web-contracts/README.md
+++ b/packages/core/doompi-web-contracts/README.md
@@ -1,27 +1,46 @@
 # @agimon-ai/doompi-web-contracts
 
-Web cockpit plugin contracts for DoomPi.
+Typed plugin, slot, session-channel, and hub-channel contracts for the DoomPi web cockpit.
 
-Part of the [DoomPi distribution](https://www.npmjs.com/package/@agimon-ai/doompi).
+This is a library, not a Pi extension. It starts no process and does not belong in `.doom/modes.yaml`.
 
-A DoomPi web plugin has two halves that share these types:
+> **Alpha:** web plugin contracts may change between releases.
 
-- A client entry exporting `webPlugin: WebPluginDefinition`, compiled into the cockpit bundle by
-  the host package's build. It can contribute tabs with panels and badges, session data channels,
-  overlays, Leader Space key bindings, command palette commands, rail, selection bar, and
-  activity dock sections, and tool renderers: one `message` component per claimed tool (by name,
-  or by a `matches` predicate for tools named at runtime) that owns the tool call's whole timeline
-  item, composed from the shared components package's `MessageItem` so it looks like every other
-  item; `toolResultText` and `toolResultTextLines` read a result's text blocks the same way.
-- An optional hub entry exporting `webHubChannels: readonly WebHubChannel[]`, loaded by the cockpit
-  server at startup. A channel watches some data source and answers per-session payloads that reach
-  the page as `ChannelFrame` messages whose frame type is the channel name.
+## Install
 
-Plugin packages declare both entries in a `doompiWeb` block in their package.json; the cockpit's
-build scans the workspace and generates its registration modules from those blocks.
+```bash
+npm install @agimon-ai/doompi-web-contracts
+```
 
-Use `defineWebPlugin` and `defineSessionChannel` for checked literals. Server code should import
-these contracts type-only.
+Web plugin clients also require the package's React, React DOM, and TanStack Store peers when they use
+those surfaces.
+
+## Plugin shape
+
+A web plugin can have two entries:
+
+- A client entry exports `webPlugin: WebPluginDefinition`. It can contribute tabs, slots, Leader
+  bindings, commands, session channels, activity surfaces, and tool renderers.
+- An optional hub entry exports `webHubChannels: readonly WebHubChannel[]`. Each channel watches a
+  data source and emits per-session `ChannelFrame` payloads to the page.
+
+Declare both entries in the plugin package's `doompiWeb` manifest block. The DoomPi cockpit bundler
+reads those declarations and generates the registration modules.
+
+Use the definition helpers for checked literals:
+
+```ts
+import {
+  defineSessionChannel,
+  defineSessionStore,
+  defineSlot,
+  defineWebPlugin,
+  toolResultText,
+} from '@agimon-ai/doompi-web-contracts';
+```
+
+Import contracts type-only from server code. The `/testing` subpath provides channel, render, slot,
+and tool-message fixtures for plugin tests.
 
 ## License
 

--- a/packages/minor/doompi-goal/README.md
+++ b/packages/minor/doompi-goal/README.md
@@ -1,7 +1,6 @@
 # @agimon-ai/doompi-goal
 
-A Pi minor mode that keeps one objective, an optional token budget, and completion tools active
-across turns.
+Keep one objective, an optional token budget, and completion tools active across Pi turns.
 
 Part of the [DoomPi distribution](https://www.npmjs.com/package/@agimon-ai/doompi).
 
@@ -38,8 +37,7 @@ pi install npm:@agimon-ai/doompi-goal
 Budgets accept compact values such as `100k` and `1.5m`. Goal adds `goal_complete` and
 `goal_blocked` only while host policy permits and the objective is operational.
 
-In DoomPi, `SPC g e` starts a goal and ends and archives the one being worked, `SPC g g` shows
-status, and `SPC g l` opens history. These views require a TUI; slash commands and tools support headless operation.
+In DoomPi, `SPC g e` starts a goal. If another goal is active, it ends and archives that goal first. `SPC g g` shows status, and `SPC g l` opens history. These views require a TUI; slash commands and tools support headless operation.
 
 ## In the cockpit
 

--- a/packages/minor/doompi-help/README.md
+++ b/packages/minor/doompi-help/README.md
@@ -1,11 +1,10 @@
 # @agimon-ai/doompi-help
 
-Activation-gated, package-owned guidance for DoomPi.
+Load package-owned DoomPi guidance only when Help mode is active.
 
 Part of the [DoomPi distribution](https://www.npmjs.com/package/@agimon-ai/doompi).
 
-Help keeps extension documentation out of the default model context. Packages contribute concise
-`llms.txt` indexes; the Help host resolves and exposes them only while Help mode is active.
+Packages contribute concise `llms.txt` indexes. Help keeps them out of the default model context and exposes them only while Help mode is active.
 
 > **Alpha:** Help contribution contracts may change between releases.
 

--- a/packages/minor/doompi-loop/README.md
+++ b/packages/minor/doompi-loop/README.md
@@ -1,6 +1,6 @@
 # @agimon-ai/doompi-loop
 
-A session-scoped scheduler that sends a prompt immediately and repeats it at a bounded interval.
+Send a prompt now, then repeat it at a bounded interval for the current session.
 
 Part of the [DoomPi distribution](https://www.npmjs.com/package/@agimon-ai/doompi).
 

--- a/packages/minor/doompi-plan/README.md
+++ b/packages/minor/doompi-plan/README.md
@@ -1,7 +1,6 @@
 # @agimon-ai/doompi-plan
 
-A reviewable planning lifecycle for Pi with narrowed tools, plan storage, normal, debug, and
-Fable-assisted flows, and explicit completion.
+Create and review stored plans in Pi with narrowed tools, explicit completion, and normal, debug, or Fable-assisted flows.
 
 Part of the [DoomPi distribution](https://www.npmjs.com/package/@agimon-ai/doompi).
 

--- a/packages/minor/doompi-voice/README.md
+++ b/packages/minor/doompi-voice/README.md
@@ -1,7 +1,6 @@
 # @agimon-ai/doompi-voice
 
-Client speech capture, host-side transcription engines, playback, and autonomous Voice mode for
-DoomPi.
+Capture speech on the client, transcribe it on the host, and play responses through DoomPi Voice mode.
 
 Part of the [DoomPi distribution](https://www.npmjs.com/package/@agimon-ai/doompi).
 
@@ -71,8 +70,9 @@ defaults to 3,000.
 
 When the agent is launched by `doompi-server`, capture and narration use the connected browser.
 The browser sends mono 16 kHz PCM16 through the authenticated session media API, while VAD,
-spooling, and Whisper stay on the agent host. Standalone terminal launches retain the macOS
-FFmpeg and `say` adapters. The client media contract is browser-neutral so a native client can
+spooling, and Whisper stay on the agent host. Standalone terminal launches retain the macOS FFmpeg and `say` adapters. In the browser,
+`tts.voice` selects an exact SpeechSynthesis voice name or URI. If it does not match, the browser
+uses its default voice. The client media contract is browser-neutral so a native client can
 provide its own microphone and playback adapters later through
 `@agimon-ai/doompi-voice/client-media`.
 

--- a/packages/minor/doompi-voice/docs/ARCHITECTURE.md
+++ b/packages/minor/doompi-voice/docs/ARCHITECTURE.md
@@ -7,9 +7,6 @@ question of what the system _must_ do; this one explains what the code _is_. Whe
 disagreed, the disagreements are listed in [Known divergences](#known-divergences) rather than
 quietly reconciled.
 
-Line references are accurate as of the commit that introduced this file. They are navigation aids,
-not guarantees.
-
 ## Contents
 
 - [1. What runs where](#1-what-runs-where)
@@ -63,8 +60,8 @@ flowchart TB
   play --> say
 ```
 
-The boundary is constructed in exactly two places: `voiceWorkerClient.ts:59`
-(`new Worker(workerUrl, { name: 'doompi-voice' })`) and `voiceWorker.ts:167`
+The boundary is constructed in exactly two places: `voiceWorkerClient.ts`
+(`new Worker(workerUrl, { name: 'doompi-voice' })`) and `voiceWorker.ts`
 (`if (!isMainThread) startVoiceWorker()`). Every subprocess is spawned from one file,
 `adapters/audio/infrastructure.ts`, which is the only module in `src/` that imports
 `node:child_process`.
@@ -74,7 +71,7 @@ Two consequences worth holding onto:
 - **`say` runs on the main thread while `ffmpeg` runs in the worker.** The two halves of the
   half-duplex problem are therefore in different threads, which is why playback gating is a
   protocol message (`playback-state`) rather than a local boolean.
-- **No audio crosses the protocol.** `assertNoRawAudio` (`voiceWorkerProtocol.ts:185`) rejects any
+- **No audio crosses the protocol.** `assertNoRawAudio` (`voiceWorkerProtocol.ts`) rejects any
   `ArrayBuffer`, typed array, or key named `audio` / `pcm` / `wav` / `buffer` / `rawAudio` on any
   message. PCM lives and dies in the worker and its private spool.
 
@@ -125,19 +122,19 @@ sequenceDiagram
 Two facts this diagram exists to make unmissable, because both routinely surprise people and both
 drove recent design work:
 
-- **A turn produces exactly one transcript.** `transcribe()` (`voiceWorkerPipeline.ts:524`) reads
+- **A turn produces exactly one transcript.** `transcribe()` (`voiceWorkerPipeline.ts`) reads
   the whole committed spool in a single pass. There is no interim or streaming ASR, so the
   transcript policy never sees a partial hypothesis. A command spoken after a brief pause arrives
   glued to the sentence before it unless the endpoint window is short enough to split the turn.
 - **The VAD's 600 ms trailing window is inside `utteranceIdleMs`, not additional to it.**
-  `speechEnded` (`autonomousEndpoint.ts:40-56`) arms a timer for
+  `speechEnded` (`autonomousEndpoint.ts`) arms a timer for
   `utteranceIdleMs - observedSilence`, so the default 3000 ms means roughly 3 s of true silence in
   total, not 3.6 s.
 
 **The composing branch.** While a composition draft is collecting, `effect.beginCapture` carries
-`composing: true` (`autonomousVoiceMachine.ts:287`) and the session substitutes
+`composing: true` (`autonomousVoiceMachine.ts`) and the session substitutes
 `composeUtteranceIdleMs` (default 1200 ms) for `utteranceIdleMs`
-(`autonomousVoiceSession.ts:381`). That is what lets a short command such as `that's it` finalize
+(`autonomousVoiceSession.ts`). That is what lets a short command such as `that's it` finalize
 as its own turn. Over-splitting is harmless in that mode and only that mode, because draft
 segments are rejoined with a space.
 
@@ -262,7 +259,7 @@ cannot mutate a turn that has already moved on.
 
 ### What the UI shows
 
-`autonomousVoiceState()` (`autonomousVoiceMachine.ts:773`) collapses the tree into
+`autonomousVoiceState()` (`autonomousVoiceMachine.ts`) collapses the tree into
 `off | starting | listening | speech | processing | stopping | failed`. Everything from
 `finalizing` onward, six distinct states, projects to the single value `processing`. The modeline
 is therefore deliberately coarser than the machine, and a user watching the indicator cannot tell
@@ -319,20 +316,20 @@ sequenceDiagram
 
 ### Pi into Voice
 
-| Hook                   | Site               | What it does                                                                   |
-| ---------------------- | ------------------ | ------------------------------------------------------------------------------ |
-| `session_start`        | `extension.ts:162` | Refreshes config readiness, gates `waitUntilConfigured`                        |
-| `session_start`        | `voice.ts:978`     | Deactivates capture, rebinds the voice-tool session, consumes a reload handoff |
-| `before_agent_start`   | `voice.ts:1024`    | Refreshes `activeContext`, reconciles the tool set                             |
-| `before_agent_start`   | `voice.ts:406`     | Captures fallback-narration ownership for the run                              |
-| `tool_execution_start` | `voice.ts:420`     | Notes that `narrate` was attempted, which suppresses the fallback              |
-| `turn_end`             | `voice.ts:426`     | Stores the terminal assistant text                                             |
-| `agent_settled`        | `voice.ts:431`     | Fires the zero-call fallback if `narrate` was never attempted                  |
-| `session_shutdown`     | `extension.ts:212` | Disposes the cordis fiber and the host connection                              |
+| Hook                   | Site           | What it does                                                                   |
+| ---------------------- | -------------- | ------------------------------------------------------------------------------ |
+| `session_start`        | `extension.ts` | Refreshes config readiness, gates `waitUntilConfigured`                        |
+| `session_start`        | `voice.ts`     | Deactivates capture, rebinds the voice-tool session, consumes a reload handoff |
+| `before_agent_start`   | `voice.ts`     | Refreshes `activeContext`, reconciles the tool set                             |
+| `before_agent_start`   | `voice.ts`     | Captures fallback-narration ownership for the run                              |
+| `tool_execution_start` | `voice.ts`     | Notes that `narrate` was attempted, which suppresses the fallback              |
+| `turn_end`             | `voice.ts`     | Stores the terminal assistant text                                             |
+| `agent_settled`        | `voice.ts`     | Fires the zero-call fallback if `narrate` was never attempted                  |
+| `session_shutdown`     | `extension.ts` | Disposes the cordis fiber and the host connection                              |
 
 ### Voice into Pi
 
-Delivery is nine lines and is the whole contract (`voice.ts:321-336`):
+The delivery branch is the whole contract (`voice.ts`):
 
 ```ts
 if (intent === 'queuedFollowUp') {
@@ -347,12 +344,12 @@ pi.sendUserMessage(text, { deliverAs: 'steer' });
 ```
 
 **Delivery success is weaker than it looks.** `sendUserMessage` exposes no downstream receipt, so
-`DELIVERY_SUCCEEDED` means only that the call did not throw (`voiceDelivery.ts:50-68`). Voice must
+`DELIVERY_SUCCEEDED` means only that the call did not throw (`voiceDelivery.ts`). Voice must
 not claim confirmed host delivery, retry automatically, or clear a composed draft on the strength
 of it.
 
 Three tools are registered, and all three are removed from the active set unless autonomous voice
-is exactly `active` with a matching TUI session (`voice.ts:846-850`):
+is exactly `active` with a matching TUI session (`voice.ts`):
 
 | Tool                   | Purpose                                                         |
 | ---------------------- | --------------------------------------------------------------- |
@@ -403,14 +400,14 @@ flowchart TB
 
 ### Cordis services
 
-| Direction | Service                           | Site                                                  |
-| --------- | --------------------------------- | ----------------------------------------------------- |
-| provides  | `DOOM_VOICE_TOOLS_SERVICE`        | `voice.ts:816`                                        |
-| provides  | `DOOM_NARRATION_SERVICE`          | `voice.ts:897`                                        |
-| injects   | `DOOM_HELP_SERVICE`               | `extension.ts:46`                                     |
-| injects   | `DOOM_UI_HUB_SERVICE`             | `extension.ts:128`                                    |
-| injects   | `DOOM_MINOR_MODE_CATALOG_SERVICE` | `voice.ts:901`                                        |
-| listens   | `DOOM_ASK_USER_BLOCKED_EVENT`     | `voice.ts:363`, blocks delivery while a modal is open |
+| Direction | Service                           | Site                                              |
+| --------- | --------------------------------- | ------------------------------------------------- |
+| provides  | `DOOM_VOICE_TOOLS_SERVICE`        | `voice.ts`                                        |
+| provides  | `DOOM_NARRATION_SERVICE`          | `voice.ts`                                        |
+| injects   | `DOOM_HELP_SERVICE`               | `extension.ts`                                    |
+| injects   | `DOOM_UI_HUB_SERVICE`             | `extension.ts`                                    |
+| injects   | `DOOM_MINOR_MODE_CATALOG_SERVICE` | `voice.ts`                                        |
+| listens   | `DOOM_ASK_USER_BLOCKED_EVENT`     | `voice.ts`, blocks delivery while a modal is open |
 
 ### Worker protocol
 
@@ -491,7 +488,7 @@ sequenceDiagram
   Note over GT: 800 ms echo tail, then reopen
 ```
 
-Evidence is ranked deterministically (`narrationBargeIn.ts:144-157`):
+Evidence is ranked deterministically (`narrationBargeIn.ts`):
 
 | Guard                                              | Weight |
 | -------------------------------------------------- | ------ |
@@ -527,10 +524,10 @@ Recorded rather than fixed, because each is a design decision rather than a typo
 | Divergence                                      | Detail                                                                                                                                                                                                                                                    |
 | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ACTIVITY_OBSERVED` and `SPEECH_ENDED` are dead | Declared in the event union, never sent, never handled. The worker publishes `activity` at 8 Hz carrying `levelDbfs` and `speechProbability`, and the session has no branch for it, so AV-USER-006's responsiveness clause is unobservable from the host. |
-| `recovered` events are dropped                  | The worker publishes them (`voiceWorkerPipeline.ts:573`), nothing consumes them, so AV-WORKER-002's requirement to surface recovered spools has no mechanism.                                                                                             |
-| `narrationFailed` has no implementation         | SPEC lists it as a playback state. TTS failure is handled outside XState, in `narrationPlayback.ts:137-146`, by flipping a private flag. The playback region has exactly three nodes.                                                                     |
+| `recovered` events are dropped                  | The worker publishes them (`voiceWorkerPipeline.ts`), nothing consumes them, so AV-WORKER-002's requirement to surface recovered spools has no mechanism.                                                                                                 |
+| `narrationFailed` has no implementation         | SPEC lists it as a playback state. TTS failure is handled outside XState, in `narrationPlayback.ts`, by flipping a private flag. The playback region has exactly three nodes.                                                                             |
 | UI indicator list is wrong in SPEC §4.12        | It names `composing`, `sending`, `starting`, `stopping` and `error`, none of which exist in `AutoCaptureIndicatorState`, and omits `confirming` and `waiting`, which do. Composition appears only in the status string.                                   |
-| `confirming` is unreachable                     | `confirmationPending` is hard-coded `false` at its only call site (`autonomousVoiceSession.ts:762`).                                                                                                                                                      |
-| Guard `stopWasRequested` is unused              | Declared at `autonomousVoiceMachine.ts:211`; the equivalent check is written inline in `acknowledging` instead.                                                                                                                                           |
+| `confirming` is unreachable                     | `confirmationPending` is hard-coded `false` at its only call site (`autonomousVoiceSession.ts`).                                                                                                                                                          |
+| Guard `stopWasRequested` is unused              | Declared at `autonomousVoiceMachine.ts`; the equivalent check is written inline in `acknowledging` instead.                                                                                                                                               |
 | No `invoke:` anywhere                           | SPEC §3.5 permits "invoked actors or explicit effects". The machine uses only emitted effects, so the follow-on requirement that exiting a state cancels its invoked actor has no machine-level implementation; cancellation is manual in the session.    |
 | Duration limit arrives as a failure             | A recoverable lifecycle boundary is transported as `failure` with code `capture_duration_limit`.                                                                                                                                                          |

--- a/packages/minor/doompi-voice/docs/SPEC.md
+++ b/packages/minor/doompi-voice/docs/SPEC.md
@@ -51,7 +51,7 @@ turn identities and MUST NOT attach an unrelated previous spool.
 
 ## 2. User contract
 
-### AV-USER-001 — Enable
+### AV-USER-001: Enable
 
 When autonomous voice is off, pressing `SPC v e` MUST:
 
@@ -63,7 +63,7 @@ When autonomous voice is off, pressing `SPC v e` MUST:
 
 If any step fails, the mode MUST return to `off`, stop acquired resources, and show an actionable error.
 
-### AV-USER-002 — Automatic turn processing
+### AV-USER-002: Automatic turn processing
 
 While enabled, a normal user turn MUST complete without another key press:
 
@@ -80,7 +80,7 @@ listening
 
 `SPC v e` MUST NOT be required to trigger endpointing, transcription, submission, acknowledgement, or the next capture.
 
-### AV-USER-003 — Toggle off
+### AV-USER-003: Toggle off
 
 Pressing `SPC v e` while autonomous voice is enabled MUST request a graceful stop and MUST be idempotent.
 
@@ -93,17 +93,17 @@ Pressing `SPC v e` while autonomous voice is enabled MUST request a graceful sto
 
 Extension disposal and session shutdown are hard stops: they MUST abort outstanding work rather than deliver a new user turn.
 
-### AV-USER-004 — Continuous operation
+### AV-USER-004: Continuous operation
 
 After any committed, empty, or deliberately discarded turn, the machine MUST either start exactly one next capture or enter a visible terminal state. It MUST never report `listening` without a live worker capture.
 
-### AV-USER-005 — Exact delivery
+### AV-USER-005: Exact delivery
 
 The submitted prompt MUST be the deterministic transcript-policy result, with only documented control-phrase removal and an optional validated ASR-wording correction. A correction MUST consist solely of bounded, non-overlapping exact-source replacements whose replacement text is an exact phrase in the bounded runtime reference context. It MUST preserve intent, content, constraints, ordering, specificity, negation, and every number.
 
 A language model MUST NOT return or submit a free-form rewritten prompt. Runtime context is untrusted quoted reference vocabulary, never an instruction or a source of additional user content. Missing or ambiguous context, invalid output, timeout, cancellation, or model failure MUST deliver the unchanged transcript-policy result.
 
-### AV-USER-006 — Responsiveness
+### AV-USER-006: Responsiveness
 
 With a healthy recorder and local model:
 
@@ -577,7 +577,7 @@ Impact on result: makes real failures diagnosable rather than represented by gen
 
 ## 5. Audio and VAD requirements
 
-### AV-AUDIO-001 — Format
+### AV-AUDIO-001: Format
 
 - sample rate: 16,000 Hz;
 - channels: mono;
@@ -602,7 +602,7 @@ Default behavior:
 - adaptive threshold: noise floor +10 dB, clamped from -50 to -25 dBFS;
 - Silero threshold: 0.5 over 512-sample windows.
 
-### AV-VAD-002 — Endpoint timing
+### AV-VAD-002: Endpoint timing
 
 `utteranceIdleMs` is measured from the last accepted voiced frame. The default is 3000 ms and the supported configuration range is 1500–10000 ms.
 
@@ -610,51 +610,51 @@ The VAD trailing-silence window is part of that total, not additional to it. Exa
 
 While a composition draft is collecting, the endpoint MUST instead use `composeUtteranceIdleMs`, default 1200 ms with a supported range of 800 to 3000 ms. A turn produces exactly one transcript, so at the ordinary window a short command spoken after a brief pause arrives appended to the sentence before it and cannot be adjudicated as a command. Over-splitting is acceptable in this mode because draft segments are rejoined.
 
-### AV-VAD-003 — No acoustic TTS cancellation
+### AV-VAD-003: No acoustic TTS cancellation
 
 Neither provisional nor confirmed VAD speech may directly abort TTS. Playback cancellation requires priority supersession, hard stop, or future Section 10 barge-in evidence.
 
 ## 6. Capture, spool, and worker requirements
 
-### AV-CAP-001 — Readiness and recovery
+### AV-CAP-001: Readiness and recovery
 
 First-frame readiness, liveness checks, recorder exits, and recovery exhaustion MUST return typed events to the lifecycle machine.
 
 Total recorder startup/recovery before a terminal outcome MUST be bounded. Repeating four independent 8-second first-frame attempts while showing `listening` is prohibited.
 
-### AV-CAP-002 — Frame callback performance
+### AV-CAP-002: Frame callback performance
 
 The 20 ms recorder callback MUST NOT perform an `fsync`, manifest rewrite, WAV conversion, ASR invocation, model invocation, or other unbounded synchronous operation per frame.
 
 Durability MAY be batched with a documented maximum loss window. Finalization MUST flush committed audio before snapshot creation.
 
-### AV-CAP-003 — Bounded capture windows
+### AV-CAP-003: Bounded capture windows
 
 A manual capture finalizes when its configured duration limit expires. An autonomous duration limit is a recoverable lifecycle boundary, not worker exhaustion: XState cancels and replaces a still-listening capture with a new turn identity, or finalizes the current capture with reason `duration-limit` when speech is confirmed. Idle rotation removes the old private spool and MUST NOT disable autonomous voice or run ASR over an idle five-minute window.
 
-### AV-WORKER-001 — Supervision
+### AV-WORKER-001: Supervision
 
 Worker supervision MUST cover functional health, not heartbeat delivery alone. A heartbeat from a worker with hung ASR does not satisfy health. ASR has its own timeout and cancellation path.
 
-### AV-WORKER-002 — Recovery
+### AV-WORKER-002: Recovery
 
 After worker restart, only the machine's current capture may resume. Recovered spools from unrelated prior extension sessions MUST be surfaced for explicit recovery/discard policy and MUST NOT silently attach to a new turn.
 
 ## 7. Transcription and delivery requirements
 
-### AV-ASR-001 — Single final pass
+### AV-ASR-001: Single final pass
 
 A normal autonomous turn performs one final ASR request. The worker MUST freeze capture before creating its final snapshot, and no later PCM may enter that revision.
 
-### AV-ASR-002 — Timeout
+### AV-ASR-002: Timeout
 
 ASR defaults to a 15-second deadline. Timeout aborts the adapter process and returns `TRANSCRIPTION_TIMED_OUT`. The lifecycle then discards/retries according to a bounded policy or enters `failed`; it never remains indefinitely in `transcribing`.
 
-### AV-ASR-003 — Empty transcript
+### AV-ASR-003: Empty transcript
 
 Digital silence is discarded without a normalization retry. Nonzero PCM that produces an empty transcript MAY receive one bounded gain-normalized retry within the same ASR deadline. A final empty result is acknowledged as discarded and leads to exactly one next capture unless stopping.
 
-### AV-CORRECTION-001 — Context-bounded wording repair
+### AV-CORRECTION-001: Context-bounded wording repair
 
 Command correction runs only after deterministic transcript policy has accepted a deliverable prompt. The request MAY contain the accepted prompt plus the bounded context defined by Section 4.9; it MUST NOT contain other branch messages or tool payloads. Model output is an untrusted patch proposal, not a rewritten prompt.
 
@@ -662,7 +662,7 @@ Every accepted replacement MUST use an exact whole-phrase source from the prompt
 
 An absent context skips the model call. Invalid JSON, an unsafe patch, model failure, or timeout falls back to the unchanged transcript-policy result. Toggle-off aborts the request and may use that fallback for the already-confirmed turn; hard shutdown aborts it and MUST NOT deliver a new turn.
 
-### AV-DELIVERY-001 — Exact once
+### AV-DELIVERY-001: Exact once
 
 Delivery and acknowledgement are separate effects coordinated by the machine:
 
@@ -676,7 +676,7 @@ A failed model call or undefined branch MUST NOT acknowledge a spool and then sk
 
 ## 8. Narration, playback gating, and barge-in requirements
 
-### AV-TTS-001 — Playback gate
+### AV-TTS-001: Playback gate
 
 Before or immediately when TTS starts, the worker receives `playback-state(active: true, generation: N)` with the exact narration reference when ranked barge-in was capability-negotiated. When `intentional-barge-in` is also negotiated, the message includes configured start phrases; older protocol-v1 workers receive no unsupported field and can authorize only command-only discard. The worker keeps the recorder alive for liveness and excludes unconfirmed playback frames from user-turn persistence, ordinary VAD, activity, and endpointing. A bounded overlap monitor may inspect private copies under Section 10.
 
@@ -684,7 +684,7 @@ After playback completes, fails, or is explicitly aborted, the worker receives `
 
 Older generations cannot shorten newer suppression.
 
-### AV-TTS-002 — Priority
+### AV-TTS-002: Priority
 
 Narration priority remains:
 
@@ -694,7 +694,7 @@ intent < plan < final < clarification < question
 
 The coordinator retains this ordering for shared playback. The direct `narrate` tool and zero-call final fallback enter as `final`; external narration requests enter as `clarification`. No automatic lifecycle source produces `intent`, `plan`, milestone, or tool-progress speech. Higher-priority narration may supersede lower-priority narration. Toggle-off, hard stop, and extension disposal abort playback and pending fallback generation.
 
-### AV-TTS-003 — Failure isolation
+### AV-TTS-003: Failure isolation
 
 A thrown or nonzero TTS outcome settles the request as `failed`, disables narration for the activation, and emits an actionable warning. It MUST NOT disable, restart, or strand microphone capture. A later activation MAY re-enable narration after a successful preflight.
 

--- a/packages/minor/doompi-voice/models/README.md
+++ b/packages/minor/doompi-voice/models/README.md
@@ -1,9 +1,11 @@
 # Silero VAD model
 
-`silero_vad_v6.2.1.onnx` is the upstream Silero Voice Activity Detector model used for local speech-presence inference.
+`silero_vad_v6.2.1.onnx` provides local speech-presence inference for Voice. It is the upstream Silero Voice Activity Detector model without repository-specific changes.
 
-- Upstream: https://github.com/snakers4/silero-vad
-- Release: `v6.2.1`
-- Source: https://github.com/snakers4/silero-vad/raw/refs/tags/v6.2.1/src/silero_vad/data/silero_vad.onnx
-- SHA-256: `1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3`
-- License: MIT, reproduced in `SILERO-LICENSE`
+| Field   | Value                                                                                                              |
+| ------- | ------------------------------------------------------------------------------------------------------------------ |
+| Project | [Silero VAD](https://github.com/snakers4/silero-vad)                                                               |
+| Release | `v6.2.1`                                                                                                           |
+| Source  | [silero_vad.onnx](https://github.com/snakers4/silero-vad/raw/refs/tags/v6.2.1/src/silero_vad/data/silero_vad.onnx) |
+| SHA-256 | `1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3`                                                 |
+| License | MIT, reproduced in `SILERO-LICENSE`                                                                                |

--- a/packages/minor/doompi-workflow/README.md
+++ b/packages/minor/doompi-workflow/README.md
@@ -1,7 +1,6 @@
 # @agimon-ai/doompi-workflow
 
-Asynchronous workflow discovery, launch, monitoring, control, and recovery from terminal failures
-for DoomPi.
+Discover, launch, monitor, control, and recover asynchronous DoomPi workflows.
 
 Part of the [DoomPi distribution](https://www.npmjs.com/package/@agimon-ai/doompi).
 

--- a/packages/tooling/vibe-lint-plugin-doom-extension/README.md
+++ b/packages/tooling/vibe-lint-plugin-doom-extension/README.md
@@ -2,15 +2,19 @@
 
 Deterministic Vibe-Lint rules for publishable DoomPi extension packages.
 
+This package is alpha software. Its rules and package contracts may change between alpha releases. It requires Node.js 22.19.0 or newer and the `@agimon-ai/vibe-lint` peer version declared in its package metadata.
+
 ## Install
 
 ```bash
 pnpm add -D @agimon-ai/vibe-lint @agimon-ai/vibe-lint-plugin-doom-extension
 ```
 
+This installs the Vibe-Lint CLI and the DoomPi extension rule plugin as development dependencies.
+
 ## Configure
 
-Vibe-Lint resolves the short plugin name to this package:
+Add the plugin and one preset to `vibe-lint.config.yaml`:
 
 ```yaml
 plugins:
@@ -22,26 +26,36 @@ extends:
   - doom-extension/recommended
 ```
 
-Use `doom-extension/migration` to enable every rule at warning severity while migrating an existing package.
+Vibe-Lint resolves the short name `doom-extension` to this package. The recommended preset enables the extension contract at error severity. For an existing package migration, replace `doom-extension/recommended` with `doom-extension/migration`. The migration preset enables the same rules at warning severity.
 
-Package-owned Help prompts live under `src/prompts/<prompt-name>/SKILL.md`. The
-`doom-prompt-shape` rule checks their directory names, frontmatter, `llms.txt`
-links, and publish allowlist entry. Prompt support resources may remain beside
-the skill in standard `references`, `scripts`, `assets`, and `agents` folders.
+Run the configured checks with:
 
-A package that serves HTTP declares it in package.json under `doompiApi`, naming
-a base path and an entry per scope it offers: `session` for the session's own
-server, `hub` for the cockpit hub. The `package-api-manifest` rule checks the
-base path, that each declared entry exists, and that the built entry a host
-imports is in the publish allowlist; `package-api-entry` checks that the entry
-exports `api`, the name the generated route module imports it by. Both matter
-because nothing validates the block at install time, so a wrong path first shows
-up as a notice on a user machine after publishing.
+```bash
+pnpm exec vibe-lint check .
+```
 
-The Cordis rules enforce one runner-owned host, host-first/finalizer-last activation in the final activation array, exactly one captured feature lease and plugin fiber, and control-flow-ordered shutdown of the fiber before its lease. A provider may publish only from the context owned by its mounted plugin or an owned injection; package-wide publication does not satisfy that boundary. Required services must be owned by `ctx.inject`, and a stable Pi wrapper must identity-check and clear its active binding from that injection's cleanup when the provider unloads.
+The command checks the current directory using its resolved Vibe-Lint configuration. The plugin reports violations but does not rewrite package files.
 
-Pi EventBus use is followed through local aliases and helper parameters and is reserved for the versioned host query. Same-runner runtime protocol imports are denied by default except for passive protocol error classes. Live `global` or `globalThis` capability registries are rejected; the exact reload-handoff and bootstrap-claim modules remain exceptions only while they retain their TTL/generation or identity/release fences.
+## Enforced package contracts
+
+The preset checks the canonical DoomPi source layout, layer dependencies, public exports, schemas, services, Pi entry points, peer versions, Cordis ownership, lifecycle cleanup, package metadata, optional HTTP APIs, and optional web cockpit plugins.
+
+### Help prompts
+
+Package-owned Help prompts live at `src/prompts/<prompt-name>/SKILL.md`. The `doom-prompt-shape` rule checks the prompt directory name, frontmatter, `llms.txt` link, and publish allowlist entry. A prompt may keep support material in adjacent `references`, `scripts`, `assets`, and `agents` directories.
+
+### HTTP APIs
+
+A package that serves HTTP declares `doompiApi` in `package.json`. The declaration names a base path and an entry for each supported scope: `session` for the session server and `hub` for the cockpit hub.
+
+`package-api-manifest` checks the base path, each declared entry, and the publish allowlist for the built module imported by the host. `package-api-entry` checks that the entry exports the named `api` value expected by generated route modules. Installation does not validate this manifest, so an invalid published path may not surface until a host loads the package.
+
+### Cordis and runtime ownership
+
+The Cordis rules require one runner-owned host. They check host-first and finalizer-last activation, one captured feature lease and plugin fiber, and shutdown of the fiber before its lease. Providers may publish only from the context owned by their mounted plugin or an owned injection. Required services belong in `ctx.inject`. Stable Pi wrappers must identity-check and clear their active binding during injection cleanup when a provider unloads.
+
+Pi EventBus use is reserved for the versioned host query and is followed through local aliases and helper parameters. Same-runner runtime protocol imports are rejected except for passive protocol error classes. Live `global` and `globalThis` capability registries are rejected. The reload-handoff and bootstrap-claim modules remain narrow exceptions only while their TTL, generation, identity, or release fences remain intact.
 
 ## Public API
 
-The default export is the Vibe-Lint plugin contract. The package also exports `doomExtensionPlugin`, `rules`, `recommended`, `migration`, and each deterministic rule definition as named exports.
+The default export is the Vibe-Lint plugin contract. Named exports include `doomExtensionPlugin`, `rules`, `recommended`, `migration`, and the rule definitions re-exported by the package entry point.

--- a/plugins/blog-writing/README.md
+++ b/plugins/blog-writing/README.md
@@ -1,25 +1,19 @@
 # DoomPi Blog Writing Plugin
 
-This example turns a topic into a source-backed, review-ready blog post through separate research,
-outline, drafting, and editorial stages. It demonstrates that DoomPi can compose non-code work with
-the same native plugin conventions used for development.
+This example plugin takes a blog post from research through editorial review. It works with Codex, Claude Code, and DoomPi without choosing a model, CMS, publication platform, brand voice, or content directory.
 
-## Components
+## What it includes
 
-- [`blog-research`](skills/blog-research/SKILL.md) produces a traceable research brief and source list.
-- [`blog-outline`](skills/blog-outline/SKILL.md) turns approved research into a focused structure.
-- [`blog-draft`](skills/blog-draft/SKILL.md) writes a sourced draft without publishing it.
-- [`blog-review`](skills/blog-review/SKILL.md) fact-checks and edits the draft.
-- On hosts that support Markdown agents,
-  [`blog-researcher`](agents/blog-researcher.md), [`blog-writer`](agents/blog-writer.md), and
-  [`blog-editor`](agents/blog-editor.md) provide clear stage ownership.
+- [`blog-research`](skills/blog-research/SKILL.md) creates a research brief and numbered source list. It separates verified facts, inferences, disputed claims, and open questions.
+- [`blog-outline`](skills/blog-outline/SKILL.md) turns approved research into a source-aware outline. It does not draft the post.
+- [`blog-draft`](skills/blog-draft/SKILL.md) writes a sourced, review-ready draft from the approved outline. It does not publish or update a CMS.
+- [`blog-review`](skills/blog-review/SKILL.md) fact-checks and edits the draft, then returns a revision and publication-readiness checklist.
 
-The plugin does not pin a model, publication platform, CMS, brand voice, or content directory. The
-user or workflow supplies those choices when they matter.
+Hosts that support Markdown agents can assign those stages to [`blog-researcher`](agents/blog-researcher.md), [`blog-writer`](agents/blog-writer.md), and [`blog-editor`](agents/blog-editor.md).
 
-## Install directly
+## Install the plugin directly
 
-Register the repository marketplace once from the repository root, then install the plugin.
+Run these commands from the DoomPi repository root. The first command registers the repository's `doompi-examples` marketplace. The second installs `blog-writing` from that marketplace.
 
 Codex:
 
@@ -35,15 +29,21 @@ claude plugin marketplace add ./ --scope user
 claude plugin install blog-writing@doompi-examples --scope user
 ```
 
-## Compose with DoomPi
+The Claude Code commands register and install the plugin for the current user.
+
+## Load it with DoomPi
+
+The repository maps the `blog` domain to this plugin:
 
 ```bash
 doompi --major-mode copilot --domains blog --explain
 doompi --major-mode copilot --domains blog
 ```
 
+The first command prints the resolved composition and estimated prompt cost without launching Pi. The second launches the Copilot composition with the `blog` domain.
+
 Try: `Research and draft a practical post about this topic for this audience.`
 
-Research must remain traceable, unsupported claims stay marked, and no stage publishes or writes to
-a CMS. When a workflow run directory is supplied, the skills write only to declared artifacts
-inside it.
+## Output boundaries
+
+The workflow does not publish or write to a CMS. It keeps unsupported claims marked instead of turning them into facts. When `WORKFLOW_RUN_DIR` is set, each skill writes only to its declared artifacts inside that directory. Otherwise, it uses the destination requested by the user.

--- a/plugins/development/README.md
+++ b/plugins/development/README.md
@@ -1,22 +1,18 @@
 # DoomPi Development Plugin
 
-This example packages a portable development workflow for Codex, Claude Code, and DoomPi. It
-demonstrates how native plugin manifests can share one skills directory instead of maintaining
-vendor-specific prompt copies.
+This example plugin provides one portable implementation workflow for Codex, Claude Code, and DoomPi. Both native plugin manifests load the same skill instead of maintaining host-specific prompt copies.
 
-## Components
+## What it includes
 
-- [`doompi-development`](skills/doompi-development/SKILL.md) guides scoped implementation and verification.
-- [`doompi-developer`](agents/doompi-developer.md) is the corresponding implementation agent for
-  hosts that support Markdown agents.
-- `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json` expose the same `skills/` directory.
+- [`doompi-development`](skills/doompi-development/SKILL.md) scopes a requested code change, implements the smallest coherent solution, and verifies it with the target repository's own checks.
+- [`doompi-developer`](agents/doompi-developer.md) provides the corresponding implementation agent on hosts that support Markdown agents.
+- `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json` expose the shared `skills/` directory to their respective hosts.
 
-The plugin does not pin a model, framework, package manager, or test runner. It discovers and
-follows the target repository's own instructions.
+The plugin does not choose a model, framework, package manager, or test runner. It reads and follows the target repository's instructions and existing conventions.
 
-## Install directly
+## Install the plugin directly
 
-Register the repository marketplace once from the repository root, then install the plugin.
+Run these commands from the DoomPi repository root. The first command registers the repository's `doompi-examples` marketplace. The second installs `development` from that marketplace.
 
 Codex:
 
@@ -32,16 +28,21 @@ claude plugin marketplace add ./ --scope user
 claude plugin install development@doompi-examples --scope user
 ```
 
-## Compose with DoomPi
+The Claude Code commands register and install the plugin for the current user.
 
-The repository's DoomPi domain configuration selects this plugin as `development`:
+## Load it with DoomPi
+
+The repository maps the `development` domain to this plugin:
 
 ```bash
 doompi --major-mode copilot --domains development --explain
 doompi --major-mode copilot --domains development
 ```
 
-Try a request such as: `Implement the smallest safe version of this feature and verify it.`
+The first command prints the resolved composition and estimated prompt cost without launching Pi. The second launches the Copilot composition with the `development` domain.
 
-The plugin never creates a branch, commit, release, or pull request unless the user asks for that
-action.
+Try: `Implement the smallest safe version of this feature and verify it.`
+
+## Operational boundaries
+
+The workflow preserves unrelated worktree changes and avoids new dependencies or abstractions unless the task requires them. It does not create a branch, commit, release, or pull request unless the user explicitly requests that action.

--- a/plugins/testing/README.md
+++ b/plugins/testing/README.md
@@ -1,22 +1,19 @@
 # DoomPi Testing Plugin
 
-This example packages focused testing and evidence-based code review for Codex, Claude Code, and
-DoomPi. The Codex and Claude Code manifests load the same skills, while hosts that support Markdown
-agents can also route work to a tester or reviewer.
+This example plugin provides focused testing and read-only code review for Codex, Claude Code, and DoomPi. Both native plugin manifests load the same skills. Hosts that support Markdown agents can also assign work to a dedicated tester or reviewer.
 
-## Components
+## What it includes
 
-- [`doompi-testing`](skills/doompi-testing/SKILL.md) designs, implements, and runs behavior-focused tests.
-- [`doompi-review`](skills/doompi-review/SKILL.md) reviews changes for concrete defects and regressions.
-- [`doompi-tester`](agents/doompi-tester.md) owns test evidence.
-- [`doompi-reviewer`](agents/doompi-reviewer.md) owns read-only code review.
+- [`doompi-testing`](skills/doompi-testing/SKILL.md) designs, adds, and runs tests for observable behavior.
+- [`doompi-review`](skills/doompi-review/SKILL.md) reviews a change for concrete defects, regressions, missing tests, and contract violations.
+- [`doompi-tester`](agents/doompi-tester.md) owns test implementation and verification evidence.
+- [`doompi-reviewer`](agents/doompi-reviewer.md) performs review without editing the change.
 
-The plugin uses the repository's existing test tools and conventions. It does not pin a model,
-language, framework, or runner.
+The plugin uses the target repository's existing tools and conventions. It does not choose a model, language, framework, or test runner.
 
-## Install directly
+## Install the plugin directly
 
-Register the repository marketplace once from the repository root, then install the plugin.
+Run these commands from the DoomPi repository root. The first command registers the repository's `doompi-examples` marketplace. The second installs `testing` from that marketplace.
 
 Codex:
 
@@ -32,15 +29,21 @@ claude plugin marketplace add ./ --scope user
 claude plugin install testing@doompi-examples --scope user
 ```
 
-## Compose with DoomPi
+The Claude Code commands register and install the plugin for the current user.
+
+## Load it with DoomPi
+
+The repository maps the `testing` domain to this plugin:
 
 ```bash
 doompi --major-mode copilot --domains testing --explain
 doompi --major-mode copilot --domains testing
 ```
 
-Try `Add focused regression coverage for this bug` for testing, or
-`Review this diff for concrete regressions` for a read-only review.
+The first command prints the resolved composition and estimated prompt cost without launching Pi. The second launches the Copilot composition with the `testing` domain.
 
-Testing may edit tests, but it does not authorize production-code changes. Review remains read-only
-unless the user separately requests a fix.
+Try `Add focused regression coverage for this bug` for test work, or `Review this diff for concrete regressions` for review.
+
+## Editing boundaries
+
+Testing may add or change tests, but it does not authorize production-code changes. Review is read-only. A separate user request must authorize a production fix or edits during review.


### PR DESCRIPTION
## Summary

- audit 63 user-facing Markdown files and rewrite 32 root, package, layer, and plugin documents
- correct CLI, synchronization, configuration, security, Runner, web cockpit, and Voice behavior claims against source and tests
- add dependency review, CodeQL, dependency audit, and registry-signature security checks while tightening release workflow setup

## Documentation changes

- align package documentation with the root README's direct, practical tone
- remove filler, repetition, brittle source line references, and em dashes
- document browser SpeechSynthesis voice selection and default fallback
- preserve normative Voice specification behavior and model provenance

## Verification

Passed:

- `pnpm examples:check`
- `pnpm lint:vibe --preflight-only`
- Oxfmt checks for all selected Markdown and changed workflow files
- relative Markdown links, code fences, table shapes, and `git diff --check`
- focused Voice, web, foundation, and plugin checks

Known failures:

- the affected Nx run reported seven package test targets unable to find the composed Doom Cordis host
- the root package run reported 562 passing tests and eight synchronized-bootstrap failures

No runtime source files changed. The failing test gates are recorded here rather than hidden.