### PR TITLE
fix(doompi-voice): stop manual recording on silence

### DIFF
--- a/packages/minor/doompi-voice/tests/manualBrowserRecorder.test.ts
+++ b/packages/minor/doompi-voice/tests/manualBrowserRecorder.test.ts
@@ -6,6 +6,7 @@ import {
   MANUAL_TRANSCRIPTION_ROUTE,
 } from '../src/types/manualTranscription.ts';
 import {
+  ManualRecordingSilenceGate,
   startManualBrowserRecording,
   type ManualBrowserRecording,
   type ManualBrowserRecordingResult,
@@ -15,7 +16,9 @@ import { transcribeManualRecording } from '../web/manualTranscriptionClient.ts';
 
 function recorderFixture() {
   const stopTrack = vi.fn();
+  const stopSilenceMonitor = vi.fn();
   let autoStop: (() => void) | undefined;
+  let silenceStop: ((speechDetected: boolean) => void) | undefined;
   const recorder = {
     mimeType: 'audio/webm;codecs=opus',
     state: 'inactive' as 'inactive' | 'recording' | 'paused',
@@ -43,8 +46,19 @@ function recorderFixture() {
     }),
     clearTimer: vi.fn((timer: ReturnType<typeof setTimeout>) => clearTimeout(timer)),
     now: vi.fn().mockReturnValueOnce(100).mockReturnValue(225),
+    watchSilence: vi.fn((_stream, onSilence: (speechDetected: boolean) => void) => {
+      silenceStop = onSilence;
+      return stopSilenceMonitor;
+    }),
   };
-  return { dependencies, recorder, stopTrack, autoStop: () => autoStop?.() };
+  return {
+    dependencies,
+    recorder,
+    stopTrack,
+    stopSilenceMonitor,
+    autoStop: () => autoStop?.(),
+    silenceStop: (speechDetected: boolean) => silenceStop?.(speechDetected),
+  };
 }
 
 function deferred<T>() {
@@ -223,6 +237,42 @@ describe('manual browser recording', () => {
     expect(fixture.stopTrack).toHaveBeenCalledOnce();
   });
 
+  it('stops after trailing silence and discards a recording that never contained speech', async () => {
+    const spoken = recorderFixture();
+    const spokenRecording = await startManualBrowserRecording(spoken.dependencies);
+
+    spoken.silenceStop(true);
+
+    await expect(spokenRecording.result).resolves.toMatchObject({ durationMs: 125 });
+    expect(spoken.recorder.stop).toHaveBeenCalledOnce();
+    expect(spoken.stopSilenceMonitor).toHaveBeenCalledOnce();
+
+    const silent = recorderFixture();
+    const silentRecording = await startManualBrowserRecording(silent.dependencies);
+
+    silent.silenceStop(false);
+
+    await expect(silentRecording.result).resolves.toBeUndefined();
+    expect(silent.recorder.stop).toHaveBeenCalledOnce();
+    expect(silent.stopSilenceMonitor).toHaveBeenCalledOnce();
+  });
+
+  it('requires sustained initial or trailing silence before stopping', () => {
+    const silence = new Float32Array(32);
+    const speech = new Float32Array(32).fill(0.1);
+    const initial = new ManualRecordingSilenceGate();
+
+    expect(initial.observe(silence, 0)).toBe(false);
+    expect(initial.observe(silence, 9_999)).toBe(false);
+    expect(initial.observe(silence, 10_000)).toBe(true);
+    expect(initial.speechDetected).toBe(false);
+
+    const trailing = new ManualRecordingSilenceGate();
+    expect(trailing.observe(speech, 0)).toBe(false);
+    expect(trailing.observe(silence, 2_999)).toBe(false);
+    expect(trailing.observe(silence, 3_000)).toBe(true);
+    expect(trailing.speechDetected).toBe(true);
+  });
   it('cancels without returning audio and lets Safari choose its native fallback format', async () => {
     const fixture = recorderFixture();
     const recording = await startManualBrowserRecording(fixture.dependencies);

--- a/packages/minor/doompi-voice/web/manualBrowserRecorder.ts
+++ b/packages/minor/doompi-voice/web/manualBrowserRecorder.ts
@@ -4,7 +4,35 @@ import {
 } from '../src/types/manualTranscription.ts';
 
 const DATA_TIMESLICE_MS = 1_000;
+const SILENCE_SAMPLE_INTERVAL_MS = 100;
+const INITIAL_SILENCE_TIMEOUT_MS = 10_000;
+const TRAILING_SILENCE_TIMEOUT_MS = 3_000;
+const SPEECH_RMS_THRESHOLD = 0.01;
 const MEDIA_TYPES = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4'] as const;
+
+/** Tracks speech and reports when initial or trailing silence should finish a manual recording. */
+export class ManualRecordingSilenceGate {
+  private startedAt: number | undefined;
+  private lastSpeechAt: number | undefined;
+
+  public get speechDetected(): boolean {
+    return this.lastSpeechAt !== undefined;
+  }
+
+  public observe(samples: Float32Array, observedAt: number): boolean {
+    this.startedAt ??= observedAt;
+    let squareSum = 0;
+    for (const sample of samples) squareSum += sample * sample;
+    const rms = samples.length === 0 ? 0 : Math.sqrt(squareSum / samples.length);
+    if (rms >= SPEECH_RMS_THRESHOLD) {
+      this.lastSpeechAt = observedAt;
+      return false;
+    }
+    const silenceStartedAt = this.lastSpeechAt ?? this.startedAt;
+    const timeout = this.speechDetected ? TRAILING_SILENCE_TIMEOUT_MS : INITIAL_SILENCE_TIMEOUT_MS;
+    return observedAt - silenceStartedAt >= timeout;
+  }
+}
 
 type RecorderState = 'inactive' | 'recording' | 'paused';
 
@@ -29,6 +57,25 @@ interface ManualRecorderDependencies {
   setTimer: (callback: () => void, delay: number) => ReturnType<typeof setTimeout>;
   clearTimer: (timer: ReturnType<typeof setTimeout>) => void;
   now: () => number;
+  watchSilence?: (stream: ManualMediaStream, onSilence: (speechDetected: boolean) => void) => () => void;
+}
+
+interface ManualAudioAnalyser {
+  fftSize: number;
+  smoothingTimeConstant: number;
+  getFloatTimeDomainData(samples: Float32Array): void;
+}
+
+interface ManualAudioSource {
+  connect(analyser: ManualAudioAnalyser): void;
+  disconnect(): void;
+}
+
+interface ManualAudioContext {
+  createMediaStreamSource(stream: ManualMediaStream): ManualAudioSource;
+  createAnalyser(): ManualAudioAnalyser;
+  resume(): Promise<void>;
+  close(): Promise<void>;
 }
 
 interface BrowserRecorderConstructor {
@@ -36,7 +83,12 @@ interface BrowserRecorderConstructor {
   isTypeSupported(type: string): boolean;
 }
 
+interface BrowserAudioContextConstructor {
+  new (): ManualAudioContext;
+}
+
 interface BrowserMediaGlobals {
+  AudioContext?: BrowserAudioContextConstructor;
   MediaRecorder?: BrowserRecorderConstructor;
   navigator?: { mediaDevices?: { getUserMedia(options: { audio: boolean }): Promise<ManualMediaStream> } };
 }
@@ -50,6 +102,39 @@ export interface ManualBrowserRecording {
   readonly result: Promise<ManualBrowserRecordingResult | undefined>;
   stop(): void;
   cancel(): void;
+}
+
+function watchBrowserSilence(stream: ManualMediaStream, onSilence: (speechDetected: boolean) => void): () => void {
+  const AudioContextConstructor = (globalThis as unknown as BrowserMediaGlobals).AudioContext;
+  if (AudioContextConstructor === undefined) return () => undefined;
+  let context: ManualAudioContext | undefined;
+  let source: ManualAudioSource | undefined;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  try {
+    context = new AudioContextConstructor();
+    source = context.createMediaStreamSource(stream);
+    const analyser = context.createAnalyser();
+    analyser.fftSize = 2_048;
+    analyser.smoothingTimeConstant = 0.2;
+    source.connect(analyser);
+    const samples = new Float32Array(analyser.fftSize);
+    const gate = new ManualRecordingSilenceGate();
+    timer = setInterval(() => {
+      analyser.getFloatTimeDomainData(samples);
+      if (!gate.observe(samples, Date.now())) return;
+      onSilence(gate.speechDetected);
+    }, SILENCE_SAMPLE_INTERVAL_MS);
+    void context.resume().catch(() => undefined);
+  } catch {
+    source?.disconnect();
+    void context?.close().catch(() => undefined);
+    return () => undefined;
+  }
+  return () => {
+    if (timer !== undefined) clearInterval(timer);
+    source?.disconnect();
+    void context?.close().catch(() => undefined);
+  };
 }
 
 function browserDependencies(): ManualRecorderDependencies {
@@ -66,6 +151,7 @@ function browserDependencies(): ManualRecorderDependencies {
     setTimer: (callback, delay) => setTimeout(callback, delay),
     clearTimer: (timer) => clearTimeout(timer),
     now: () => Date.now(),
+    watchSilence: watchBrowserSilence,
   };
 }
 
@@ -90,6 +176,7 @@ export async function startManualBrowserRecording(
   let cancelled = false;
   let stopping = false;
   let startedAt = 0;
+  let stopSilenceMonitor = (): void => undefined;
   let resolveResult: (result: ManualBrowserRecordingResult | undefined) => void = () => undefined;
   let rejectResult: (error: Error) => void = () => undefined;
   const result = new Promise<ManualBrowserRecordingResult | undefined>((resolve, reject) => {
@@ -98,6 +185,7 @@ export async function startManualBrowserRecording(
   });
   const cleanup = (): void => {
     dependencies.clearTimer(timer);
+    stopSilenceMonitor();
     recorder.ondataavailable = null;
     recorder.onerror = null;
     recorder.onstop = null;
@@ -155,6 +243,14 @@ export async function startManualBrowserRecording(
   try {
     startedAt = dependencies.now();
     recorder.start(DATA_TIMESLICE_MS);
+    const stopWatching = dependencies.watchSilence?.(stream, (speechDetected) => {
+      if (!speechDetected) cancelled = true;
+      stopRecorder();
+    });
+    if (stopWatching !== undefined) {
+      stopSilenceMonitor = stopWatching;
+      if (finished) stopSilenceMonitor();
+    }
   } catch (error) {
     settle(undefined, error instanceof Error ? error : new Error('Browser audio recording failed.'));
     await result;


### PR DESCRIPTION
## Summary

- stop manual recording after sustained trailing silence
- discard recordings that contain no detected speech
- keep the existing hard duration and upload limits

## Verification

- `pnpm --filter @agimon-ai/doompi-voice exec vitest --run tests/manualBrowserRecorder.test.ts --coverage.enabled=false`
- `pnpm lint:vibe --preflight-only`
- `pnpm nx run-many -t lint,typecheck,build,test -p @agimon-ai/doompi-voice --parallel=1`