### PR TITLE
fix(doompi-server): bundle patched Pi protocol

### DIFF
--- a/packages/clients/doompi-server/tests/contract/packageShape.test.ts
+++ b/packages/clients/doompi-server/tests/contract/packageShape.test.ts
@@ -81,6 +81,17 @@ describe('doompi-server package contract', () => {
     }
   });
 
+  it('bundles the patched Pi protocol runtime into published artifacts', async () => {
+    const [buildConfig, protocolPatch] = await Promise.all([
+      readFile(path.join(packageDirectory, 'tsdown.config.ts'), 'utf8'),
+      readFile(path.resolve(packageDirectory, '../../../patches/@earendil-works__pi-protocol@0.84.4.patch'), 'utf8'),
+    ]);
+
+    expect(buildConfig).toContain('unbundle: false');
+    expect(buildConfig).toContain('alwaysBundle: [/^@earendil-works\\/pi-(?:protocol|server)(?:\\/|$)/u]');
+    expect(protocolPatch).toContain('Check(ServerMessageContext, ServerMessageSchema, value)');
+  });
+
   it('pins matching Pi peer and development versions', async () => {
     const manifest = await readManifest();
 

--- a/packages/clients/doompi-server/tsdown.config.ts
+++ b/packages/clients/doompi-server/tsdown.config.ts
@@ -19,5 +19,10 @@ export default defineConfig({
   },
   platform: 'node',
   sourcemap: true,
-  unbundle: true,
+  deps: {
+    // Pi Server invokes Pi Protocol's hot-path validators. Bundle both so the
+    // published executable retains our patched protocol codec.
+    alwaysBundle: [/^@earendil-works\/pi-(?:protocol|server)(?:\/|$)/u],
+  },
+  unbundle: false,
 });


### PR DESCRIPTION
## What this changes

Bundles `@earendil-works/pi-server` and the patched `@earendil-works/pi-protocol` into `@agimon-ai/doompi-server` distribution artifacts. Adds a package contract test that keeps the patched runtime bundling configuration tied to the workspace patch.

## Why

Workspace installs apply the Pi Protocol performance patch through pnpm, but npm consumers previously loaded an external, unpatched protocol dependency because the server build was unbundled. Published installs now execute the patched validator path.

## Checks

- [x] `pnpm lint:vibe --preflight-only`
- [x] Affected Nx targets pass: `lint`, `typecheck`, `build`, `test`
- [x] `pnpm fmt:check`
- [x] Packed-install system tests: `pnpm nx run-many -t test-system --parallel=1`

Docker reproduced `.github/actions/setup-monorepo` with Node 22.22.1 and pnpm 11.1.3, then ran the CI quality and installed-runtime commands. One scripted-agent RPC case timed out with empty stderr during the cold packed-install run. Its focused retry passed both tests in the file. The other 344 packed-install tests passed in the original run.

## Scope

- [x] Package boundaries are respected (`packages/core`, `packages/default`, `packages/minor`, `packages/clients`, `layers/`, `packages/tooling`)
- [x] Doom-to-Doom dependencies stay `workspace:*`
- [x] Package exports, Pi entries, resources, runtime ordering, and RMUX LFS payloads are preserved
- [x] No unrelated changes bundled in

## Risk

The server distribution now owns the bundled Pi Server and Pi Protocol runtime for this path. The versions remain pinned, and a contract test guards inclusion of the patched codec.
