### PR TITLE
feat(root): improve session voice queue and agent catalogs

### DIFF
--- a/layers/team/doompi-team/package.json
+++ b/layers/team/doompi-team/package.json
@@ -108,6 +108,13 @@
   "engines": {
     "node": ">=22.19.0"
   },
+  "doompiApi": {
+    "basePath": "team",
+    "session": {
+      "entry": "./src/exports/sessionApi.ts",
+      "dist": "./dist/sessionApi.mjs"
+    }
+  },
   "doompiWeb": {
     "pluginId": "subagents",
     "channels": [

--- a/layers/team/doompi-team/src/adapters/teamCatalogApi.ts
+++ b/layers/team/doompi-team/src/adapters/teamCatalogApi.ts
@@ -1,0 +1,51 @@
+import type { DoomApi, DoomApiHandler } from '@agimon-ai/doompi-extension-contracts/package-api';
+import type { CatalogAgentInput } from '../services/webSubagentCatalog.ts';
+import { AgentDiscoveryService, resolveActiveTeamModelSpecs } from './agents/discovery.ts';
+
+export const TEAM_API_BASE_PATH = 'team';
+export const TEAM_CATALOG_ROUTE = '/catalog';
+
+export interface TeamCatalogSnapshot {
+  agents: CatalogAgentInput[];
+  models: string[];
+}
+
+export interface TeamCatalogApiOptions {
+  cwd: string;
+  read?: (cwd: string) => TeamCatalogSnapshot;
+}
+
+/** Serves catalog discovery from the session process, which owns the active domain environment. */
+export function createTeamCatalogApi(options: TeamCatalogApiOptions): DoomApiHandler {
+  const discovery = new AgentDiscoveryService();
+  const read =
+    options.read ??
+    ((cwd: string): TeamCatalogSnapshot => ({
+      agents: discovery.discover(cwd, 'both').agents,
+      models: resolveActiveTeamModelSpecs() ?? [],
+    }));
+
+  return {
+    fetch(request) {
+      const url = new URL(request.url);
+      if (request.method !== 'GET' || url.pathname !== TEAM_CATALOG_ROUTE) {
+        return Response.json({ error: 'Not found.' }, { status: 404 });
+      }
+      try {
+        return Response.json(read(options.cwd));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return Response.json({ error: message }, { status: 500 });
+      }
+    },
+    close: () => undefined,
+  };
+}
+
+/** Session package API entry loaded by doompi-server. */
+export const api: DoomApi = {
+  basePath: TEAM_API_BASE_PATH,
+  start(context) {
+    return createTeamCatalogApi({ cwd: context.cwd ?? process.cwd() });
+  },
+};

--- a/layers/team/doompi-team/src/adapters/webSubagentCatalogChannel.ts
+++ b/layers/team/doompi-team/src/adapters/webSubagentCatalogChannel.ts
@@ -1,83 +1,140 @@
-import type { HubChannelSource, HubSessionScope, WebHubChannel } from '@agimon-ai/doompi-web-contracts';
+import type { HubChannelHost, HubChannelSource, HubSessionScope, WebHubChannel } from '@agimon-ai/doompi-web-contracts';
 import { type CatalogAgentInput, catalogModels, presentCatalog } from '../services/webSubagentCatalog.ts';
 import { SUBAGENT_CATALOG_TYPE, type SubagentCatalogPayload } from '../types/webSubagents.ts';
 import { AgentDiscoveryService, resolveActiveTeamModelSpecs } from './agents/discovery.ts';
+import { TEAM_API_BASE_PATH, TEAM_CATALOG_ROUTE, type TeamCatalogSnapshot } from './teamCatalogApi.ts';
 
 /** Agent files change rarely; discovery's own cache makes each look cheap. */
 const CATALOG_REFRESH_MS = 15_000;
 
-/** Reads the launchable agents for one directory; injectable so a test needs no agent files on disk. */
-export type CatalogReader = (cwd: string) => { agents: CatalogAgentInput[]; models: string[] };
+/** Injectable catalog read for tests and alternate hosts. Production reads through the session API. */
+export type CatalogReader = (cwd: string) => TeamCatalogSnapshot | Promise<TeamCatalogSnapshot>;
 
-export function defaultCatalogReader(): CatalogReader {
-  const discovery = new AgentDiscoveryService();
-  return (cwd) => ({
-    agents: discovery.discover(cwd, 'both').agents,
-    models: resolveActiveTeamModelSpecs() ?? [],
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseCatalogSnapshot(value: unknown): TeamCatalogSnapshot {
+  if (
+    !isRecord(value) ||
+    !Array.isArray(value.agents) ||
+    !value.agents.every(isRecord) ||
+    !Array.isArray(value.models)
+  ) {
+    throw new Error('Session catalog API returned an invalid payload.');
+  }
+  return {
+    agents: value.agents as unknown as CatalogAgentInput[],
+    models: value.models.filter((model): model is string => typeof model === 'string'),
+  };
+}
+
+async function readSessionCatalog(
+  host: HubChannelHost,
+  scope: HubSessionScope,
+  signal: AbortSignal,
+  fallback: CatalogReader,
+): Promise<TeamCatalogSnapshot> {
+  const response = await host.requestSessionApi(scope, {
+    basePath: TEAM_API_BASE_PATH,
+    path: TEAM_CATALOG_ROUTE,
+    method: 'GET',
+    signal,
   });
+  if (response.status === 404) return await fallback(scope.cwd);
+  const payload: unknown = await response.json();
+  if (!response.ok) {
+    const reason =
+      isRecord(payload) && typeof payload.error === 'string' ? payload.error : `HTTP ${String(response.status)}`;
+    throw new Error(`Session catalog API failed: ${reason}`);
+  }
+  return parseCatalogSnapshot(payload);
 }
 
 /**
- * The subagent catalog data channel: what each managed session's directory
- * can launch, published as 'subagent_catalog' payloads. Discovery runs once
- * per session on arrival, again at every subscribe, and on a slow tick so an
- * agent file written while the page is open shows up without a reload. A
- * failed read publishes an empty list with the reason rather than nothing.
+ * The subagent catalog data channel: what each managed session can launch.
+ *
+ * Discovery runs inside the session API because that process owns the active
+ * domain projection and its plugin agent directories. The hub refreshes and
+ * publishes that result, with local discovery only for older sessions lacking
+ * the API route.
  */
-export function createSubagentCatalogChannel(
-  read: CatalogReader = defaultCatalogReader(),
-  refreshMs = CATALOG_REFRESH_MS,
-): WebHubChannel {
+export function createSubagentCatalogChannel(read?: CatalogReader, refreshMs = CATALOG_REFRESH_MS): WebHubChannel {
   return {
     frameType: SUBAGENT_CATALOG_TYPE,
     start(host) {
       const scopes = new Map<string, HubSessionScope>();
-      const latest = new Map<string, string>();
+      const latestJson = new Map<string, string>();
+      const latestPayload = new Map<string, SubagentCatalogPayload>();
+      const generations = new Map<string, number>();
+      const abort = new AbortController();
+      const fallbackDiscovery = new AgentDiscoveryService();
+      const fallback: CatalogReader = (cwd) => ({
+        agents: fallbackDiscovery.discover(cwd, 'both').agents,
+        models: resolveActiveTeamModelSpecs() ?? [],
+      });
+      let closed = false;
 
-      const compute = (scope: HubSessionScope): SubagentCatalogPayload => {
-        try {
-          const { agents, models } = read(scope.cwd);
-          return { cwd: scope.cwd, agents: presentCatalog(agents), models: catalogModels(agents, models) };
-        } catch (error) {
-          const warning = error instanceof Error ? error.message : String(error);
-          return { cwd: scope.cwd, agents: [], models: [], warning };
-        }
-      };
-
-      /** Recomputes and remembers; publishes only what changed, so the tick stays quiet. */
-      const refresh = (scope: HubSessionScope, publish: boolean): SubagentCatalogPayload => {
-        const payload = compute(scope);
+      const commit = (scope: HubSessionScope, generation: number, payload: SubagentCatalogPayload): void => {
+        const active = scopes.get(scope.sessionId);
+        if (closed || active?.cwd !== scope.cwd || generations.get(scope.sessionId) !== generation) return;
         const json = JSON.stringify(payload);
-        if (latest.get(scope.sessionId) === json) return payload;
-        latest.set(scope.sessionId, json);
+        if (latestJson.get(scope.sessionId) === json) return;
+        latestJson.set(scope.sessionId, json);
+        latestPayload.set(scope.sessionId, payload);
         if (payload.warning !== undefined) {
           host.onNotice(`subagent catalog for ${scope.cwd} is unavailable (${payload.warning})`);
         }
-        if (publish) host.publish(scope.sessionId, payload);
-        return payload;
+        host.publish(scope.sessionId, payload);
+      };
+
+      const refresh = async (scope: HubSessionScope): Promise<void> => {
+        const generation = (generations.get(scope.sessionId) ?? 0) + 1;
+        generations.set(scope.sessionId, generation);
+        try {
+          const snapshot = await (read === undefined
+            ? readSessionCatalog(host, scope, abort.signal, fallback)
+            : read(scope.cwd));
+          commit(scope, generation, {
+            cwd: scope.cwd,
+            agents: presentCatalog(snapshot.agents),
+            models: catalogModels(snapshot.agents, snapshot.models),
+          });
+        } catch (error) {
+          if (closed || abort.signal.aborted) return;
+          const warning = error instanceof Error ? error.message : String(error);
+          commit(scope, generation, { cwd: scope.cwd, agents: [], models: [], warning });
+        }
       };
 
       const timer = setInterval(() => {
-        for (const scope of scopes.values()) refresh(scope, true);
+        for (const scope of scopes.values()) void refresh(scope);
       }, refreshMs);
 
       const source: HubChannelSource = {
         payloadFor(scope) {
-          // The snapshot travels on its own, so a fresh read is remembered but not also published.
-          return scopes.has(scope.sessionId) ? refresh(scope, false) : undefined;
+          if (!scopes.has(scope.sessionId)) return undefined;
+          void refresh(scope);
+          return latestPayload.get(scope.sessionId);
         },
         sessionAdded(scope) {
           scopes.set(scope.sessionId, scope);
-          refresh(scope, true);
+          void refresh(scope);
         },
         sessionRemoved(sessionId) {
           scopes.delete(sessionId);
-          latest.delete(sessionId);
+          latestJson.delete(sessionId);
+          latestPayload.delete(sessionId);
+          generations.delete(sessionId);
         },
         close() {
+          closed = true;
+          abort.abort();
           clearInterval(timer);
           scopes.clear();
-          latest.clear();
+          latestJson.clear();
+          latestPayload.clear();
+          generations.clear();
         },
       };
       return source;

--- a/layers/team/doompi-team/src/exports/sessionApi.ts
+++ b/layers/team/doompi-team/src/exports/sessionApi.ts
@@ -1,0 +1,8 @@
+export {
+  api,
+  createTeamCatalogApi,
+  TEAM_API_BASE_PATH,
+  TEAM_CATALOG_ROUTE,
+  type TeamCatalogApiOptions,
+  type TeamCatalogSnapshot,
+} from '../adapters/teamCatalogApi.ts';

--- a/layers/team/doompi-team/tests/unit/teamCatalogApi.test.ts
+++ b/layers/team/doompi-team/tests/unit/teamCatalogApi.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTeamCatalogApi } from '../../src/adapters/teamCatalogApi.ts';
+
+const pluginAgent = {
+  name: 'plugins.reviewer',
+  source: 'plugin' as const,
+  description: 'Reviews changes.',
+  filePath: '/projection/agents/reviewer.md',
+};
+
+describe('the Team session catalog API', () => {
+  it('discovers from the session cwd and returns plugin agents', async () => {
+    const read = vi.fn(() => ({ agents: [pluginAgent], models: ['team/model'] }));
+    const api = createTeamCatalogApi({ cwd: '/workspace/project', read });
+
+    const response = await api.fetch(new Request('http://session/catalog'));
+
+    expect(response.status).toBe(200);
+    expect(read).toHaveBeenCalledWith('/workspace/project');
+    await expect(response.json()).resolves.toEqual({ agents: [pluginAgent], models: ['team/model'] });
+  });
+
+  it('keeps discovery failures visible to the hub', async () => {
+    const api = createTeamCatalogApi({
+      cwd: '/workspace/project',
+      read: () => {
+        throw new Error('bad projected agent');
+      },
+    });
+
+    const response = await api.fetch(new Request('http://session/catalog'));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: 'bad projected agent' });
+  });
+});

--- a/layers/team/doompi-team/tests/unit/webSubagentCatalogChannel.test.ts
+++ b/layers/team/doompi-team/tests/unit/webSubagentCatalogChannel.test.ts
@@ -57,6 +57,7 @@ describe('the subagent catalog hub channel', () => {
     expect(channel.frameType).toBe('subagent_catalog');
 
     source.sessionAdded?.({ sessionId: 's1', cwd: '/w' });
+    await waitFor(() => host.published.length === 1, 'the arrival catalog');
     expect(host.published).toHaveLength(1);
     expect(host.published[0]).toMatchObject({ sessionId: 's1', payload: { cwd: '/w', models: ['t1'] } });
     expect(host.published[0]?.payload.agents.map((row) => row.name)).toEqual(['reviewer']);
@@ -77,7 +78,7 @@ describe('the subagent catalog hub channel', () => {
     expect(source.payloadFor({ sessionId: 's1', cwd: '/w' })).toBeUndefined();
   });
 
-  it('publishes an empty catalog with the reason when discovery fails, noticing once', () => {
+  it('publishes an empty catalog with the reason when discovery fails, noticing once', async () => {
     const host = fakeHost();
     const channel = createSubagentCatalogChannel(() => {
       throw new Error('bad frontmatter');
@@ -86,9 +87,31 @@ describe('the subagent catalog hub channel', () => {
     cleanups.push(() => source.close());
 
     source.sessionAdded?.({ sessionId: 's1', cwd: '/w' });
+    await waitFor(() => host.published.length === 1, 'the failed catalog');
     expect(host.published[0]?.payload).toEqual({ cwd: '/w', agents: [], models: [], warning: 'bad frontmatter' });
     expect(host.notices).toHaveLength(1);
     source.payloadFor({ sessionId: 's1', cwd: '/w' });
+    await sleep(0);
     expect(host.notices).toHaveLength(1);
+  });
+
+  it('reads plugin agents from the session API that owns the active domains', async () => {
+    const host = fakeHost();
+    host.requestSessionApi = async (scope, request) => {
+      expect(scope).toEqual({ sessionId: 's1', cwd: '/w' });
+      expect(request).toMatchObject({ basePath: 'team', path: '/catalog', method: 'GET' });
+      return Response.json({ agents: [agent('plugins.reviewer', 'plugin')], models: ['team/model'] });
+    };
+    const source = createSubagentCatalogChannel(undefined, 1_000_000).start(host);
+    cleanups.push(() => source.close());
+
+    source.sessionAdded?.({ sessionId: 's1', cwd: '/w' });
+    await waitFor(() => host.published.length === 1, 'the session API catalog');
+
+    expect(host.published[0]?.payload).toMatchObject({
+      cwd: '/w',
+      agents: [{ name: 'plugins.reviewer', source: 'plugin' }],
+      models: ['team/model'],
+    });
   });
 });

--- a/packages/clients/doompi-web/src/web/features/session/Composer.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/Composer.tsx
@@ -28,6 +28,7 @@ import {
 import {
   abortRun,
   clearQueuedMessages,
+  deleteQueuedMessage,
   queueFollowUp,
   submitMessage,
   useActiveSession,
@@ -425,7 +426,12 @@ export function Composer() {
   if (prompt !== null) {
     return (
       <div className="shrink-0 border-t border-doom-border bg-doom-rail px-3 pt-3 pb-2.5 sm:px-5">
-        <QueueSheet count={queued} entries={queuedEntries} onClear={() => clearQueuedMessages(sessionId)} />
+        <QueueSheet
+          count={queued}
+          entries={queuedEntries}
+          onClear={() => clearQueuedMessages(sessionId)}
+          onDelete={(id) => deleteQueuedMessage(id, queued, sessionId)}
+        />
         <div className="rounded-lg border border-doom-edge-magenta bg-doom-deep">
           <ComposerPrompt claim={prompt} sessionId={sessionId} />
         </div>
@@ -435,7 +441,12 @@ export function Composer() {
 
   return (
     <div className="shrink-0 border-t border-doom-border bg-doom-rail px-3 pt-3 pb-2.5 sm:px-5">
-      <QueueSheet count={queued} entries={queuedEntries} onClear={() => clearQueuedMessages(sessionId)} />
+      <QueueSheet
+        count={queued}
+        entries={queuedEntries}
+        onClear={() => clearQueuedMessages(sessionId)}
+        onDelete={(id) => deleteQueuedMessage(id, queued, sessionId)}
+      />
       <Popover
         open={completion !== null}
         onOpenChange={(next) => {

--- a/packages/clients/doompi-web/src/web/features/session/QueueSheet.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/QueueSheet.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
   RefreshIcon,
+  TrashIcon,
 } from '@agimon-ai/doompi-web-components';
 import { useState } from 'react';
 import type { QueuedEntry } from '../../lib/sessionModel.ts';
@@ -15,10 +16,12 @@ export function QueueSheet({
   count,
   entries,
   onClear,
+  onDelete,
 }: {
   count: number;
   entries: readonly QueuedEntry[];
   onClear: () => void;
+  onDelete: (id: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const unlisted = Math.max(0, count - entries.length);
@@ -81,6 +84,20 @@ export function QueueSheet({
                       </p>
                     ) : null}
                   </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    data-testid={`queue-delete-${String(index)}`}
+                    aria-label={`delete queued message ${String(index + 1)}`}
+                    title={
+                      unlisted > 0 ? 'Wait for the complete queue before deleting one message' : 'Delete this message'
+                    }
+                    disabled={unlisted > 0}
+                    onClick={() => onDelete(entry.id)}
+                    className="h-7 w-7 shrink-0 text-doom-faint hover:text-doom-red"
+                  >
+                    <TrashIcon className="h-3.5 w-3.5" />
+                  </Button>
                 </li>
               ))}
               {unlisted > 0 ? (

--- a/packages/clients/doompi-web/src/web/features/session/Timeline.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/Timeline.tsx
@@ -11,6 +11,7 @@ import { useStore } from '@tanstack/react-store';
 import type { Store } from '@tanstack/store';
 import { useActivityGroups } from '../../lib/composition.ts';
 import { parseFileMentions } from '../../lib/fileMentions.ts';
+import { pluginToolRenderer } from '../../lib/pluginRegistry.ts';
 import { isSupportedImageMimeType, type SessionState, type TimelineEntry } from '../../lib/sessionModel.ts';
 import {
   requestOlderHistory,
@@ -64,6 +65,28 @@ function Gutter({ label, tone, trailing = false }: { label: string; tone: string
   return <span className={`shrink-0 text-[10px] font-bold ${placement} ${tone}`}>{label}</span>;
 }
 
+function ToolEntryRow({
+  entry,
+  sessionId,
+}: {
+  entry: Extract<TimelineEntry, { kind: 'tool' }>;
+  sessionId: string | null;
+}) {
+  const statuses = useActiveSession((state) => state.statuses);
+  const presentation = pluginToolRenderer(entry.name, statuses)?.timelinePresentation ?? 'tool';
+  return (
+    <div
+      data-testid="entry-tool-row"
+      data-tool-presentation={presentation}
+      className="flex flex-col gap-1 sm:flex-row sm:gap-3"
+    >
+      {presentation === 'tool' ? <Gutter label="tool" tone="text-doom-faint" /> : null}
+      <div className="min-w-0 flex-1">
+        <ToolCard entry={entry} sessionId={sessionId} />
+      </div>
+    </div>
+  );
+}
 const Entry = memo(function Entry({ entry, sessionId }: { entry: TimelineEntry; sessionId: string | null }) {
   if (entry.kind === 'user') {
     return (
@@ -131,16 +154,7 @@ const Entry = memo(function Entry({ entry, sessionId }: { entry: TimelineEntry; 
     );
   }
 
-  if (entry.kind === 'tool') {
-    return (
-      <div className="flex flex-col gap-1 sm:flex-row sm:gap-3">
-        <Gutter label="tool" tone="text-doom-faint" />
-        <div className="min-w-0 flex-1">
-          <ToolCard entry={entry} sessionId={sessionId} />
-        </div>
-      </div>
-    );
-  }
+  if (entry.kind === 'tool') return <ToolEntryRow entry={entry} sessionId={sessionId} />;
 
   if (entry.kind === 'settled') {
     return (

--- a/packages/clients/doompi-web/src/web/lib/protocolTimeline.ts
+++ b/packages/clients/doompi-web/src/web/lib/protocolTimeline.ts
@@ -85,7 +85,7 @@ export function toTimelineEntries(transcript: readonly TranscriptItem[]): Timeli
   return transcript.map(timelineEntry);
 }
 
-/** Projects the protocol's authoritative pending input queue onto composer rows. */
+/** Projects the protocol's authoritative pending steer queue onto composer rows. */
 export function toQueuedEntries(queue: readonly UserTranscriptItem[]): QueuedEntry[] {
-  return queue.map((item) => ({ ...userEntry(item), kind: 'queued' }));
+  return queue.map((item) => ({ ...userEntry(item), kind: 'queued', delivery: 'steer' }));
 }

--- a/packages/clients/doompi-web/src/web/lib/sessionModel.ts
+++ b/packages/clients/doompi-web/src/web/lib/sessionModel.ts
@@ -56,6 +56,8 @@ export interface QueuedEntry {
   kind: 'queued';
   id: string;
   text: string;
+  /** How Pi must receive this entry when the browser rebuilds the queue after deleting one item. */
+  delivery?: 'steer' | 'followUp';
   images?: UserImage[];
 }
 
@@ -709,8 +711,11 @@ export function reduceSession(state: SessionState, frame: Frame, options: Reduce
     case 'queue_update': {
       const steering = Array.isArray(frame.steering) ? frame.steering : [];
       const followUp = Array.isArray(frame.followUp) ? frame.followUp : [];
-      const queue = [...steering, ...followUp]
-        .map((entry, index) => ({ kind: 'queued' as const, id: `queue-${index}`, text: asString(entry) }))
+      const queue = [
+        ...steering.map((entry) => ({ text: asString(entry), delivery: 'steer' as const })),
+        ...followUp.map((entry) => ({ text: asString(entry), delivery: 'followUp' as const })),
+      ]
+        .map((entry, index) => ({ kind: 'queued' as const, id: `queue-${index}`, ...entry }))
         .filter((entry) => entry.text.length > 0);
       return replaceQueuedEntries(state, queue);
     }
@@ -779,7 +784,13 @@ export function appendUserPrompt(state: SessionState, text: string, images: User
 /** A follow-up waits for the current run, so it is marked rather than shown as sent. */
 export function appendQueued(state: SessionState, text: string, images: UserImage[] = []): SessionState {
   const id = `q${state.nextId}`;
-  const entry: QueuedEntry = { kind: 'queued', id, text, ...(images.length > 0 ? { images } : {}) };
+  const entry: QueuedEntry = {
+    kind: 'queued',
+    id,
+    text,
+    delivery: 'followUp',
+    ...(images.length > 0 ? { images } : {}),
+  };
   return withPendingUser(withEntry(state, entry), id, text, images);
 }
 
@@ -792,7 +803,12 @@ export function replaceQueuedEntries(state: SessionState, queue: readonly Queued
     const [existing] = remaining.splice(existingIndex, 1);
     return existing === undefined
       ? entry
-      : { ...entry, id: existing.id, ...(existing.images ? { images: existing.images } : {}) };
+      : {
+          ...entry,
+          id: existing.id,
+          ...(entry.delivery === undefined && existing.delivery !== undefined ? { delivery: existing.delivery } : {}),
+          ...(existing.images ? { images: existing.images } : {}),
+        };
   });
   const pendingUserEntries = [...state.pendingUserEntries];
   for (const entry of normalized) {
@@ -817,6 +833,14 @@ export function clearQueuedEntries(state: SessionState): SessionState {
   };
 }
 
+/** Removes one queued row and the optimistic reconciliation record tied to it. */
+export function removeQueuedEntry(state: SessionState, id: string): SessionState {
+  return {
+    ...state,
+    entries: state.entries.filter((entry) => entry.kind !== 'queued' || entry.id !== id),
+    pendingUserEntries: state.pendingUserEntries.filter((entry) => entry.id !== id),
+  };
+}
 export function clearDialog(state: SessionState): SessionState {
   return { ...state, dialog: null };
 }

--- a/packages/clients/doompi-web/src/web/stores/sessionStore.ts
+++ b/packages/clients/doompi-web/src/web/stores/sessionStore.ts
@@ -30,6 +30,7 @@ import {
   prependHistory,
   reduceSession,
   replaceQueuedEntries,
+  removeQueuedEntry,
   type QueuedEntry,
   type SessionState,
   type TimelineEntry,
@@ -386,6 +387,34 @@ export function clearQueuedMessages(sessionId: string | null = activeSessionId()
   if (sessionId === null) return;
   sessionStoreFor(sessionId).setState(clearQueuedEntries);
   sendFrame(sessionId, clearQueueCommand());
+}
+
+/**
+ * Deletes one queued message through Pi's clear-only RPC queue contract.
+ *
+ * Clearing and replaying is safe only with a complete browser snapshot. The UI
+ * passes the authoritative count and disables this action while any rows are
+ * unlisted, so an unseen message is never lost during reconstruction.
+ */
+export function deleteQueuedMessage(
+  id: string,
+  knownQueueCount: number,
+  sessionId: string | null = activeSessionId(),
+): void {
+  if (sessionId === null) return;
+  const store = sessionStoreFor(sessionId);
+  const queued = store.state.entries.filter((entry): entry is QueuedEntry => entry.kind === 'queued');
+  if (queued.length !== knownQueueCount || !queued.some((entry) => entry.id === id)) return;
+  const remaining = queued.filter((entry) => entry.id !== id);
+  store.setState((state) => removeQueuedEntry(state, id));
+  sendFrame(sessionId, clearQueueCommand());
+  for (const entry of remaining) {
+    const images: RpcImage[] = (entry.images ?? []).map((image) => ({ type: 'image', ...image }));
+    sendFrame(
+      sessionId,
+      entry.delivery === 'steer' ? steerCommand(entry.text, images) : followUpCommand(entry.text, images),
+    );
+  }
 }
 
 /**

--- a/packages/clients/doompi-web/tests/e2e/states.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/states.spec.ts
@@ -32,7 +32,7 @@ test('views queued follow-ups and can delete the queue', async ({ page, cockpit 
   await cockpit.session.waitForCommand('follow_up');
   await page.getByTestId('composer-input').fill('then report the bundle size');
   await page.getByTestId('composer-queue').click();
-  await cockpit.session.waitForCommand('follow_up');
+  await expect.poll(() => cockpit.session.received.filter((frame) => frame.type === 'follow_up').length).toBe(2);
 
   await expect(page.getByTestId('entry-queued')).toHaveCount(0);
   await expect(page.getByTestId('composer-queued')).toContainText('2 queued messages');
@@ -43,8 +43,16 @@ test('views queued follow-ups and can delete the queue', async ({ page, cockpit 
   await expect(page.getByTestId('queue-sheet')).toContainText('then run the packed-install gate');
   await expect(page.getByTestId('queue-sheet')).toContainText('then report the bundle size');
 
-  await page.getByTestId('queue-clear').click();
+  await page.getByTestId('queue-delete-0').click();
   await cockpit.session.waitForCommand('clear_queue');
+  await expect
+    .poll(() => cockpit.session.received.filter((frame) => frame.type === 'follow_up').at(-1)?.message)
+    .toBe('then report the bundle size');
+  await expect(page.getByTestId('queue-sheet-item')).toHaveCount(1);
+  await expect(page.getByTestId('queue-sheet')).not.toContainText('then run the packed-install gate');
+  await expect(page.getByTestId('queue-sheet')).toContainText('then report the bundle size');
+  await page.getByTestId('queue-clear').click();
+  await expect.poll(() => cockpit.session.received.filter((frame) => frame.type === 'clear_queue').length).toBe(2);
   await expect(page.getByTestId('queue-sheet')).toBeHidden();
   await expect(page.getByTestId('composer-queued')).toBeHidden();
 });

--- a/packages/clients/doompi-web/tests/unit/clientStores.test.ts
+++ b/packages/clients/doompi-web/tests/unit/clientStores.test.ts
@@ -59,6 +59,7 @@ import {
   applySessionFrame,
   cancelDialog,
   clearQueuedMessages,
+  deleteQueuedMessage,
   dropSessionStore,
   loadModelChoices,
   queueFollowUp,
@@ -615,8 +616,8 @@ describe('session actions', () => {
   it('replaces local queue rows from legacy and protocol snapshots', () => {
     applySessionFrame('s1', { type: 'queue_update', steering: ['interrupt'], followUp: ['later'] });
     expect(sessionStoreFor('s1').state.entries).toMatchObject([
-      { kind: 'queued', text: 'interrupt' },
-      { kind: 'queued', text: 'later' },
+      { kind: 'queued', text: 'interrupt', delivery: 'steer' },
+      { kind: 'queued', text: 'later', delivery: 'followUp' },
     ]);
 
     applyProtocolQueue('s1', [{ kind: 'queued', id: 'server-q1', text: 'after that' }]);
@@ -634,6 +635,30 @@ describe('session actions', () => {
 
     expect(sessionStoreFor('s1').state.entries.filter((entry) => entry.kind === 'queued')).toEqual([]);
     expect(sent.map((item) => item.frame)).toEqual([{ type: 'follow_up', message: 'later' }, { type: 'clear_queue' }]);
+  });
+
+  it('deletes one known queue row and restores the others through Pi clear_queue', () => {
+    setActiveSession('s1');
+    const images = [{ type: 'image' as const, data: 'aGVsbG8=', mimeType: 'image/png' }];
+    queueFollowUp('first');
+    queueFollowUp('second', images);
+    const queued = sessionStoreFor('s1').state.entries.filter((entry) => entry.kind === 'queued');
+    const first = queued[0];
+    if (first === undefined) throw new Error('Expected the first queued entry.');
+
+    deleteQueuedMessage(first.id, 3);
+    expect(sent).toHaveLength(2);
+    deleteQueuedMessage(first.id, 2);
+
+    expect(sessionStoreFor('s1').state.entries.filter((entry) => entry.kind === 'queued')).toMatchObject([
+      { text: 'second', delivery: 'followUp', images: [{ data: 'aGVsbG8=', mimeType: 'image/png' }] },
+    ]);
+    expect(sent.map((item) => item.frame)).toEqual([
+      { type: 'follow_up', message: 'first' },
+      { type: 'follow_up', message: 'second', images },
+      { type: 'clear_queue' },
+      { type: 'follow_up', message: 'second', images },
+    ]);
   });
 
   it('ask for every fact the rail shows', () => {

--- a/packages/clients/doompi-web/tests/unit/protocolTimeline.test.ts
+++ b/packages/clients/doompi-web/tests/unit/protocolTimeline.test.ts
@@ -185,6 +185,7 @@ describe('protocol transcript projection', () => {
         kind: 'queued',
         id: 'queued-1',
         text: 'run the release checks',
+        delivery: 'steer',
         images: [{ data: 'cG5n', mimeType: 'image/png' }],
       },
     ]);

--- a/packages/core/doompi-web-contracts/src/types/webPlugin.ts
+++ b/packages/core/doompi-web-contracts/src/types/webPlugin.ts
@@ -494,6 +494,8 @@ export interface ToolPromptContribution {
 export interface ToolRendererContribution {
   /** Tool names as registered with Pi (registerTool's `name`). */
   tools: string[];
+  /** Render outside the host's tool gutter when the item is conversational content rather than implementation detail. */
+  timelinePresentation?: 'tool' | 'message';
   /**
    * Claims a tool named only at runtime (an MCP server's tools) when no
    * plugin lists the name. The session's footer statuses come along so the

--- a/packages/minor/doompi-voice/src/adapters/pi/narrationTool.ts
+++ b/packages/minor/doompi-voice/src/adapters/pi/narrationTool.ts
@@ -22,16 +22,16 @@ import type { VoiceToolReadinessWaiter } from './voiceTools.ts';
 
 const NARRATE_LABEL = 'Narrate';
 const NARRATE_DESCRIPTION =
-  'Speak one complete primary-agent-authored update through the active autonomous Voice session and wait until physical playback settles. Use it when work starts, after a meaningful finding, before asking for feedback or a decision, and before every user-facing final response. Final narration must contain the complete answer, including all user-relevant conclusions, questions, warnings, results, and next actions, rather than a shorter summary that leaves essential information only in text.';
-const NARRATE_PROMPT_SNIPPET =
-  'When available, you MUST call narrate when starting work, after interesting or meaningful findings, before requesting user feedback or a decision, and before ending the task with a user-facing final response; final narration must include the complete user-facing answer.';
+  'Speak one concise primary-agent-authored update through the active autonomous Voice session and wait until physical playback settles.';
 const NARRATE_PROMPT_GUIDELINES = [
-  'When narrate is available, you MUST call it before ending a task with a user-facing final response. Speak the complete answer, including every user-relevant conclusion, question, warning, result, and next action that will appear in the written response. Do not narrate a shorter summary and leave essential information only in text.',
-  'For a short conversational, clarification, refusal, or error turn, one call that speaks the complete answer is enough.',
-  'For non-trivial work, you MUST also call narrate when starting work, after interesting or meaningful findings, and before requesting user feedback or a decision. Do not narrate repetitive low-level progress.',
+  'When the user asks for work, acknowledge the request with a brief narration before using tools or starting the work. Say what you are about to do, not the full plan.',
+  'During non-trivial work, narrate a meaningful finding, blocker, risk, or change in plan or direction. State why it matters and what you will do next so the user can follow progress.',
+  'Do not narrate routine commands, repeated low-level progress, internal reasoning, or the same update more than once.',
+  'Before every user-facing final response, narrate a concise, action-focused summary. Include the outcome, any material warning or unresolved question, and the next action when one exists; leave supporting detail in text.',
+  'For a short conversational, clarification, refusal, or error turn, one narration that speaks the concise response is enough.',
   'Only a narrate call produces speech; ordinary response text and visible status or progress prose are not narration.',
   'Use narrate with one complete utterance per call, ready to speak verbatim. Never split one utterance across calls or request another summarization pass.',
-  'Keep the complete answer within the 4,096-character narration limit while autonomous Voice is active. Use concise plain language. Avoid Markdown, code, secrets, and raw paths.',
+  'Keep narration within the 4,096-character limit. Use concise plain language. Avoid Markdown, code, secrets, and raw paths.',
   'Wait for each narrate result. Treat interrupted, superseded, or failed playback as terminal for that utterance; do not automatically repeat it.',
 ] as const;
 
@@ -119,7 +119,6 @@ export function createNarrationTool(
     name: VOICE_NARRATE_TOOL_NAME,
     label: NARRATE_LABEL,
     description: NARRATE_DESCRIPTION,
-    promptSnippet: NARRATE_PROMPT_SNIPPET,
     promptGuidelines: [...NARRATE_PROMPT_GUIDELINES],
     parameters: NarrationRequestSchema,
     executionMode: 'sequential',

--- a/packages/minor/doompi-voice/tests/narrationTool.test.ts
+++ b/packages/minor/doompi-voice/tests/narrationTool.test.ts
@@ -75,25 +75,24 @@ describe('narrate Pi tool', () => {
     });
     expect(h.tool.description).toContain('active autonomous Voice session');
     expect(h.tool.description).toContain('physical playback settles');
-    expect(h.tool.description).toContain('when work starts');
-    expect(h.tool.description).toContain('meaningful finding');
-    expect(h.tool.description).toContain('feedback or a decision');
-    expect(h.tool.description).toContain('before every user-facing final response');
-    expect(h.tool.description).toContain('complete answer');
-    expect(h.tool.description).toContain('conclusions, questions, warnings, results, and next actions');
-    expect(h.tool.description).toContain('rather than a shorter summary');
-    expect(h.tool.promptSnippet).toContain('MUST call narrate');
-    expect(h.tool.promptGuidelines?.join('\n')).toContain('you MUST call it');
-    expect(h.tool.promptGuidelines?.join('\n')).toContain('starting work');
-    expect(h.tool.promptGuidelines?.join('\n')).toContain('interesting or meaningful findings');
-    expect(h.tool.promptGuidelines?.join('\n')).toContain('user feedback or a decision');
+    expect(h.tool.description).toContain('one concise primary-agent-authored update');
+    expect(h.tool.description).not.toContain('complete answer');
+    expect(h.tool.promptSnippet).toBeUndefined();
+    expect(h.tool.promptGuidelines?.join('\n')).toContain('acknowledge the request');
+    expect(h.tool.promptGuidelines?.join('\n')).toContain('before using tools or starting the work');
+    expect(h.tool.promptGuidelines?.join('\n')).toContain(
+      'meaningful finding, blocker, risk, or change in plan or direction',
+    );
+    expect(h.tool.promptGuidelines?.join('\n')).toContain('why it matters and what you will do next');
+    expect(h.tool.promptGuidelines?.join('\n')).toContain('same update more than once');
     expect(h.tool.promptGuidelines?.join('\n')).toContain(
       'short conversational, clarification, refusal, or error turn',
     );
     expect(h.tool.promptGuidelines?.join('\n')).toContain('Only a narrate call produces speech');
     expect(h.tool.promptGuidelines?.join('\n')).toContain('one complete utterance');
-    expect(h.tool.promptGuidelines?.join('\n')).toContain('Do not narrate a shorter summary');
-    expect(h.tool.promptGuidelines?.join('\n')).toContain('4,096-character narration limit');
+    expect(h.tool.promptGuidelines?.join('\n')).toContain('concise, action-focused summary');
+    expect(h.tool.promptGuidelines?.join('\n')).toContain('leave supporting detail in text');
+    expect(h.tool.promptGuidelines?.join('\n')).toContain('4,096-character limit');
     expect(h.tool.promptGuidelines?.join('\n')).toContain('Avoid Markdown, code, secrets, and raw paths');
 
     h.session.dispose();

--- a/packages/minor/doompi-voice/tests/webVoiceMedia.test.ts
+++ b/packages/minor/doompi-voice/tests/webVoiceMedia.test.ts
@@ -1,10 +1,11 @@
 import { readFile } from 'node:fs/promises';
-import { renderPlugin, slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { renderPlugin, slotPropsFixture, toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
 import { afterEach, describe, expect, it } from 'vitest';
 import { VOICE_OWNERSHIP_PROTOCOL_VERSION } from '../src/types/voiceOwnership.ts';
 import { browserVoiceMediaClientId } from '../web/browserMediaIdentity.ts';
 import { VoiceActivitySection } from '../web/VoiceActivitySection.tsx';
 import { VoiceComposerAction } from '../web/VoiceComposerAction.tsx';
+import { VoiceToolMessage } from '../web/VoiceToolMessage.tsx';
 import {
   activeVoiceSession,
   voiceMediaBrowserState,
@@ -33,6 +34,83 @@ describe('browser voice media', () => {
     expect(source).toContain("command: 'minor voice-auto'");
     const runtimeSource = await readFile(new URL('../web/VoiceMediaRuntime.tsx', import.meta.url), 'utf8');
     expect(runtimeSource).toContain('this.device.armUserGesture()');
+  });
+
+  it('does not classify autonomous voice capture as background work', async () => {
+    const source = await readFile(new URL('../web/index.ts', import.meta.url), 'utf8');
+
+    expect(source).toContain('marksBackgroundWork: false');
+  });
+
+  it('presents narration as readable conversational output', async () => {
+    const source = await readFile(new URL('../web/index.ts', import.meta.url), 'utf8');
+    const rendered = renderPlugin(
+      VoiceToolMessage,
+      toolMessagePropsFixture({
+        toolName: 'narrate',
+        args: { text: 'The migration is complete.' },
+        running: false,
+      }).props,
+    );
+
+    expect(source).toContain('tools: [VOICE_NARRATE_TOOL]');
+    expect(source).toContain("timelinePresentation: 'message'");
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.html).toContain('data-testid="narration-message"');
+    expect(rendered.html).toContain('aria-label="narration"');
+    expect(rendered.html).toContain('The migration is complete.');
+    expect(rendered.html).not.toContain('data-slot="message-item"');
+  });
+
+  it('keeps narration state readable without changing facade calls into messages', () => {
+    const playing = renderPlugin(
+      VoiceToolMessage,
+      toolMessagePropsFixture({ toolName: 'narrate', args: { text: 'Still working.' }, running: true }).props,
+    );
+    const failed = renderPlugin(
+      VoiceToolMessage,
+      toolMessagePropsFixture({ toolName: 'narrate', args: {}, running: false, isError: true }).props,
+    );
+    const facade = renderPlugin(
+      VoiceToolMessage,
+      toolMessagePropsFixture({
+        toolName: 'describe_voice_tools',
+        args: { names: ['minor_mode'] },
+        running: false,
+        result: { content: [{ type: 'text', text: 'Catalog ready.' }], details: null },
+      }).props,
+    );
+    const batch = renderPlugin(
+      VoiceToolMessage,
+      toolMessagePropsFixture({
+        toolName: 'use_voice_tools',
+        args: { calls: [{ name: 'one' }, { name: 'two' }] },
+        running: false,
+      }).props,
+    );
+    const idleFacade = renderPlugin(
+      VoiceToolMessage,
+      toolMessagePropsFixture({ toolName: 'describe_voice_tools', running: false }).props,
+    );
+    const runningFacade = renderPlugin(
+      VoiceToolMessage,
+      toolMessagePropsFixture({ toolName: 'describe_voice_tools', running: true }).props,
+    );
+    const failedFacade = renderPlugin(
+      VoiceToolMessage,
+      toolMessagePropsFixture({ toolName: 'describe_voice_tools', running: false, isError: true }).props,
+    );
+
+    expect(playing.html).toContain('data-narration-state="playing"');
+    expect(failed.html).toContain('data-narration-state="failed"');
+    expect(failed.html).toContain('Narration unavailable.');
+    expect(facade.html).toContain('data-slot="message-item"');
+    expect(facade.html).toContain('minor_mode');
+    expect(facade.html).toContain('Catalog ready.');
+    expect(batch.html).toContain('2 capabilities');
+    expect(idleFacade.html).toContain('discover');
+    expect(runningFacade.html).toContain('Working');
+    expect(failedFacade.html).toContain('ERROR');
   });
 
   it('keeps process-local manual recording out of the browser minor-mode picker', async () => {

--- a/packages/minor/doompi-voice/tests/webVoiceToolRender.test.ts
+++ b/packages/minor/doompi-voice/tests/webVoiceToolRender.test.ts
@@ -145,6 +145,10 @@ describe('voice tool result lines', () => {
     expect(texts(voiceResultLines('use_voice_tools', text('', { error: {} }), done))).toEqual([
       '✗ Voice capability failed.',
     ]);
+    expect(texts(voiceResultLines('use_voice_tools', text('', { results: [{}] }), done))).toEqual([
+      '✗ Voice batch failed · 1 call',
+      '✗ capability · failed',
+    ]);
   });
 
   it('falls back to the text with the outcome glyph', () => {

--- a/packages/minor/doompi-voice/web/VoiceToolMessage.tsx
+++ b/packages/minor/doompi-voice/web/VoiceToolMessage.tsx
@@ -3,17 +3,33 @@ import {
   MessageItemBody,
   MessageItemHeader,
   MessageLines,
+  VolumeIcon,
   toolTone,
 } from '@agimon-ai/doompi-web-components';
 import type { ToolMessageRenderProps } from '@agimon-ai/doompi-web-contracts';
-import { voiceCallSummary, voiceResultLines } from './voiceToolRender.ts';
+import { VOICE_NARRATE_TOOL, voiceCallSummary, voiceResultLines } from './voiceToolRender.ts';
 
 /**
- * The voice tools' timeline item: discover, run, or narrate with the
- * capability or speech preview in the header; the capability catalog, the
- * batch outcome, or the narration status line in the body.
+ * The voice tools' timeline item. Facade calls keep their structured tool card.
+ * Narration is conversational output rather than implementation detail, so its
+ * spoken text stays in the transcript as a plain message with a speaker icon.
  */
 export function VoiceToolMessage({ toolName, args, result, running, isError }: ToolMessageRenderProps) {
+  if (toolName === VOICE_NARRATE_TOOL) {
+    const text = typeof args.text === 'string' ? args.text.normalize('NFKC').replace(/\s+/gu, ' ').trim() : '';
+    return (
+      <div
+        role="group"
+        aria-label="narration"
+        data-testid="narration-message"
+        data-narration-state={running ? 'playing' : isError ? 'failed' : 'complete'}
+        className="flex min-w-0 items-start gap-2 text-[13px] text-doom-text"
+      >
+        <VolumeIcon aria-hidden="true" className="mt-0.5 h-3.5 w-3.5 shrink-0 text-doom-magenta" />
+        <p className="min-w-0 flex-1 whitespace-pre-wrap break-words">{text || 'Narration unavailable.'}</p>
+      </div>
+    );
+  }
   const summary = voiceCallSummary(toolName, args);
   const collapsed = voiceResultLines(toolName, result, { expanded: false, isError, isPartial: running });
   const full = voiceResultLines(toolName, result, { expanded: true, isError, isPartial: running });
@@ -24,8 +40,7 @@ export function VoiceToolMessage({ toolName, args, result, running, isError }: T
           <MessageItemHeader title={toolName}>
             <span data-testid={`tool-call-${toolName}`} className="flex min-w-0 flex-1 items-center gap-2">
               <span className="font-bold text-doom-hi">
-                {summary.glyph ? `${summary.glyph} ` : ''}
-                {summary.action}
+                {summary.glyph} {summary.action}
               </span>
               {summary.detail ? (
                 <span className={`min-w-0 truncate ${summary.detailIsName ? 'text-doom-blue' : 'text-doom-faint'}`}>
@@ -34,11 +49,9 @@ export function VoiceToolMessage({ toolName, args, result, running, isError }: T
               ) : null}
             </span>
           </MessageItemHeader>
-          {(expanded ? full : collapsed).length > 0 ? (
-            <MessageItemBody data-testid={`tool-result-${toolName}`}>
-              <MessageLines lines={expanded ? full : collapsed} />
-            </MessageItemBody>
-          ) : null}
+          <MessageItemBody data-testid={`tool-result-${toolName}`}>
+            <MessageLines lines={expanded ? full : collapsed} />
+          </MessageItemBody>
         </>
       )}
     </MessageItem>

--- a/packages/minor/doompi-voice/web/index.ts
+++ b/packages/minor/doompi-voice/web/index.ts
@@ -3,7 +3,7 @@ import { VoiceActivitySection } from './VoiceActivitySection.tsx';
 import { VoiceComposerAction } from './VoiceComposerAction.tsx';
 import { startVoiceMediaRuntime } from './VoiceMediaRuntime.tsx';
 import { VoiceToolMessage } from './VoiceToolMessage.tsx';
-import { VOICE_TOOL_NAMES } from './voiceToolRender.ts';
+import { VOICE_DESCRIBE_TOOL, VOICE_NARRATE_TOOL, VOICE_TRANSFER_TOOL, VOICE_USE_TOOL } from './voiceToolRender.ts';
 import { voiceMediaWakeChannel, voiceOwnershipChannel } from './voiceMediaWakeStore.ts';
 
 /**
@@ -18,18 +18,38 @@ export const webPlugin = defineWebPlugin({
   // one-shot manual dictation exclusively on the visible Composer button.
   minorModes: [{ name: 'voice', modeId: 'voice-auto', keys: 'v e', statusKey: 'doom-voice', order: 60 }],
   // A microphone you cannot see is one you cannot trust, so voice earns a
-  // group in the dock rather than a word inside a chip.
-  // hideWhenEmpty: the group reports a capture in progress, so it belongs in
-  // the dock while one is running and nowhere otherwise.
+  // group in the dock rather than a word inside a chip. Autonomous capture is
+  // an interactive session mode, not background work, so it must not increment
+  // the dock's running count or hold the background-work notice open.
+  // hideWhenEmpty keeps the group present only while voice reports activity.
   activityGroups: [
-    { name: 'voice', keys: 'v e', statusKey: 'doom-voice', hideWhenEmpty: true, placement: 'bottom', order: 60 },
+    {
+      name: 'voice',
+      keys: 'v e',
+      statusKey: 'doom-voice',
+      hideWhenEmpty: true,
+      marksBackgroundWork: false,
+      placement: 'bottom',
+      order: 60,
+    },
   ],
   // Same name as the group: the dock renders this inside it, in place of the
   // raw status line the session publishes for a terminal footer.
   activitySections: [{ id: 'voice', component: VoiceActivitySection }],
   composerActions: [{ id: 'voice', component: VoiceComposerAction }],
-  // The voice tools' timeline cards, the web half of src/adapters/pi/voiceToolRender.ts.
-  toolRenderers: [{ tools: [...VOICE_TOOL_NAMES], message: VoiceToolMessage }],
+  // Narration reads as conversational output; the remaining façade calls keep
+  // the ordinary tool presentation because they expose implementation detail.
+  toolRenderers: [
+    {
+      tools: [VOICE_DESCRIBE_TOOL, VOICE_USE_TOOL, VOICE_TRANSFER_TOOL],
+      message: VoiceToolMessage,
+    },
+    {
+      tools: [VOICE_NARRATE_TOOL],
+      timelinePresentation: 'message',
+      message: VoiceToolMessage,
+    },
+  ],
   // The browser leader binding controls autonomous capture only.
   leaderBindings: [
     {


### PR DESCRIPTION
## Summary
- improve autonomous voice narration guidance and transcript presentation
- add individual queued-message deletion with queue reconstruction
- load the web agent catalog from the session-authoritative Team API

## Verification
- affected typechecks passed in commit hooks
- DoomPi web lint, typecheck, tests, build, and focused queue E2E passed
- DoomPi Team lint, typecheck, tests, build, and focused catalog E2E passed
- vibe-lint preflight completed with existing unrelated PWA coverage warnings