### PR TITLE
fix(doompi): resolve global and web compositions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "audit:workspace": "node scripts/audit-workspace.mjs",
     "build": "nx run-many -t build",
     "cockpit": "pnpm cockpit:build && pnpm doompi-web",
-    "cockpit:build": "nx run-many -t build -p @agimon-ai/doompi @agimon-ai/doompi-server @agimon-ai/doompi-web @agimon-ai/doompi-file-edit @agimon-ai/doompi-mcp @agimon-ai/doompi-task @agimon-ai/doompi-team @agimon-ai/doompi-workflow @agimon-ai/doompi-user-feedback",
+    "cockpit:build": "nx run-many -t build -p @agimon-ai/doompi @agimon-ai/doompi-server @agimon-ai/doompi-web @agimon-ai/doompi-file-edit @agimon-ai/doompi-mcp @agimon-ai/doompi-task @agimon-ai/doompi-team @agimon-ai/doompi-voice @agimon-ai/doompi-workflow @agimon-ai/doompi-user-feedback",
     "examples:check": "node scripts/check-examples.mjs",
     "hooks:check": "node scripts/emit-hooks.mjs --check",
     "hooks:write": "node scripts/emit-hooks.mjs --write",

--- a/packages/clients/doompi-web/README.md
+++ b/packages/clients/doompi-web/README.md
@@ -26,27 +26,31 @@ npm install -g @agimon-ai/doompi-web
 doompi-web
 ```
 
-Open `http://127.0.0.1:7433`. With no flags, the hub watches `~/.doompi/run`, attaches to registered sessions, and can start new sessions from the page. Sessions started by the cockpit use the server and agent from the same installation.
+Open `http://127.0.0.1:7433`. With no flags, the hub watches `~/.doompi/run`, attaches to registered sessions, and resolves the union of their synchronized cockpit compositions from `~/.pi/.doom/sync/registrations`. The directory that launches `doompi-web` does not select the bundle. Sessions started by the cockpit use the server and agent from the same installation.
 
-If a hub already answers on the port, a second `doompi-web` process prints its URL and exits.
+If `~/.pi/.doom` does not exist, the command runs its bundled `doompi init` before starting. If a hub already answers on the port, a second `doompi-web` process prints its URL and exits.
 
-To run this repository's build:
+To run this repository's build with its composition pinned and watched:
 
 ```bash
-pnpm cockpit
+pnpm cockpit:build
+pnpm doompi-web --dir=<PWD>
 ```
 
-The command builds the required packages and starts the hub on port 7433. Sessions created from the page use this checkout's builds.
+`--dir` accepts `--dir <path>` too. It synchronizes that repository before launch and watches it for development rebuilds.
 
-| Flag              | Default         | Meaning                                          |
-| ----------------- | --------------- | ------------------------------------------------ |
-| `--registry-dir`  | `~/.doompi/run` | Registry to watch (also `DOOMPI_RUNTIME_DIR`)    |
-| `--spawn-command` | this install    | Command launching sessions created from the page |
-| `--port`          | `7433`          | HTTP port                                        |
-| `--host`          | `127.0.0.1`     | Bind address                                     |
-| `--assets`        | bundled         | Override the built SPA directory                 |
-| `--state-dir`     | `~/.doompi/web` | Remote-access settings and the tunnel pid file   |
-| `--cloudflared`   | from `PATH`     | Tunnel binary (also `DOOMPI_CLOUDFLARED`)        |
+| Flag              | Default                  | Meaning                                          |
+| ----------------- | ------------------------ | ------------------------------------------------ |
+| `--dir`           | live-session union       | Pin, sync, and watch one repository composition  |
+| `--registry-dir`  | `~/.doompi/run`          | Registry to watch (also `DOOMPI_RUNTIME_DIR`)    |
+| `--spawn-command` | this install             | Command launching sessions created from the page |
+| `--port`          | `7433`                   | HTTP port                                        |
+| `--host`          | `127.0.0.1`              | Bind address                                     |
+| `--assets`        | synchronized or packaged | Override the built SPA directory                 |
+| `--state-dir`     | `~/.doompi/web`          | Remote-access settings and cockpit cache         |
+| `--cloudflared`   | from `PATH`              | Tunnel binary (also `DOOMPI_CLOUDFLARED`)        |
+| `-h`, `--help`    |                          | Print command help                               |
+| `-v`, `--version` |                          | Print the installed package version              |
 
 Install [doompi-server](https://www.npmjs.com/package/@agimon-ai/doompi-server) when you also want to run a session server directly. The hub does not require `doompi-server` on `PATH` to create sessions.
 

--- a/packages/clients/doompi-web/src/adapters/doomInitialization.ts
+++ b/packages/clients/doompi-web/src/adapters/doomInitialization.ts
@@ -1,0 +1,49 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { globalDoomConfigDirectory } from '@agimon-ai/doompi-config';
+
+const DOOMPI_PACKAGE = '@agimon-ai/doompi';
+const CLI_SEGMENTS = ['dist', 'bin', 'cli.mjs'];
+
+export interface DoomInitializationOptions {
+  homeDirectory?: string;
+  onNotice?: (message: string) => void;
+  /** Test seam over the global configuration directory check. */
+  exists?: (directory: string) => boolean;
+  /** Test seam over the child command. */
+  runInit?: () => Promise<void>;
+}
+
+function bundledDoomPiCli(): string {
+  const packageRoot = path.dirname(createRequire(import.meta.url).resolve(`${DOOMPI_PACKAGE}/package.json`));
+  return path.join(packageRoot, ...CLI_SEGMENTS);
+}
+
+function runBundledInit(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [bundledDoomPiCli(), 'init'], {
+      cwd: os.homedir(),
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    child.once('error', (error) =>
+      reject(new Error(`doompi init could not start: ${error.message}`, { cause: error })),
+    );
+    child.once('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`doompi init exited with code ${String(code)}`));
+    });
+  });
+}
+
+/** Ensures the global configuration and managed Pi integration exist before the web hub starts. */
+export async function ensureDoomInitialized(options: DoomInitializationOptions = {}): Promise<boolean> {
+  const homeDirectory = options.homeDirectory ?? os.homedir();
+  const configDirectory = globalDoomConfigDirectory(homeDirectory);
+  if ((options.exists ?? fs.existsSync)(configDirectory)) return false;
+  options.onNotice?.(`${configDirectory} is missing; running doompi init`);
+  await (options.runInit ?? runBundledInit)();
+  return true;
+}

--- a/packages/clients/doompi-web/src/adapters/httpServer.ts
+++ b/packages/clients/doompi-web/src/adapters/httpServer.ts
@@ -6,12 +6,13 @@ import { serve } from '@hono/node-server';
 import { createNodeWebSocket } from '@hono/node-ws';
 import { SessionManager } from '@earendil-works/pi-coding-agent';
 import { PiServer, PiServerError } from '@earendil-works/pi-server';
-import { readSyncDrift, readSyncRegistration, type SyncRegistration } from '@agimon-ai/doompi/services';
+import { readSyncDrift, readSyncRegistration } from '@agimon-ai/doompi/services';
+import { globalDoomConfigDirectory } from '@agimon-ai/doompi-config';
 import { readSyncState, type SyncState } from '@agimon-ai/doompi/services/syncState';
 import type { DoomTelemetry } from '@agimon-ai/doompi-telemetry';
 import { BUNDLE_MANIFEST_ROUTE, assetFor } from '@agimon-ai/doompi-web-security';
 import { createPiHubService } from './piHubService.ts';
-import { createSyncGuard } from './syncGuard.ts';
+import { createSyncGuard, type SyncGuard } from './syncGuard.ts';
 import { createPiWebSocketListener } from './piWebSocketListener.ts';
 import { type Context, Hono } from 'hono';
 import { getCookie } from 'hono/cookie';
@@ -55,7 +56,7 @@ import {
 import { parseDoomNotificationEntry } from '../types/notification.ts';
 import { ATTACH_TYPE, type SessionFrame } from '../types/session.ts';
 import { readGitStatus } from './gitStatus.ts';
-import { watchRegistry } from './registryWatcher.ts';
+import { readRegistryRecords, watchRegistry } from './registryWatcher.ts';
 import { createServerSpawner } from './serverSpawner.ts';
 import { createSessionHub, type SessionHub } from './sessionHub.ts';
 import { allowedOriginsFromEnv } from '../services/remoteGuardPolicy.ts';
@@ -96,6 +97,7 @@ import {
   shutdownWebTelemetry,
   WEB_TELEMETRY_ROUTE,
 } from './webTelemetry.ts';
+import { resolveWebComposition } from './webComposition.ts';
 
 // Pi's protocol rides its own socket so the DoomPi channel keeps the
 // vocabulary the protocol has no shape for: dialogs, minor modes, selection.
@@ -248,13 +250,13 @@ export function packagedVersion(): string {
 /** The assets to serve, with explicit overrides ahead of this hub's registration. */
 function resolveAssetsDir(
   explicit: string | undefined,
-  registration: SyncRegistration | undefined,
+  composition: { webDirectory: string | null } | undefined,
   notice: (message: string) => void,
 ): string {
   if (explicit !== undefined) return explicit;
   const fromEnv = process.env[WEB_DIST_ENV];
   if (fromEnv !== undefined && fromEnv !== '') return fromEnv;
-  const synced = registration?.webDirectory;
+  const synced = composition?.webDirectory;
   if (synced !== undefined && synced !== null && fs.existsSync(path.join(synced, INDEX_FILE))) {
     notice(`serving the synced cockpit bundle from ${synced}`);
     return synced;
@@ -460,37 +462,66 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
   const host = options.host ?? '127.0.0.1';
   const notice = options.onNotice ?? ((): void => {});
   const telemetry = createWebTelemetry();
-  let startupRoot: string | undefined;
-  try {
-    startupRoot = findRepositoryRoot(process.cwd());
-  } catch {
-    startupRoot = undefined;
-  }
-  const syncGuard = createSyncGuard({
-    ...(startupRoot === undefined ? { cwd: process.cwd() } : { repoRoot: startupRoot }),
-    onNotice: notice,
-  });
-  await syncGuard.ensureSynced();
-  let startupRegistration: SyncRegistration | undefined;
-  if (startupRoot !== undefined) {
+  const store = createRemoteAccessStore({ stateDir: options.remoteStateDir, onNotice: notice });
+  const repositoryRoot = (directory: string): string | undefined => {
     try {
-      startupRegistration = readSyncRegistration(startupRoot);
-    } catch (error) {
-      notice(`synced registration is unavailable (${describeError(error)})`);
+      return fs.realpathSync(findRepositoryRoot(directory));
+    } catch {
+      return undefined;
     }
+  };
+  const compositionRoot = (directory: string): string | undefined => {
+    const repository = repositoryRoot(directory);
+    if (repository !== undefined) return repository;
+    const globalRoot = globalDoomConfigDirectory();
+    try {
+      return readSyncRegistration(globalRoot)?.root;
+    } catch (error) {
+      notice(`global cockpit composition is unreadable (${describeError(error)})`);
+      return undefined;
+    }
+  };
+  const pinnedRoot = options.compositionDir === undefined ? undefined : repositoryRoot(options.compositionDir);
+  if (options.compositionDir !== undefined && pinnedRoot === undefined) {
+    throw new Error(`Cockpit composition directory is not inside a repository: ${options.compositionDir}`);
   }
-  /**
-   * The generation the hub is currently serving.
-   *
-   * Resolved once at startup and then re-read whenever the guard reports a
-   * rebuild. Capturing it for the process lifetime meant a hub that started
-   * before the first successful sync served the packaged, plugin-free bundle
-   * until it was restarted, and a hub that outlived a sync kept serving a
-   * generation that had already been superseded.
-   */
+  const initialRecords = readRegistryRecords(options.registryDir, notice);
+  const liveRoots = initialRecords
+    .map((record) => compositionRoot(record.cwd))
+    .filter((root): root is string => root !== undefined);
+  const compositionRoots = [...new Set(pinnedRoot === undefined ? liveRoots : [pinnedRoot])].sort((left, right) =>
+    left.localeCompare(right),
+  );
+  const syncGuards = new Map<string, SyncGuard>();
+  for (const root of compositionRoots) {
+    syncGuards.set(root, createSyncGuard({ repoRoot: root, onNotice: notice }));
+  }
+  await Promise.all([...syncGuards.values()].map(async (guard) => await guard.ensureSynced()));
+  const resolveComposition = async () =>
+    await resolveWebComposition({
+      repositoryRoots: compositionRoots,
+      stateDirectory: store.directory,
+      onNotice: notice,
+    });
+  const startupComposition = await resolveComposition();
   let served = {
-    assetsDir: resolveAssetsDir(options.assetsDir, startupRegistration, notice),
-    apiDirectory: startupRegistration?.apiDirectory,
+    assetsDir: resolveAssetsDir(options.assetsDir, startupComposition, notice),
+    apiDirectory: startupComposition?.apiDirectory,
+  };
+  const ensureSessionSynced = async (directory: string): Promise<void> => {
+    const root = compositionRoot(directory);
+    if (root === undefined) return;
+    const existing = syncGuards.get(root);
+    if (existing !== undefined) {
+      await existing.ensureSynced();
+      return;
+    }
+    const guard = createSyncGuard({ repoRoot: root, onNotice: notice });
+    try {
+      await guard.ensureSynced();
+    } finally {
+      guard.close();
+    }
   };
   const hub = buildHub(options, notice, await loadHubChannels(served.assetsDir, notice), telemetry);
   // Threads are journals the data channels can name (a subagent run's own
@@ -518,7 +549,6 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
   const nodeWs = createNodeWebSocket({ app });
   /** Known once the listener binds; until then the guard treats every request as remote. */
   let loopbackPort: number | undefined;
-  const store = createRemoteAccessStore({ stateDir: options.remoteStateDir, onNotice: notice });
   const pwaDir = packagedPwaDir();
   const publication = createBundlePublication({
     assetsDir: () => served.assetsDir,
@@ -880,7 +910,7 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
       return context.json({ error: 'A cwd string is required.' }, 400);
     }
     const name = typeof body.name === 'string' && body.name !== '' ? body.name : undefined;
-    await syncGuard.ensureSynced();
+    await ensureSessionSynced(body.cwd);
     const outcome = await hub.create({ cwd: body.cwd, name, trace: readTraceContext(context.req.raw.headers) });
     if (outcome.ok) return context.json({ sessionId: outcome.sessionId }, 201);
     return context.json({ error: outcome.error }, outcome.code === 'invalid_request' ? 400 : 502);
@@ -892,7 +922,8 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
   // finish before the replacement starts or it reads the same stale artifacts.
   app.post(`${SESSIONS_API_ROUTE}/:sessionId/restart`, async (context) => {
     const sessionId = context.req.param('sessionId');
-    await syncGuard.ensureSynced();
+    const summary = hub.snapshot().find((candidate) => candidate.id === sessionId);
+    if (summary !== undefined) await ensureSessionSynced(summary.cwd);
     const outcome = await hub.restart(sessionId, readTraceContext(context.req.raw.headers));
     if (outcome.ok) return context.json({ sessionId: outcome.sessionId }, 202);
     return context.json({ error: outcome.error }, outcome.code === 'invalid_request' ? 404 : 502);
@@ -931,7 +962,7 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
     const sessions = await SessionManager.list(summary.cwd);
     const target = sessions.find((session) => session.id === body.targetSessionId);
     if (!target) return context.json({ error: 'That Pi thread does not belong to this workspace.' }, 404);
-    await syncGuard.ensureSynced();
+    await ensureSessionSynced(summary.cwd);
     const outcome = await hub.resume(
       sessionId,
       { sessionId: target.id, name: resumedSessionName(target, summary.cwd) },
@@ -1327,28 +1358,24 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
     return context.text('Not found.', 404);
   });
 
-  // A rebuilt bundle only changes on disk, so the page it replaced has to be
-  // told; nothing about a loaded bundle notices that its source moved. Sync
-  // publishes each rebuild as a new generation, so the paths resolved at
-  // startup have to be re-read before anything is served from them.
-  syncGuard.watch(() => {
-    let rebuilt: SyncRegistration | undefined;
-    if (startupRoot !== undefined) {
-      try {
-        rebuilt = readSyncRegistration(startupRoot);
-      } catch (error) {
-        // An unreadable registration leaves the hub on the generation it is
-        // already serving, which still works, rather than on nothing at all.
-        notice(`the rebuilt registration is unavailable (${describeError(error)}); keeping the served bundle`);
+  // A rebuilt bundle only changes on disk, so re-resolve the synchronized
+  // registrations and tell every page to stage the replacement.
+  const refreshServedComposition = async (): Promise<void> => {
+    try {
+      const rebuilt = await resolveComposition();
+      if (rebuilt !== undefined && rebuilt.webDirectory !== served.assetsDir) {
+        served = { assetsDir: rebuilt.webDirectory, apiDirectory: rebuilt.apiDirectory };
+        notice(`serving the rebuilt cockpit bundle from ${served.assetsDir}`);
       }
+      publication.refresh();
+      broadcast({ type: HUB_RESYNCED_TYPE }, false);
+    } catch (error) {
+      notice(`the rebuilt cockpit composition is unavailable (${describeError(error)}); keeping the served bundle`);
     }
-    if (rebuilt?.webDirectory != null && rebuilt.webDirectory !== served.assetsDir) {
-      served = { assetsDir: rebuilt.webDirectory, apiDirectory: rebuilt.apiDirectory };
-      notice(`serving the rebuilt cockpit bundle from ${served.assetsDir}`);
-    }
-    publication.refresh();
-    broadcast({ type: HUB_RESYNCED_TYPE }, false);
-  });
+  };
+  for (const guard of syncGuards.values()) {
+    guard.watch(() => void refreshServedComposition());
+  }
 
   return new Promise<WebServer>((resolve, reject) => {
     const server = serve({ fetch: app.fetch, port: options.port, hostname: host }, (info) => {
@@ -1365,7 +1392,7 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
         await remote.close();
         await new Promise<void>((done) => {
           threads.close();
-          syncGuard.close();
+          for (const guard of syncGuards.values()) guard.close();
           void localProtocolServer.close();
           void remoteProtocolServer.close();
           disconnectLivePush();

--- a/packages/clients/doompi-web/src/adapters/registryWatcher.ts
+++ b/packages/clients/doompi-web/src/adapters/registryWatcher.ts
@@ -24,6 +24,38 @@ function pidAlive(pid: number): boolean {
   }
 }
 
+/** Reads the currently live session records without starting a watcher. */
+export function readRegistryRecords(registryDir: string, onNotice?: (message: string) => void): SessionRecord[] {
+  const recordsDir = sessionRecordsDir(registryDir);
+  let names: string[];
+  try {
+    names = fs.readdirSync(recordsDir);
+  } catch {
+    // The directory appears with the first server; an empty registry is not an error.
+    return [];
+  }
+  const records: SessionRecord[] = [];
+  for (const name of names.filter(isRecordFileName)) {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(path.join(recordsDir, name), 'utf8');
+    } catch {
+      continue; // Withdrawn between readdir and read; the next scan settles it.
+    }
+    const record = parseSessionRecord(raw);
+    if (!record) continue;
+    if (!pidAlive(record.pid)) {
+      fs.rmSync(path.join(recordsDir, name), { force: true });
+      onNotice?.(`removed stale record for session ${record.id}`);
+      continue;
+    }
+    records.push(record);
+  }
+  return records.sort(
+    (left, right) => left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
+  );
+}
+
 /**
  * Watches the registry directory for session records.
  *
@@ -40,36 +72,7 @@ export function watchRegistry(registryDir: string, onNotice?: (message: string) 
   let poll: NodeJS.Timeout | undefined;
   let closed = false;
 
-  const scan = (): SessionRecord[] => {
-    let names: string[];
-    try {
-      names = fs.readdirSync(recordsDir);
-    } catch {
-      // The directory appears with the first server; an empty registry is not
-      // an error.
-      return [];
-    }
-    const records: SessionRecord[] = [];
-    for (const name of names.filter(isRecordFileName)) {
-      let raw: string;
-      try {
-        raw = fs.readFileSync(path.join(recordsDir, name), 'utf8');
-      } catch {
-        continue; // Withdrawn between readdir and read; the next scan settles it.
-      }
-      const record = parseSessionRecord(raw);
-      if (!record) continue;
-      if (!pidAlive(record.pid)) {
-        fs.rmSync(path.join(recordsDir, name), { force: true });
-        onNotice?.(`removed stale record for session ${record.id}`);
-        continue;
-      }
-      records.push(record);
-    }
-    return records.sort(
-      (left, right) => left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
-    );
-  };
+  const scan = (): SessionRecord[] => readRegistryRecords(registryDir, onNotice);
 
   const emit = (): void => {
     if (!closed) listener?.(scan());

--- a/packages/clients/doompi-web/src/adapters/syncGuard.ts
+++ b/packages/clients/doompi-web/src/adapters/syncGuard.ts
@@ -137,6 +137,16 @@ export function createSyncGuard(options: SyncGuardOptions): SyncGuard {
       }
       return false;
     }
+    const remaining = readDrift(repoRoot);
+    if (!remaining.fresh) {
+      consecutiveFailures += 1;
+      const message = `sync completed but did not resolve drift (${describeSyncDrift({ fresh: false, reasons: remaining.reasons as never })})`;
+      if (message !== lastFailureNotice) {
+        notice(message);
+        lastFailureNotice = message;
+      }
+      return false;
+    }
     consecutiveFailures = 0;
     lastFailureNotice = undefined;
     notice('sync complete');

--- a/packages/clients/doompi-web/src/adapters/webComposition.ts
+++ b/packages/clients/doompi-web/src/adapters/webComposition.ts
@@ -1,0 +1,240 @@
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { readSyncRegistration, type SyncRegistration } from '@agimon-ai/doompi/services';
+import { PLUGIN_ROOTS_FILE } from '../services/webDevRoots.ts';
+import { bundleCockpitWeb, type BundleCockpitWebOptions } from './webBundler.ts';
+import { SERVER_REGISTRY_FILE } from './webPluginGenerate.ts';
+
+const INDEX_FILE = 'index.html';
+const HUB_ROUTES_FILE = 'hub.routes.mjs';
+const SESSION_ROUTES_FILE = 'session.routes.mjs';
+const COMPOSITIONS_DIRECTORY = 'compositions';
+const COMPOSITION_CACHE_VERSION = 2;
+export interface ResolvedWebComposition {
+  /** The synchronized repositories represented in this cockpit bundle. */
+  repositoryRoots: readonly string[];
+  /** The built SPA directory. */
+  webDirectory: string;
+  /** Generated hub package API routes for the same package union. */
+  apiDirectory: string;
+}
+
+export interface ResolveWebCompositionOptions {
+  /** Canonical repository roots belonging to the live sessions, or the one pinned repository. */
+  repositoryRoots: readonly string[];
+  /** Machine-local cockpit state directory. Union bundles are cached below it. */
+  stateDirectory: string;
+  onNotice?: (message: string) => void;
+  /** Test seam over registration discovery. */
+  readRegistration?: (repositoryRoot: string) => SyncRegistration | undefined;
+  /** Test seam over Vite's bundle build. */
+  bundle?: (options: BundleCockpitWebOptions) => Promise<{ assetsDir: string; pluginIds: string[] }>;
+}
+
+interface RegisteredComposition {
+  registration: SyncRegistration;
+  pluginRoots: string[];
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values.map((value) => path.resolve(value)))].sort((left, right) => left.localeCompare(right));
+}
+
+function sameValues(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function packageRootOf(entryPath: string): string | undefined {
+  let directory = path.dirname(path.resolve(entryPath));
+  for (;;) {
+    if (fs.existsSync(path.join(directory, 'package.json'))) return directory;
+    const parent = path.dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+function rootsFromState(registration: SyncRegistration, notice: (message: string) => void): string[] | undefined {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(registration.statePath, 'utf8'));
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('the sync state is not an object');
+    }
+    const resolved = (parsed as Record<string, unknown>).resolved;
+    if (typeof resolved !== 'object' || resolved === null || Array.isArray(resolved)) {
+      throw new Error('the sync state has no resolved entries');
+    }
+    return uniqueSorted(
+      Object.values(resolved as Record<string, unknown>)
+        .filter((entry): entry is string => typeof entry === 'string' && entry !== '')
+        .map(packageRootOf)
+        .filter((root): root is string => root !== undefined),
+    );
+  } catch (error) {
+    notice(
+      `repository ${registration.root} has unreadable synchronized package roots (${describeError(error)}); it is skipped`,
+    );
+    return undefined;
+  }
+}
+
+function readPluginRoots(registration: SyncRegistration, notice: (message: string) => void): string[] | undefined {
+  if (registration.webDirectory !== null && fs.existsSync(path.join(registration.webDirectory, INDEX_FILE))) {
+    const rootsPath = path.join(path.dirname(registration.webDirectory), PLUGIN_ROOTS_FILE);
+    try {
+      const parsed: unknown = JSON.parse(fs.readFileSync(rootsPath, 'utf8'));
+      if (!Array.isArray(parsed) || parsed.some((root) => typeof root !== 'string' || root === '')) {
+        throw new Error('the roots file is not an array of paths');
+      }
+      return uniqueSorted(parsed as string[]);
+    } catch (error) {
+      notice(
+        `repository ${registration.root} has unreadable cockpit roots (${describeError(error)}); using its sync state`,
+      );
+    }
+  }
+  return rootsFromState(registration, notice);
+}
+
+function readCompositions(options: ResolveWebCompositionOptions): RegisteredComposition[] {
+  const notice = options.onNotice ?? ((): void => {});
+  const readRegistration = options.readRegistration ?? ((root: string) => readSyncRegistration(root));
+  const registrations: RegisteredComposition[] = [];
+  for (const repositoryRoot of uniqueSorted(options.repositoryRoots)) {
+    let registration: SyncRegistration | undefined;
+    try {
+      registration = readRegistration(repositoryRoot);
+    } catch (error) {
+      notice(
+        `repository ${repositoryRoot} has an unreadable sync registration (${describeError(error)}); it is skipped`,
+      );
+      continue;
+    }
+    if (registration === undefined) {
+      notice(`repository ${repositoryRoot} has no sync registration; run doompi sync there to add its cockpit plugins`);
+      continue;
+    }
+    const pluginRoots = readPluginRoots(registration, notice);
+    if (pluginRoots !== undefined) registrations.push({ registration, pluginRoots });
+  }
+  return registrations;
+}
+
+function fingerprint(compositions: readonly RegisteredComposition[], pluginRoots: readonly string[]): string {
+  const registrations = compositions.map(({ registration }) => ({
+    root: registration.root,
+    generation: registration.generation,
+    stateSha256: registration.stateSha256,
+    webDirectory: registration.webDirectory,
+    apiDirectory: registration.apiDirectory,
+  }));
+  return createHash('sha256')
+    .update(JSON.stringify({ cacheVersion: COMPOSITION_CACHE_VERSION, registrations, pluginRoots }))
+    .digest('hex')
+    .slice(0, 32);
+}
+
+function apiModule(directory: string): string | undefined {
+  const modulePath = path.join(directory, HUB_ROUTES_FILE);
+  return fs.existsSync(modulePath) ? modulePath : undefined;
+}
+
+function writeUnionApiDirectory(outputDirectory: string, compositions: readonly RegisteredComposition[]): void {
+  fs.mkdirSync(outputDirectory, { recursive: true });
+  const modulePaths = uniqueSorted(
+    compositions
+      .map(({ registration }) => apiModule(registration.apiDirectory))
+      .filter((modulePath): modulePath is string => modulePath !== undefined),
+  );
+  const imports = modulePaths.map(
+    (modulePath, index) => `import { apis as apis${String(index)} } from '${pathToFileURL(modulePath).href}';`,
+  );
+  const names = modulePaths.map((_, index) => `...apis${String(index)}`);
+  const header = '// Generated by doompi-web composition resolution. Do not edit.';
+  fs.writeFileSync(
+    path.join(outputDirectory, HUB_ROUTES_FILE),
+    `${[header, ...imports, '', `export const apis = [${names.join(', ')}];`, ''].join('\n')}`,
+  );
+  fs.writeFileSync(path.join(outputDirectory, SESSION_ROUTES_FILE), `${header}\n\nexport const apis = [];\n`);
+}
+
+function cachedComposition(directory: string): ResolvedWebComposition | undefined {
+  const webDirectory = path.join(directory, 'web');
+  const apiDirectory = path.join(directory, 'api');
+  if (
+    !fs.existsSync(path.join(webDirectory, INDEX_FILE)) ||
+    !fs.existsSync(path.join(directory, SERVER_REGISTRY_FILE)) ||
+    !fs.existsSync(path.join(apiDirectory, HUB_ROUTES_FILE))
+  ) {
+    return undefined;
+  }
+  return { repositoryRoots: [], webDirectory, apiDirectory };
+}
+
+/**
+ * Resolves the cockpit bundle independently from the directory that launched the hub.
+ *
+ * One synchronized composition is served directly. Several live compositions first
+ * reuse an existing superset when one already contains every package root. Only a
+ * genuinely new union invokes Vite, and that result is cached by immutable sync
+ * generation under the cockpit's machine-local state directory.
+ */
+export async function resolveWebComposition(
+  options: ResolveWebCompositionOptions,
+): Promise<ResolvedWebComposition | undefined> {
+  const notice = options.onNotice ?? ((): void => {});
+  const compositions = readCompositions(options);
+  if (compositions.length === 0) return undefined;
+
+  const repositoryRoots = uniqueSorted(compositions.map(({ registration }) => registration.root));
+  const pluginRoots = uniqueSorted(compositions.flatMap((composition) => composition.pluginRoots));
+  const existing = compositions.find(
+    (composition) =>
+      sameValues(composition.pluginRoots, pluginRoots) &&
+      composition.registration.webDirectory !== null &&
+      fs.existsSync(path.join(composition.registration.webDirectory, INDEX_FILE)),
+  );
+  if (existing !== undefined && existing.registration.webDirectory !== null) {
+    notice(`serving the synchronized cockpit composition for ${repositoryRoots.join(', ')}`);
+    return {
+      repositoryRoots,
+      webDirectory: existing.registration.webDirectory,
+      apiDirectory: existing.registration.apiDirectory,
+    };
+  }
+
+  const cacheRoot = path.join(options.stateDirectory, COMPOSITIONS_DIRECTORY);
+  const outputDirectory = path.join(cacheRoot, fingerprint(compositions, pluginRoots));
+  const cached = cachedComposition(outputDirectory);
+  if (cached !== undefined) return { ...cached, repositoryRoots };
+
+  fs.mkdirSync(cacheRoot, { recursive: true });
+  const stagingDirectory = path.join(cacheRoot, `.staging-${process.pid}-${randomUUID()}`);
+  fs.mkdirSync(stagingDirectory, { recursive: true });
+  try {
+    notice(`bundling the union of ${String(compositions.length)} live cockpit compositions`);
+    await (options.bundle ?? bundleCockpitWeb)({
+      pluginRoots,
+      outDir: stagingDirectory,
+      onNotice: notice,
+    });
+    writeUnionApiDirectory(path.join(stagingDirectory, 'api'), compositions);
+    fs.rmSync(outputDirectory, { recursive: true, force: true });
+    fs.renameSync(stagingDirectory, outputDirectory);
+  } catch (error) {
+    fs.rmSync(stagingDirectory, { recursive: true, force: true });
+    throw error;
+  }
+
+  return {
+    repositoryRoots,
+    webDirectory: path.join(outputDirectory, 'web'),
+    apiDirectory: path.join(outputDirectory, 'api'),
+  };
+}

--- a/packages/clients/doompi-web/src/adapters/webPluginScan.ts
+++ b/packages/clients/doompi-web/src/adapters/webPluginScan.ts
@@ -54,8 +54,12 @@ function declaredPluginsIn(resolved: string, isHost: boolean): DeclaredWebPlugin
     if (!fs.existsSync(entryPath)) {
       throw new WebPluginManifestError(resolved, `client.entry '${plugin.client.entry}' does not exist.`);
     }
-    if (plugin.hub && !fs.existsSync(path.join(resolved, plugin.hub.entry))) {
-      throw new WebPluginManifestError(resolved, `hub.entry '${plugin.hub.entry}' does not exist.`);
+    if (plugin.hub) {
+      const kind = plugin.isHost ? 'entry' : 'dist';
+      const hubPath = plugin.hub[kind];
+      if (hubPath === undefined || !fs.existsSync(path.join(resolved, hubPath))) {
+        throw new WebPluginManifestError(resolved, `hub.${kind} '${String(hubPath)}' does not exist.`);
+      }
     }
   }
   return declared;

--- a/packages/clients/doompi-web/src/bin/serve.ts
+++ b/packages/clients/doompi-web/src/bin/serve.ts
@@ -3,12 +3,13 @@
 import os from 'node:os';
 import { createCockpitContainer } from '../adapters/cockpitContainer.ts';
 import { handOffRemoteAccess } from '../adapters/cockpitHandoff.ts';
+import { ensureDoomInitialized } from '../adapters/doomInitialization.ts';
 import { hubAnswers, probeHub } from '../adapters/hubProbe.ts';
 import { packagedVersion, serveWeb } from '../adapters/httpServer.ts';
 import { defaultRemoteStateDir } from '../adapters/remoteAccessStore.ts';
 import { relaunchSessions } from '../adapters/sessionRelaunch.ts';
 import { REGISTRY_DIR_ENV, resolveRegistryDir } from '../services/registryStore.ts';
-import { isLoopbackHost, parseServeOptions } from '../services/serveOptions.ts';
+import { isLoopbackHost, parseServeOptions, serveHelp } from '../services/serveOptions.ts';
 import type { WebServer } from '../types/bridge.ts';
 import type { MigratingSession, RemoteAccessSettings } from '../types/remoteAccess.ts';
 
@@ -42,6 +43,15 @@ async function stopRunningHub(pid: number, host: string, port: number): Promise<
 
 async function main(): Promise<void> {
   const options = parseServeOptions(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(serveHelp());
+    return;
+  }
+  if (options.version) {
+    process.stdout.write(`${packagedVersion()}\n`);
+    return;
+  }
+  await ensureDoomInitialized({ homeDirectory: os.homedir(), onNotice: notice });
   const url = `http://${options.host}:${String(options.port)}`;
   const stateDir = options.stateDir ?? defaultRemoteStateDir();
   const container = createCockpitContainer({ stateDir, onNotice: notice });
@@ -102,6 +112,7 @@ async function main(): Promise<void> {
       port: options.port,
       host: options.host,
       assetsDir: options.assetsDir,
+      compositionDir: options.directory,
       registryDir: resolveRegistryDir({
         flagValue: options.registryDir,
         envValue: process.env[REGISTRY_DIR_ENV],

--- a/packages/clients/doompi-web/src/services/serveOptions.ts
+++ b/packages/clients/doompi-web/src/services/serveOptions.ts
@@ -6,10 +6,14 @@ export interface ServeOptions {
   port: number;
   host: string;
   assetsDir?: string;
+  /** Repository composition to sync, watch, and serve explicitly. */
+  directory?: string;
   /** Where remote-access settings and the tunnel pid file live; the caller resolves a default. */
   stateDir?: string;
   /** Explicit cloudflared binary, ahead of DOOMPI_CLOUDFLARED and a PATH scan. */
   cloudflaredPath?: string;
+  help: boolean;
+  version: boolean;
 }
 
 /** Addresses that keep the cockpit off the network; anything else needs saying out loud. */
@@ -23,8 +27,13 @@ const DEFAULT_PORT = 7433;
 const DEFAULT_HOST = '127.0.0.1';
 
 function requireValue(flag: string, value: string | undefined): string {
-  if (value === undefined || value.startsWith('--')) throw new Error(`${flag} needs a value.`);
+  if (value === undefined || value === '' || value.startsWith('--')) throw new Error(`${flag} needs a value.`);
   return value;
+}
+
+function inlineValue(flag: string, prefix: string): string | undefined {
+  if (!flag.startsWith(prefix)) return undefined;
+  return requireValue(prefix.slice(0, -1), flag.slice(prefix.length));
 }
 
 /**
@@ -41,10 +50,18 @@ export function parseServeOptions(argv: readonly string[]): ServeOptions {
   let host = DEFAULT_HOST;
   let assetsDir: string | undefined;
   let stateDir: string | undefined;
+  let directory: string | undefined;
   let cloudflaredPath: string | undefined;
+  let help = false;
+  let version = false;
 
   for (let index = 0; index < argv.length; index += 1) {
     const flag = argv[index];
+    const inlineDirectory = inlineValue(flag, '--dir=');
+    if (inlineDirectory !== undefined) {
+      directory = inlineDirectory;
+      continue;
+    }
     switch (flag) {
       case '--registry-dir':
         registryDir = requireValue(flag, argv[++index]);
@@ -70,13 +87,39 @@ export function parseServeOptions(argv: readonly string[]): ServeOptions {
       case '--state-dir':
         stateDir = requireValue(flag, argv[++index]);
         break;
+      case '--dir':
+        directory = requireValue(flag, argv[++index]);
+        break;
       case '--cloudflared':
         cloudflaredPath = requireValue(flag, argv[++index]);
+        break;
+      case '--help':
+      case '-h':
+        help = true;
+        break;
+      case '--version':
+      case '-v':
+        version = true;
         break;
       default:
         throw new Error(`Unknown option "${flag}".`);
     }
   }
 
-  return { registryDir, spawnCommand, port, host, assetsDir, stateDir, cloudflaredPath };
+  return {
+    registryDir,
+    spawnCommand,
+    port,
+    host,
+    assetsDir,
+    stateDir,
+    directory,
+    cloudflaredPath,
+    help,
+    version,
+  };
+}
+
+export function serveHelp(): string {
+  return `Usage: doompi-web [options]\n\nOptions:\n  --dir <path>          Pin, sync, and watch one repository composition\n  --registry-dir <path> Session registry (default: ~/.doompi/run)\n  --spawn-command <cmd> Command used to launch sessions\n  --port <number>       HTTP port (default: 7433)\n  --host <address>      Bind address (default: 127.0.0.1)\n  --assets <path>       Override the built SPA directory\n  --state-dir <path>    Remote-access and cockpit state directory\n  --cloudflared <path>  cloudflared binary\n  -h, --help            Show this help\n  -v, --version         Show the package version\n`;
 }

--- a/packages/clients/doompi-web/src/types/bridge.ts
+++ b/packages/clients/doompi-web/src/types/bridge.ts
@@ -28,6 +28,8 @@ export interface WebServerOptions {
   host?: string;
   /** Directory holding the built SPA. Defaults to the bundled dist/web. */
   assetsDir?: string;
+  /** Repository whose synchronized composition is pinned instead of resolving live-session compositions. */
+  compositionDir?: string;
   onNotice?: (message: string) => void;
   /** Watch this registry directory for running sessions. */
   registryDir: string;

--- a/packages/clients/doompi-web/tests/unit/doomInitialization.test.ts
+++ b/packages/clients/doompi-web/tests/unit/doomInitialization.test.ts
@@ -1,0 +1,36 @@
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { ensureDoomInitialized } from '../../src/adapters/doomInitialization.ts';
+
+describe('doompi-web initialization', () => {
+  it('leaves an existing global Doom configuration untouched', async () => {
+    const runInit = vi.fn(async () => {});
+
+    const initialized = await ensureDoomInitialized({
+      homeDirectory: '/home/tester',
+      exists: () => true,
+      runInit,
+    });
+
+    expect(initialized).toBe(false);
+    expect(runInit).not.toHaveBeenCalled();
+  });
+
+  it('runs doompi init when the global configuration directory is absent', async () => {
+    const runInit = vi.fn(async () => {});
+    const notices: string[] = [];
+    const exists = vi.fn(() => false);
+
+    const initialized = await ensureDoomInitialized({
+      homeDirectory: '/home/tester',
+      exists,
+      runInit,
+      onNotice: (message) => notices.push(message),
+    });
+
+    expect(initialized).toBe(true);
+    expect(exists).toHaveBeenCalledWith(path.join('/home/tester', '.pi', '.doom'));
+    expect(runInit).toHaveBeenCalledOnce();
+    expect(notices).toContainEqual(expect.stringContaining('running doompi init'));
+  });
+});

--- a/packages/clients/doompi-web/tests/unit/serveOptions.test.ts
+++ b/packages/clients/doompi-web/tests/unit/serveOptions.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { parseServeOptions, serveHelp } from '../../src/services/serveOptions.ts';
+
+describe('doompi-web command options', () => {
+  it('keeps the no-argument hub defaults', () => {
+    expect(parseServeOptions([])).toMatchObject({
+      port: 7433,
+      host: '127.0.0.1',
+      directory: undefined,
+      help: false,
+      version: false,
+    });
+  });
+
+  it('accepts both forms of the pinned repository directory', () => {
+    expect(parseServeOptions(['--dir=/workspace/inline']).directory).toBe('/workspace/inline');
+    expect(parseServeOptions(['--dir', '/workspace/separate']).directory).toBe('/workspace/separate');
+  });
+
+  it('recognizes standard help and version flags', () => {
+    expect(parseServeOptions(['--help']).help).toBe(true);
+    expect(parseServeOptions(['-h']).help).toBe(true);
+    expect(parseServeOptions(['--version']).version).toBe(true);
+    expect(parseServeOptions(['-v']).version).toBe(true);
+    expect(serveHelp()).toContain('Usage: doompi-web [options]');
+    expect(serveHelp()).toContain('--dir <path>');
+  });
+
+  it('rejects an empty or missing pinned directory', () => {
+    expect(() => parseServeOptions(['--dir='])).toThrow('--dir needs a value');
+    expect(() => parseServeOptions(['--dir'])).toThrow('--dir needs a value');
+  });
+
+  it('preserves the existing serve overrides', () => {
+    expect(
+      parseServeOptions([
+        '--registry-dir',
+        '/tmp/run',
+        '--spawn-command',
+        'doompi-server',
+        '--port',
+        '8123',
+        '--host',
+        'localhost',
+        '--assets',
+        '/tmp/web',
+        '--state-dir',
+        '/tmp/state',
+        '--cloudflared',
+        '/usr/local/bin/cloudflared',
+      ]),
+    ).toMatchObject({
+      registryDir: '/tmp/run',
+      spawnCommand: 'doompi-server',
+      port: 8123,
+      host: 'localhost',
+      assetsDir: '/tmp/web',
+      stateDir: '/tmp/state',
+      cloudflaredPath: '/usr/local/bin/cloudflared',
+    });
+  });
+});

--- a/packages/clients/doompi-web/tests/unit/serverServices.test.ts
+++ b/packages/clients/doompi-web/tests/unit/serverServices.test.ts
@@ -30,7 +30,10 @@ describe('parseServeOptions', () => {
       host: '127.0.0.1',
       assetsDir: undefined,
       stateDir: undefined,
+      directory: undefined,
       cloudflaredPath: undefined,
+      help: false,
+      version: false,
     });
   });
 

--- a/packages/clients/doompi-web/tests/unit/syncGuard.test.ts
+++ b/packages/clients/doompi-web/tests/unit/syncGuard.test.ts
@@ -181,6 +181,28 @@ describe('sync guard', () => {
     expect(synced).not.toHaveBeenCalled();
   });
 
+  it('does not announce or hot-loop a sync that leaves the repository drifted', async () => {
+    const notices: string[] = [];
+    const runSync = vi.fn(async () => ({ ok: true }));
+    const subject = createSyncGuard({
+      repoRoot: REPO,
+      readDrift: () => drifted,
+      runSync,
+      onNotice: (message) => notices.push(message),
+      intervalMs: 5,
+    });
+    const synced = vi.fn();
+
+    subject.watch(synced);
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    subject.close();
+
+    expect(synced).not.toHaveBeenCalled();
+    expect(runSync.mock.calls.length).toBeLessThan(8);
+    expect(notices).toContainEqual(expect.stringContaining('did not resolve drift'));
+    expect(notices).not.toContain('sync complete');
+  });
+
   it('backs off instead of retrying a failing sync every interval', async () => {
     const attempts: number[] = [];
     const subject = createSyncGuard({

--- a/packages/clients/doompi-web/tests/unit/webComposition.test.ts
+++ b/packages/clients/doompi-web/tests/unit/webComposition.test.ts
@@ -1,0 +1,178 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { SyncRegistration } from '@agimon-ai/doompi/services';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveWebComposition } from '../../src/adapters/webComposition.ts';
+
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(label: string): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), label));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function registration(
+  repositoryRoot: string,
+  pluginRoots: readonly string[],
+  generation: string,
+  options: { web?: boolean } = {},
+): SyncRegistration {
+  const generationRoot = path.join(temporaryDirectory('doompi-web-composition-generation-'), generation);
+  const webDirectory = path.join(generationRoot, 'web');
+  const apiDirectory = path.join(generationRoot, 'api');
+  const statePath = path.join(generationRoot, 'state.json');
+  const resolved: Record<string, string> = {};
+  for (const [index, pluginRoot] of pluginRoots.entries()) {
+    const entry = path.join(pluginRoot, 'dist', 'extensions', 'pi.mjs');
+    fs.mkdirSync(path.dirname(entry), { recursive: true });
+    fs.writeFileSync(path.join(pluginRoot, 'package.json'), '{}\n');
+    fs.writeFileSync(entry, 'export {};\n');
+    resolved[`plugin-${String(index)}`] = entry;
+  }
+  fs.mkdirSync(apiDirectory, { recursive: true });
+  fs.writeFileSync(statePath, `${JSON.stringify({ resolved })}\n`);
+  fs.writeFileSync(path.join(apiDirectory, 'hub.routes.mjs'), 'export const apis = [];\n');
+  if (options.web !== false) {
+    fs.mkdirSync(webDirectory, { recursive: true });
+    fs.writeFileSync(path.join(webDirectory, 'index.html'), '<!doctype html>');
+    fs.writeFileSync(path.join(generationRoot, 'pluginRoots.json'), `${JSON.stringify(pluginRoots)}\n`);
+  }
+  return {
+    version: 1,
+    root: repositoryRoot,
+    identity: { repositoryId: `repo-${generation}`, worktreeId: `tree-${generation}` },
+    generation,
+    generationRoot,
+    statePath,
+    stateSha256: generation.padEnd(64, '0').slice(0, 64),
+    webDirectory: options.web === false ? null : webDirectory,
+    apiDirectory,
+    package: {
+      root: repositoryRoot,
+      version: '0.0.0-test',
+      manifestPath: path.join(repositoryRoot, 'package.json'),
+      entry: path.join(repositoryRoot, 'dist', 'index.mjs'),
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('live cockpit composition resolution', () => {
+  it('reuses a synchronized composition that already contains the live union', async () => {
+    const firstRoot = path.join(temporaryDirectory('doompi-web-repository-'), 'first');
+    const secondRoot = path.join(temporaryDirectory('doompi-web-repository-'), 'second');
+    const pluginA = path.join(temporaryDirectory('doompi-web-plugin-'), 'a');
+    const pluginB = path.join(temporaryDirectory('doompi-web-plugin-'), 'b');
+    const first = registration(firstRoot, [pluginA], 'one');
+    const second = registration(secondRoot, [pluginB, pluginA], 'two');
+    const registrations = new Map([
+      [firstRoot, first],
+      [secondRoot, second],
+    ]);
+    const bundle = vi.fn();
+
+    const resolved = await resolveWebComposition({
+      repositoryRoots: [secondRoot, firstRoot],
+      stateDirectory: temporaryDirectory('doompi-web-state-'),
+      readRegistration: (root) => registrations.get(root),
+      bundle,
+    });
+
+    expect(bundle).not.toHaveBeenCalled();
+    expect(resolved).toEqual({
+      repositoryRoots: [firstRoot, secondRoot].sort((left, right) => left.localeCompare(right)),
+      webDirectory: second.webDirectory,
+      apiDirectory: second.apiDirectory,
+    });
+  });
+
+  it('builds and caches a disjoint union with both hub API registries', async () => {
+    const firstRoot = path.join(temporaryDirectory('doompi-web-repository-'), 'first');
+    const secondRoot = path.join(temporaryDirectory('doompi-web-repository-'), 'second');
+    const pluginA = path.join(temporaryDirectory('doompi-web-plugin-'), 'a');
+    const pluginB = path.join(temporaryDirectory('doompi-web-plugin-'), 'b');
+    const first = registration(firstRoot, [pluginA], 'one');
+    const second = registration(secondRoot, [pluginB], 'two');
+    const registrations = new Map([
+      [firstRoot, first],
+      [secondRoot, second],
+    ]);
+    const stateDirectory = temporaryDirectory('doompi-web-state-');
+    const bundle = vi.fn(async ({ outDir }: { outDir: string }) => {
+      fs.mkdirSync(path.join(outDir, 'web'), { recursive: true });
+      fs.writeFileSync(path.join(outDir, 'web', 'index.html'), '<!doctype html>');
+      fs.writeFileSync(path.join(outDir, 'webPlugins.server.json'), '[]\n');
+      return { assetsDir: path.join(outDir, 'web'), pluginIds: ['a', 'b'] };
+    });
+
+    const firstResolution = await resolveWebComposition({
+      repositoryRoots: [firstRoot, secondRoot],
+      stateDirectory,
+      readRegistration: (root) => registrations.get(root),
+      bundle,
+    });
+    const secondResolution = await resolveWebComposition({
+      repositoryRoots: [secondRoot, firstRoot],
+      stateDirectory,
+      readRegistration: (root) => registrations.get(root),
+      bundle,
+    });
+
+    expect(bundle).toHaveBeenCalledOnce();
+    expect(bundle).toHaveBeenCalledWith(
+      expect.objectContaining({ pluginRoots: [pluginA, pluginB].sort((left, right) => left.localeCompare(right)) }),
+    );
+    expect(secondResolution).toEqual(firstResolution);
+    const hubRoutes = fs.readFileSync(path.join(firstResolution!.apiDirectory, 'hub.routes.mjs'), 'utf8');
+    expect(hubRoutes).toContain(pathToFileURL(path.join(first.apiDirectory, 'hub.routes.mjs')).href);
+    expect(hubRoutes).toContain(pathToFileURL(path.join(second.apiDirectory, 'hub.routes.mjs')).href);
+  });
+
+  it('builds from synchronized state when the repository did not publish a web bundle', async () => {
+    const repositoryRoot = path.join(temporaryDirectory('doompi-web-repository-'), 'live');
+    const pluginRoot = path.join(temporaryDirectory('doompi-web-plugin-'), 'voice');
+    const synced = registration(repositoryRoot, [pluginRoot], 'one', { web: false });
+    const bundle = vi.fn(async ({ outDir }: { outDir: string }) => {
+      fs.mkdirSync(path.join(outDir, 'web'), { recursive: true });
+      fs.writeFileSync(path.join(outDir, 'web', 'index.html'), '<!doctype html>');
+      fs.writeFileSync(path.join(outDir, 'webPlugins.server.json'), '[]\n');
+      return { assetsDir: path.join(outDir, 'web'), pluginIds: ['voice'] };
+    });
+
+    const resolved = await resolveWebComposition({
+      repositoryRoots: [repositoryRoot],
+      stateDirectory: temporaryDirectory('doompi-web-state-'),
+      readRegistration: () => synced,
+      bundle,
+    });
+
+    expect(bundle).toHaveBeenCalledWith(expect.objectContaining({ pluginRoots: [pluginRoot] }));
+    expect(resolved?.webDirectory).toContain(`${path.sep}compositions${path.sep}`);
+  });
+
+  it('does not consult the launch working directory', async () => {
+    const repositoryRoot = path.join(temporaryDirectory('doompi-web-repository-'), 'live');
+    const pluginRoot = path.join(temporaryDirectory('doompi-web-plugin-'), 'voice');
+    const synced = registration(repositoryRoot, [pluginRoot], 'one');
+    vi.spyOn(process, 'cwd').mockImplementation(() => {
+      throw new Error('launch cwd must not be read');
+    });
+
+    await expect(
+      resolveWebComposition({
+        repositoryRoots: [repositoryRoot],
+        stateDirectory: temporaryDirectory('doompi-web-state-'),
+        readRegistration: () => synced,
+      }),
+    ).resolves.toMatchObject({ webDirectory: synced.webDirectory, apiDirectory: synced.apiDirectory });
+  });
+});

--- a/packages/clients/doompi-web/tests/unit/webPluginManifest.test.ts
+++ b/packages/clients/doompi-web/tests/unit/webPluginManifest.test.ts
@@ -115,14 +115,30 @@ describe('the manifest scanner', () => {
     expect(plugins[0]?.isHost).toBe(false);
   });
 
+  it('accepts an external package that ships its built hub entry without its hub source', () => {
+    const host = pluginPackage({ name: 'host' });
+    const plugin = pluginPackage(
+      {
+        name: 'published',
+        doompiWeb: block({ hub: { entry: './src/hub.ts', dist: './dist/hub.mjs' } }),
+      },
+      ['web/index.ts', 'dist/hub.mjs'],
+    );
+
+    expect(scanWebPlugins(host, [plugin]).map(({ pluginId }) => pluginId)).toEqual(['demo']);
+  });
+
   it('skips a plugin root with a missing entry, a malformed block, or an unreadable manifest, with a notice', () => {
     const host = pluginPackage({ name: 'host' });
     const fine = pluginPackage({ name: 'fine', doompiWeb: block({ pluginId: 'fine' }) });
     const missingClient = pluginPackage({ name: 'p', doompiWeb: block() }, []);
-    const missingHub = pluginPackage({
-      name: 'p',
-      doompiWeb: block({ pluginId: 'hubless', hub: { entry: './src/hub.ts', dist: './dist/hub.mjs' } }),
-    });
+    const missingHub = pluginPackage(
+      {
+        name: 'p',
+        doompiWeb: block({ pluginId: 'hubless', hub: { entry: './src/hub.ts', dist: './dist/hub.mjs' } }),
+      },
+      ['web/index.ts', 'src/hub.ts'],
+    );
     const malformed = pluginPackage({ name: 'p', doompiWeb: block({ pluginId: 'Bad Case' }) });
     const broken = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-broken-'));
     cleanups.push(() => fs.rmSync(broken, { recursive: true, force: true }));
@@ -135,7 +151,7 @@ describe('the manifest scanner', () => {
     expect(plugins.map((p) => p.pluginId)).toEqual(['fine']);
     expect(notices).toHaveLength(4);
     expect(notices[0]).toMatch(/skipped: .*client\.entry '\.\/web\/index\.ts' does not exist/);
-    expect(notices[1]).toMatch(/skipped: .*hub\.entry '\.\/src\/hub\.ts' does not exist/);
+    expect(notices[1]).toMatch(/skipped: .*hub\.dist '\.\/dist\/hub\.mjs' does not exist/);
     expect(notices[2]).toMatch(/skipped: .*kebab-case/);
     expect(notices[3]).toMatch(/skipped: .*package\.json is unreadable/);
   });

--- a/packages/core/doompi-config/src/adapters/piConfig.ts
+++ b/packages/core/doompi-config/src/adapters/piConfig.ts
@@ -1,12 +1,23 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { CONFIG_DIR_NAME, getAgentDir } from '@earendil-works/pi-coding-agent';
 import type { PiConfig, PiConfigLoadOptions, PiConfigPaths } from '../schemas/config/schema.ts';
 
 const SETTINGS_FILE_NAME = 'settings.json';
+const CONFIG_DIR_NAME = '.pi';
+const AGENT_DIR_NAME = 'agent';
+const PI_CODING_AGENT_DIR_ENV = 'PI_CODING_AGENT_DIR';
 const LEGACY_CONFIG_DIR_NAME = 'pi';
 
+function defaultAgentDirectory(homeDirectory: string): string {
+  const fallback = path.join(homeDirectory, CONFIG_DIR_NAME, AGENT_DIR_NAME);
+  if (homeDirectory !== os.homedir()) return fallback;
+  const configured = process.env[PI_CODING_AGENT_DIR_ENV]?.trim();
+  if (!configured) return fallback;
+  if (configured === '~') return homeDirectory;
+  if (configured.startsWith('~/')) return path.join(homeDirectory, configured.slice(2));
+  return path.resolve(configured);
+}
 function isObject(value: unknown): value is PiConfig {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -60,7 +71,7 @@ function projectIsTrusted(value: PiConfigLoadOptions['isProjectTrusted']): boole
 export function piConfigPaths(
   repoRoot: string,
   homeDirectory = os.homedir(),
-  agentDirectory = homeDirectory === os.homedir() ? getAgentDir() : path.join(homeDirectory, CONFIG_DIR_NAME, 'agent'),
+  agentDirectory = defaultAgentDirectory(homeDirectory),
 ): PiConfigPaths {
   return {
     canonicalUser: path.join(agentDirectory, SETTINGS_FILE_NAME),

--- a/packages/core/doompi-config/tests/adapters.test.ts
+++ b/packages/core/doompi-config/tests/adapters.test.ts
@@ -61,6 +61,7 @@ describe('configuration adapters', () => {
       expect(piConfigSource).toContain('trusted');
       expect(schemaSource).toContain('projectTrust');
       expect(piConfigSource).not.toMatch(/\.doom|loadDoomConfig/u);
+      expect(piConfigSource).not.toContain("from '@earendil-works/pi-coding-agent'");
     },
     ADAPTER_IMPORT_TIMEOUT_MS,
   );

--- a/packages/core/doompi/README.md
+++ b/packages/core/doompi/README.md
@@ -76,24 +76,26 @@ dependency closure.
 ### Sync storage and worktrees
 
 DoomPi stores generated sync data under `~/.pi/.doom/sync`, outside the repository. Repository and
-worktree identities select separate namespaces. Each successful sync writes a new immutable generation,
-then atomically publishes that generation's registration as the final commit step. A failed sync removes
-its unpublished generation and leaves the previous registration active. Syncing one repository never
-rewrites another repository's registration or generation.
+worktree identities select separate namespaces. Outside a repository, the canonical `~/.pi/.doom`
+configuration gets its own global composition and registration. Each successful sync writes a new immutable
+generation, then atomically publishes that generation's registration as the final commit step. A failed sync
+removes its unpublished generation and leaves the previous registration active. One sync target never rewrites
+another target's registration or generation.
 
 `dpi` preserves Pi's normal global and repository settings, then applies DoomPi's extension and theme
 settings in memory. It never writes those values to `.pi/settings.json`.
 
 Run `doompi sync --check` to detect missing, invalid, or stale registered state. Unregistered legacy state
-is not loaded. Run `doompi sync` in that repository to publish a current generation.
+is not loaded. Inside a repository, `doompi sync` publishes that repository and worktree. Outside every
+repository, it publishes the global composition from `~/.pi/.doom`.
 
 When you are comfortable with DoomPi and no longer need the side-by-side experiment, initialize the
-normal Pi integration and synchronize each repository you use:
+normal Pi integration and synchronize the scopes you use:
 
 ```bash
 doompi init                                  # seed ~/.pi/.doom and register the managed Pi integration
-doompi sync                                  # publish this repository and worktree's generated runtime
-pi                                           # resolve the nearest synchronized repository at startup
+doompi sync                                  # publish the current repository, or the global composition
+pi                                           # use the nearest repository, otherwise the global composition
 ```
 
 `doompi` remains available as an explicit harness when you want per-run matrix flags:
@@ -691,8 +693,8 @@ its owning package's controls; values supplied by callers are not automatically 
 | -------------------------------------------- | --------------------------------------------------------------------------------- |
 | `dpi init`, `dpi sync`, `dpi`                | Creates, synchronizes, and runs the repository-scoped comparison setup            |
 | `doompi init`                                | Seeds personal config and installs the managed Pi dispatcher, settings, and theme |
-| `doompi sync`                                | Atomically publishes state, web, and API artifacts for one repository/worktree    |
-| `doompi sync --check`                        | Exits non-zero when the repository's registered generation is missing or stale    |
+| `doompi sync`                                | Publishes the current repository, or the global composition outside repositories  |
+| `doompi sync --check`                        | Exits non-zero when the applicable registered generation is missing or stale      |
 | `doompi compat <codex\|claude\|antigravity>` | Resolves the selected matrix and launches the compatibility adapter               |
 | `doom-runner`                                | Inspects and controls supervised Runner processes and logs                        |
 | `--explain`                                  | Prints the resolved matrix and estimated prompt cost without launching Pi         |

--- a/packages/core/doompi/src/adapters/bootstrapLocator.ts
+++ b/packages/core/doompi/src/adapters/bootstrapLocator.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { findRepositoryRoot } from './repository/repository.ts';
+import { resolveDoomConfigurationRoot } from './repository/repository.ts';
 import { readSyncRegistration } from './syncRegistration.ts';
 import { readSyncState } from './syncState.ts';
 import { BUNDLED_PRECOMPILE_STRATEGY, PRECOMPILE_STATE_VERSION } from './syncStateContract.ts';
@@ -178,13 +178,9 @@ function locationHasState(repoRoot: string, homeDirectory: string): boolean {
 
 /** Finds the nearest configured repository with generated Doom sync state. */
 export function findSyncedRoot(cwd: string, homeDirectory: string = os.homedir()): string | undefined {
-  try {
-    if (locationHasState(cwd, homeDirectory)) return canonicalPath(cwd);
-    const root = findRepositoryRoot(cwd);
-    return locationHasState(root, homeDirectory) ? root : undefined;
-  } catch {
-    return undefined;
-  }
+  if (locationHasState(cwd, homeDirectory)) return canonicalPath(cwd);
+  const root = resolveDoomConfigurationRoot(cwd, homeDirectory);
+  return locationHasState(root, homeDirectory) ? canonicalPath(root) : undefined;
 }
 
 function readBootstrapState(repoRoot: string, homeDirectory: string = os.homedir()): BootstrapState | undefined {

--- a/packages/core/doompi/src/adapters/piExtensionDispatcher.ts
+++ b/packages/core/doompi/src/adapters/piExtensionDispatcher.ts
@@ -5,7 +5,7 @@ import { writeFileAtomic } from './serialization/json.ts';
 import { SYNC_REGISTRATION_VERSION } from './syncRegistration.ts';
 
 /** Protocol marker proving that the user package path is managed by DoomPi init. */
-export const PI_DISPATCHER_VERSION = 1;
+export const PI_DISPATCHER_VERSION = 2;
 
 const DISPATCHER_ENTRY = 'dispatcher.mjs';
 const PACKAGE_MANIFEST = 'package.json';
@@ -110,20 +110,19 @@ function registration(root) {
   return value;
 }
 
-function report(pi, message) {
-  pi.on('session_start', (_event, context) => context.ui.notify(\`doompi could not load this repository: \${message}. Run doompi init, then doompi sync.\`, WARNING));
+function report(pi, target, message) {
+  pi.on('session_start', (_event, context) => context.ui.notify(\`doompi could not load \${target}: \${message}. Run doompi init, then doompi sync.\`, WARNING));
 }
-
 export default async function doompiDispatcher(pi) {
-  const root = repositoryRoot(process.cwd());
-  if (!root) return;
+  const repository = repositoryRoot(process.cwd());
   try {
+    const root = repository ?? canonical(path.join(os.homedir(), '.pi', '.doom'));
     const record = registration(root);
     const loaded = await import(pathToFileURL(record.package.entry).href);
     if (typeof loaded.default !== 'function') throw new Error('recorded package entry has no extension factory');
     await loaded.default(pi);
   } catch (error) {
-    report(pi, error instanceof Error ? error.message : String(error));
+    report(pi, repository ? 'this repository' : 'the global composition', error instanceof Error ? error.message : String(error));
   }
 }
 `;
@@ -134,16 +133,27 @@ export function piExtensionDispatcherPath(piDirectory: string): string {
   return path.join(piDirectory, ...DOOM_PACKAGE_NAME.split('/'));
 }
 
-function managedManifest(directory: string): boolean {
+function managedManifestVersion(directory: string): number | undefined {
   try {
     const parsed = JSON.parse(fs.readFileSync(path.join(directory, PACKAGE_MANIFEST), 'utf8')) as {
       name?: unknown;
       doompiDispatcher?: unknown;
     };
-    return parsed.name === DOOM_PACKAGE_NAME && parsed.doompiDispatcher === PI_DISPATCHER_VERSION;
+    return parsed.name === DOOM_PACKAGE_NAME && Number.isSafeInteger(parsed.doompiDispatcher)
+      ? (parsed.doompiDispatcher as number)
+      : undefined;
   } catch {
-    return false;
+    return undefined;
   }
+}
+
+function managedManifest(directory: string): boolean {
+  return managedManifestVersion(directory) === PI_DISPATCHER_VERSION;
+}
+
+function upgradeableManagedManifest(directory: string): boolean {
+  const version = managedManifestVersion(directory);
+  return version !== undefined && version > 0 && version <= PI_DISPATCHER_VERSION;
 }
 
 /** Whether init's dispatcher package has a supported protocol and complete entry. */
@@ -171,7 +181,7 @@ export function writePiExtensionDispatcher(piDirectory: string): string {
       throw new Error(`Refusing to replace unmanaged Pi extension path: ${directory}`);
     }
     fs.rmSync(directory, { force: true });
-  } else if (current && (!current.isDirectory() || !managedManifest(directory))) {
+  } else if (current && (!current.isDirectory() || !upgradeableManagedManifest(directory))) {
     throw new Error(`Refusing to replace unmanaged Pi extension path: ${directory}`);
   }
 

--- a/packages/core/doompi/src/adapters/repository/repository.ts
+++ b/packages/core/doompi/src/adapters/repository/repository.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { globalDoomConfigDirectory } from '@agimon-ai/doompi-config/config';
 
 /** Doom's own repository configuration directory. */
 const DOOM_DIRECTORY = '.doom';
@@ -56,5 +57,14 @@ export function findRepositoryRoot(start: string): string {
     const parent = path.dirname(directory);
     if (parent === directory) throw new Error(`Could not find repository root from ${start}`);
     directory = parent;
+  }
+}
+
+/** Uses the nearest repository when one exists, otherwise the user's global Doom composition. */
+export function resolveDoomConfigurationRoot(start: string, homeDirectory: string): string {
+  try {
+    return findRepositoryRoot(start);
+  } catch {
+    return globalDoomConfigDirectory(homeDirectory);
   }
 }

--- a/packages/core/doompi/src/commands/buildCommand.ts
+++ b/packages/core/doompi/src/commands/buildCommand.ts
@@ -18,7 +18,7 @@ import type { HarnessTelemetry } from '../adapters/telemetry/logSinkTelemetry.ts
 import { loadDomains } from '@agimon-ai/doompi-config/domains';
 import { loadMajorModesConfig } from '@agimon-ai/doompi-config/majorModes';
 import { createLayerResolvers } from '../services/extensionAssembler.ts';
-import { findRepositoryRoot } from '../adapters/repository/repository';
+import { resolveDoomConfigurationRoot } from '../adapters/repository/repository';
 import { parseHarnessArgs } from './cli/options.ts';
 import { selectionEnvironment } from './syncCommand.ts';
 
@@ -44,10 +44,11 @@ function syncStateIsCurrent(
   state: SyncState,
   majorModesConfig: MajorModesConfig,
   compositionFingerprint: string,
+  homeDirectory: string,
 ): boolean {
   if (!syncStateRootMatches(repoRoot, state.root)) return false;
   if (state.compositionFingerprint !== compositionFingerprint) return false;
-  if (computeInputsHash(repoRoot, state.selection) !== state.inputsHash) return false;
+  if (computeInputsHash(repoRoot, state.selection, homeDirectory) !== state.inputsHash) return false;
   const resolved = recordResolvedEntries(majorModesConfig, createLayerResolvers(repoRoot));
   return JSON.stringify(resolved) === JSON.stringify(state.resolved);
 }
@@ -89,16 +90,18 @@ export class BuildCommand {
     currentDirectory = process.cwd(),
     output: BuildOutput = process.stdout,
   ): Promise<number> {
-    const inheritedRoot = environment[HARNESS_ROOT_ENV];
-    const repoRoot = inheritedRoot ? path.resolve(inheritedRoot) : findRepositoryRoot(currentDirectory);
     const homeDirectory = environment.HOME ?? os.homedir();
+    const inheritedRoot = environment[HARNESS_ROOT_ENV];
+    const repoRoot = inheritedRoot
+      ? path.resolve(inheritedRoot)
+      : resolveDoomConfigurationRoot(currentDirectory, homeDirectory);
     const location = resolveSyncLocation(repoRoot, homeDirectory);
     const parsed = parseHarnessArgs(
       args.slice(1),
       selectionEnvironment(repoRoot, environment),
       currentDirectory,
-      loadMajorModesConfig(repoRoot).defaultMajorMode,
-      loadDomains(repoRoot).defaultDomains,
+      loadMajorModesConfig(repoRoot, homeDirectory).defaultMajorMode,
+      loadDomains(repoRoot, homeDirectory).defaultDomains,
     );
     const context = await buildHarnessContext({ ...parsed.options, repoRoot, homeDirectory }, this.telemetry);
     try {
@@ -118,7 +121,10 @@ export class BuildCommand {
         // An obsolete state must not prevent that repair path from completing.
         syncState = undefined;
       }
-      if (syncState && syncStateIsCurrent(repoRoot, syncState, context.majorModesConfig, built.fingerprint)) {
+      if (
+        syncState &&
+        syncStateIsCurrent(repoRoot, syncState, context.majorModesConfig, built.fingerprint, homeDirectory)
+      ) {
         const { buildSyncedRuntime } = await import('../adapters/syncedRuntimeBuilder.ts');
         synced = await buildSyncedRuntime(repoRoot, environment, homeDirectory);
       }

--- a/packages/core/doompi/src/commands/syncCommand.ts
+++ b/packages/core/doompi/src/commands/syncCommand.ts
@@ -52,7 +52,7 @@ import { DEFAULT_THEME, DEFAULT_THEME_NAME } from '@agimon-ai/doompi-ui/theme';
 import { loadDoomConfig } from '../services/config/projectTrust';
 import { createLayerResolvers, PERSONA_ENTRY, resolveExtensionComposition } from '../services/extensionAssembler.ts';
 import type { HarnessOptions } from '../types/interfaces/harness';
-import { findRepositoryRoot } from '../adapters/repository/repository';
+import { resolveDoomConfigurationRoot } from '../adapters/repository/repository';
 import { DOOMPI_DOMAINS_ENV, DOOMPI_MAJOR_MODE_ENV, DOOMPI_PROFILE_ENV } from './cli/matrixOptions.ts';
 import { parseHarnessArgs } from './cli/options.ts';
 import { SyncProgress, type SyncProgressOutput } from './syncPresenter.ts';
@@ -414,9 +414,11 @@ export class SyncCommand {
     const check = args.includes(CHECK_OPTION);
     const force = args.includes(FORCE_OPTION);
     const rest = args.slice(1).filter((argument) => argument !== CHECK_OPTION && argument !== FORCE_OPTION);
-    const inheritedRoot = environment[HARNESS_ROOT_ENV];
-    const repoRoot = inheritedRoot ? path.resolve(inheritedRoot) : findRepositoryRoot(currentDirectory);
     const homeDirectory = this.homeDirectory ?? environment.HOME ?? os.homedir();
+    const inheritedRoot = environment[HARNESS_ROOT_ENV];
+    const repoRoot = inheritedRoot
+      ? path.resolve(inheritedRoot)
+      : resolveDoomConfigurationRoot(currentDirectory, homeDirectory);
     const defaultMajorMode = loadMajorModesConfig(repoRoot, homeDirectory).defaultMajorMode;
     const defaultDomains = loadDomains(repoRoot, homeDirectory).defaultDomains;
     const parsed = parseHarnessArgs(

--- a/packages/core/doompi/src/commands/syncPipeline.ts
+++ b/packages/core/doompi/src/commands/syncPipeline.ts
@@ -2,7 +2,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { loadMajorModesConfig } from '@agimon-ai/doompi-config/majorModes';
 import { ensureLayerPackages, type LayerPackageResult } from '../adapters/layerPackageInstaller.ts';
-import { findRepositoryRoot } from '../adapters/repository/repository';
+import { resolveDoomConfigurationRoot } from '../adapters/repository/repository';
 import type { HarnessTelemetry } from '../adapters/telemetry/logSinkTelemetry.ts';
 import { acquireSyncLocationLock, resolveSyncLocation } from '../adapters/syncLocation.ts';
 import { readSyncDrift } from '../adapters/syncDrift.ts';
@@ -56,9 +56,11 @@ export class SyncPipeline {
       return new SyncCommand({ settingsMode: this.settingsMode }).execute(args, environment, currentDirectory, output);
     }
 
-    const inheritedRoot = environment[HARNESS_ROOT_ENV];
-    const repoRoot = inheritedRoot ? path.resolve(inheritedRoot) : findRepositoryRoot(currentDirectory);
     const homeDirectory = environment.HOME ?? os.homedir();
+    const inheritedRoot = environment[HARNESS_ROOT_ENV];
+    const repoRoot = inheritedRoot
+      ? path.resolve(inheritedRoot)
+      : resolveDoomConfigurationRoot(currentDirectory, homeDirectory);
 
     // Nothing drifted means the packages are current, the mode extension is
     // compiled from these exact bytes, and the published generation already
@@ -112,9 +114,12 @@ export class SyncPipeline {
     currentDirectory: string,
     progress: SyncProgress,
   ): Promise<void> {
+    const homeDirectory = environment.HOME ?? os.homedir();
     const inheritedRoot = environment[HARNESS_ROOT_ENV];
-    const repoRoot = inheritedRoot ? path.resolve(inheritedRoot) : findRepositoryRoot(currentDirectory);
-    const config = loadMajorModesConfig(repoRoot);
+    const repoRoot = inheritedRoot
+      ? path.resolve(inheritedRoot)
+      : resolveDoomConfigurationRoot(currentDirectory, homeDirectory);
+    const config = loadMajorModesConfig(repoRoot, homeDirectory);
     const done = progress.start(PACKAGES_LABEL, 'checking configured packages for updates');
     const result = await ensureLayerPackages({
       repoRoot,

--- a/packages/core/doompi/tests/commands/buildCommand.test.ts
+++ b/packages/core/doompi/tests/commands/buildCommand.test.ts
@@ -40,7 +40,9 @@ vi.mock('../../src/adapters/syncState.ts', () => ({
 vi.mock('../../src/services/extensionAssembler.ts', () => ({
   createLayerResolvers: mocks.createLayerResolvers,
 }));
-vi.mock('../../src/adapters/repository/repository.ts', () => ({ findRepositoryRoot: mocks.findRepositoryRoot }));
+vi.mock('../../src/adapters/repository/repository.ts', () => ({
+  resolveDoomConfigurationRoot: mocks.findRepositoryRoot,
+}));
 vi.mock('../../src/commands/syncCommand.ts', () => ({ selectionEnvironment: mocks.selectionEnvironment }));
 vi.mock('../../src/adapters/projectPiSettings.ts', () => ({
   DUPLICATE_REGISTRATION_DRIFT: 'duplicate DoomPi registration in .pi/settings.json',
@@ -165,7 +167,7 @@ describe('BuildCommand', () => {
 
     await new BuildCommand().execute(['build'], { DOOMPI_ROOT: '/repo' }, '/repo', output);
 
-    expect(mocks.computeInputsHash).toHaveBeenCalledWith('/repo', syncedState.selection);
+    expect(mocks.computeInputsHash).toHaveBeenCalledWith('/repo', syncedState.selection, expect.any(String));
     expect(mocks.recordResolvedEntries).toHaveBeenCalledWith(majorModesConfig, layerResolvers);
     expect(mocks.buildSyncedRuntime).toHaveBeenCalledWith('/repo', { DOOMPI_ROOT: '/repo' }, expect.any(String));
     expect(text()).toContain('bootstrap.hash.mjs');
@@ -259,7 +261,7 @@ describe('BuildCommand', () => {
       'compile failed',
     );
 
-    expect(mocks.findRepositoryRoot).toHaveBeenCalledWith('/work');
+    expect(mocks.findRepositoryRoot).toHaveBeenCalledWith('/work', expect.any(String));
     expect(cleanup).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/doompi/tests/commands/syncCommand.test.ts
+++ b/packages/core/doompi/tests/commands/syncCommand.test.ts
@@ -107,6 +107,33 @@ function makeGitRepositoryWithPersonalConfig(): string {
   return root;
 }
 
+function makeGlobalConfiguration(): {
+  root: string;
+  homeDirectory: string;
+  currentDirectory: string;
+  environment: NodeJS.ProcessEnv;
+} {
+  const fixture = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'doom-sync-global-')));
+  temporaryRoots.push(fixture);
+  const homeDirectory = path.join(fixture, 'home');
+  const root = path.join(homeDirectory, '.pi', '.doom');
+  const currentDirectory = path.join(fixture, 'Documents');
+  fs.mkdirSync(root, { recursive: true });
+  fs.mkdirSync(currentDirectory, { recursive: true });
+  fs.writeFileSync(path.join(root, 'modes.yaml'), LAYERS);
+  fs.writeFileSync(
+    path.join(root, 'domains.yaml'),
+    'defaultDomains: [default]\ndomains:\n  default:\n    plugins: []\n',
+  );
+  fs.writeFileSync(path.join(root, 'config.yaml'), 'projectTrust: ask\n');
+  initializePiFixture(root);
+  return {
+    root,
+    homeDirectory,
+    currentDirectory,
+    environment: { HOME: homeDirectory, PI_CODING_AGENT_DIR: agentDirectory(root) },
+  };
+}
 function agentDirectory(root: string): string {
   return path.join(root, '.pi-user');
 }
@@ -418,6 +445,19 @@ describe('doompi sync', { timeout: 30_000 }, () => {
     expect(fs.existsSync(path.join(root, '.doom'))).toBe(false);
     expect(text()).toContain('mode:     copilot');
     expect(readSyncState(root, homeDirectory)?.selection).toEqual(SELECTION);
+  });
+
+  it('publishes the global composition when invoked outside a repository', async () => {
+    const fixture = makeGlobalConfiguration();
+    vi.stubEnv('HOME', fixture.homeDirectory);
+    const { output, text } = capture();
+
+    const code = await new SyncCommand().execute(['sync'], fixture.environment, fixture.currentDirectory, output);
+
+    expect(code).toBe(0);
+    expect(readSyncState(fixture.root, fixture.homeDirectory)?.root).toBe(fixture.root);
+    expect(readSyncRegistration(fixture.root, fixture.homeDirectory)?.root).toBe(fixture.root);
+    expect(text()).toContain('mode:     copilot');
   });
 
   it('stages and precompiles the matrix before registering DoomPi in Pi user settings', async () => {

--- a/packages/core/doompi/tests/commands/syncPipeline.test.ts
+++ b/packages/core/doompi/tests/commands/syncPipeline.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   buildExecute: vi.fn(),
@@ -31,7 +34,11 @@ import { SyncPipeline } from '../../src/commands/syncPipeline.ts';
 
 const environment = { DOOMPI_ROOT: '/repo' };
 const output = { write: vi.fn((_chunk: string) => true) };
+const temporaryRoots: string[] = [];
 
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
 describe('SyncPipeline', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -78,6 +85,36 @@ describe('SyncPipeline', () => {
       expect.objectContaining({ settingsMode: 'embedded', lockHeld: true }),
     );
     expect(mocks.syncExecute).toHaveBeenCalledWith(['sync', '--major-mode', 'minimal'], environment, '/repo', output);
+  });
+
+  it('uses the global Doom configuration when the current directory has no repository', async () => {
+    const fixture = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'doom-sync-pipeline-global-')));
+    temporaryRoots.push(fixture);
+    const homeDirectory = path.join(fixture, 'home');
+    const globalRoot = path.join(homeDirectory, '.pi', '.doom');
+    const currentDirectory = path.join(fixture, 'Documents');
+    fs.mkdirSync(globalRoot, { recursive: true });
+    fs.mkdirSync(currentDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(globalRoot, 'modes.yaml'),
+      'layers: {}\ndefaultMajorMode: minimal\nmajorMode:\n  minimal: []\n',
+    );
+    const globalEnvironment = { HOME: homeDirectory };
+
+    await expect(
+      new SyncPipeline().execute(['sync', '--force'], globalEnvironment, currentDirectory, output),
+    ).resolves.toBe(0);
+
+    expect(mocks.ensureLayerPackages).toHaveBeenCalledWith(
+      expect.objectContaining({ repoRoot: globalRoot, environment: globalEnvironment }),
+    );
+    expect(mocks.buildExecute).toHaveBeenCalledWith(
+      ['build', '--force'],
+      globalEnvironment,
+      currentDirectory,
+      expect.any(Object),
+    );
+    expect(mocks.syncExecute).toHaveBeenCalledWith(['sync', '--force'], globalEnvironment, currentDirectory, output);
   });
 
   it('keeps check mode read-only by skipping the package refresh and the build', async () => {

--- a/packages/core/doompi/tests/services/packageBootstrap.test.ts
+++ b/packages/core/doompi/tests/services/packageBootstrap.test.ts
@@ -35,15 +35,15 @@ function homeFor(root: string): string {
   return path.join(root, 'home');
 }
 
-function generationDirectory(root: string): string {
-  return syncGenerationDirectory(resolveSyncLocation(root, homeFor(root)), 'test-generation');
+function generationDirectory(root: string, homeDirectory: string = homeFor(root)): string {
+  return syncGenerationDirectory(resolveSyncLocation(root, homeDirectory), 'test-generation');
 }
 
-function validState(root: string, bootstrap?: string): Record<string, unknown> {
+function validState(root: string, bootstrap?: string, homeDirectory: string = homeFor(root)): Record<string, unknown> {
   return {
     version: SYNC_STATE_VERSION,
     root,
-    identity: resolveSyncLocation(root, homeFor(root)).identity,
+    identity: resolveSyncLocation(root, homeDirectory).identity,
     inputsHash: 'hash',
     compositionFingerprint: TEST_COMPOSITION_FINGERPRINT,
     selection: { majorMode: 'copilot', domains: ['default'], preset: 'default' },
@@ -55,9 +55,9 @@ function validState(root: string, bootstrap?: string): Record<string, unknown> {
   };
 }
 
-function writeStateText(root: string, text: string): void {
-  const location = resolveSyncLocation(root, homeFor(root));
-  const generationRoot = generationDirectory(root);
+function writeStateText(root: string, text: string, homeDirectory: string = homeFor(root)): void {
+  const location = resolveSyncLocation(root, homeDirectory);
+  const generationRoot = generationDirectory(root, homeDirectory);
   const statePath = path.join(generationRoot, 'state.json');
   const apiDirectory = path.join(generationRoot, 'api');
   const packageRoot = path.join(root, 'doompi-package');
@@ -84,12 +84,12 @@ function writeStateText(root: string, text: string): void {
       apiDirectory,
       package: { root: packageRoot, version: 'test', manifestPath: path.join(packageRoot, 'package.json'), entry },
     },
-    homeFor(root),
+    homeDirectory,
   );
 }
 
-function writeState(root: string, state: unknown): void {
-  writeStateText(root, JSON.stringify(state));
+function writeState(root: string, state: unknown, homeDirectory: string = homeFor(root)): void {
+  writeStateText(root, JSON.stringify(state), homeDirectory);
 }
 
 function writeFreshBuild(root: string): { artifact: string; input: string; manifest: string } {
@@ -139,6 +139,18 @@ describe('package bootstrap locator', () => {
     writeState(root, validState(root));
 
     expect(findSyncedRoot(nested, homeFor(root))).toBe(root);
+  });
+
+  it('uses the global synchronized composition outside repositories', () => {
+    const fixture = temporaryRoot();
+    const homeDirectory = path.join(fixture, 'home-global');
+    const globalRoot = path.join(homeDirectory, '.pi', '.doom');
+    const currentDirectory = path.join(fixture, 'Documents');
+    fs.mkdirSync(globalRoot, { recursive: true });
+    fs.mkdirSync(currentDirectory, { recursive: true });
+    writeState(globalRoot, validState(globalRoot, undefined, homeDirectory), homeDirectory);
+
+    expect(findSyncedRoot(currentDirectory, homeDirectory)).toBe(globalRoot);
   });
 
   it('keeps the nearest unsynced repository from inheriting parent state', () => {

--- a/packages/core/doompi/tests/services/piExtensionAlias.test.ts
+++ b/packages/core/doompi/tests/services/piExtensionAlias.test.ts
@@ -1,14 +1,22 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { DefaultPackageManager, SettingsManager } from '@earendil-works/pi-coding-agent';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   doomPiPackageRoot,
   piExtensionAliasIsCurrent,
   piExtensionAliasPath,
   writePiExtensionAlias,
 } from '../../src/adapters/piExtensionAlias';
+import { PI_DISPATCHER_VERSION } from '../../src/adapters/piExtensionDispatcher.ts';
+import {
+  publishSyncRegistration,
+  SYNC_REGISTRATION_VERSION,
+  syncStateSha256,
+} from '../../src/adapters/syncRegistration.ts';
+import { resolveSyncLocation, syncGenerationDirectory } from '../../src/adapters/syncLocation.ts';
 
 const temporaryRoots: string[] = [];
 
@@ -25,6 +33,7 @@ function fakePackage(root: string, name = '@agimon-ai/doompi'): string {
 }
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   for (const root of temporaryRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 });
 
@@ -76,6 +85,73 @@ describe('Pi extension dispatcher package', () => {
     ]);
   });
 
+  it('loads the global registration when Pi starts outside a repository', async () => {
+    const fixture = temporaryRoot();
+    const homeDirectory = path.join(fixture, 'home');
+    const globalRoot = path.join(homeDirectory, '.pi', '.doom');
+    const currentDirectory = path.join(fixture, 'Documents');
+    const agentDirectory = path.join(fixture, 'agent');
+    const packageRoot = path.join(fixture, 'install', 'doompi');
+    const manifestPath = path.join(packageRoot, 'package.json');
+    const entry = path.join(packageRoot, 'extension.mjs');
+    fs.mkdirSync(globalRoot, { recursive: true });
+    fs.mkdirSync(currentDirectory, { recursive: true });
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(
+      manifestPath,
+      `${JSON.stringify({
+        name: '@agimon-ai/doompi',
+        version: 'test',
+        pi: { extensions: ['./extension.mjs'] },
+      })}\n`,
+    );
+    fs.writeFileSync(entry, 'export default (pi) => pi.loaded();\n');
+
+    const location = resolveSyncLocation(globalRoot, homeDirectory);
+    const generation = 'global-test';
+    const generationRoot = syncGenerationDirectory(location, generation);
+    const statePath = path.join(generationRoot, 'state.json');
+    const apiDirectory = path.join(generationRoot, 'api');
+    fs.mkdirSync(apiDirectory, { recursive: true });
+    fs.writeFileSync(statePath, '{}\n');
+    publishSyncRegistration(
+      globalRoot,
+      {
+        version: SYNC_REGISTRATION_VERSION,
+        root: location.root,
+        identity: location.identity,
+        generation,
+        generationRoot,
+        statePath,
+        stateSha256: syncStateSha256(statePath),
+        webDirectory: null,
+        apiDirectory,
+        package: { root: packageRoot, version: 'test', manifestPath, entry },
+      },
+      homeDirectory,
+    );
+    const dispatcherPath = writePiExtensionAlias(agentDirectory, packageRoot);
+    vi.stubEnv('HOME', homeDirectory);
+    const previousDirectory = process.cwd();
+    const loaded = vi.fn();
+    const on = vi.fn();
+
+    try {
+      process.chdir(currentDirectory);
+      const dispatcher = (await import(
+        `${pathToFileURL(path.join(dispatcherPath, 'dispatcher.mjs')).href}?global`
+      )) as {
+        default: (pi: { loaded: () => void; on: typeof on }) => Promise<void>;
+      };
+      await dispatcher.default({ loaded, on });
+    } finally {
+      process.chdir(previousDirectory);
+    }
+
+    expect(loaded).toHaveBeenCalledOnce();
+    expect(on).not.toHaveBeenCalled();
+  });
+
   it('migrates a legacy DoomPi package link', () => {
     const root = temporaryRoot();
     const packageRoot = fakePackage(path.join(root, 'install', 'doompi'));
@@ -90,6 +166,25 @@ describe('Pi extension dispatcher package', () => {
     expect(piExtensionAliasIsCurrent(root)).toBe(true);
   });
 
+  it('upgrades an init-owned dispatcher from an earlier protocol', () => {
+    const root = temporaryRoot();
+    const packageRoot = fakePackage(path.join(root, 'install', 'doompi'));
+    const dispatcherPath = piExtensionAliasPath(root);
+    fs.mkdirSync(dispatcherPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(dispatcherPath, 'package.json'),
+      `${JSON.stringify({ name: '@agimon-ai/doompi', doompiDispatcher: 1 })}\n`,
+    );
+    fs.writeFileSync(path.join(dispatcherPath, 'dispatcher.mjs'), 'stale\n');
+
+    writePiExtensionAlias(root, packageRoot);
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(dispatcherPath, 'package.json'), 'utf8')) as {
+      doompiDispatcher?: unknown;
+    };
+    expect(manifest.doompiDispatcher).toBe(PI_DISPATCHER_VERSION);
+    expect(piExtensionAliasIsCurrent(root)).toBe(true);
+  });
   it('does not replace an unmanaged path', () => {
     const root = temporaryRoot();
     const packageRoot = fakePackage(path.join(root, 'install', 'doompi'));

--- a/packages/core/doompi/tests/system/packInstall.system.test.ts
+++ b/packages/core/doompi/tests/system/packInstall.system.test.ts
@@ -2109,7 +2109,7 @@ describe('RPC-LIFECYCLE installed runtime', () => {
       expect(fs.lstatSync(dispatcher).isSymbolicLink()).toBe(false);
       expect(JSON.parse(fs.readFileSync(path.join(dispatcher, 'package.json'), 'utf8'))).toMatchObject({
         name: '@agimon-ai/doompi',
-        doompiDispatcher: 1,
+        doompiDispatcher: 2,
       });
       expect(fs.statSync(path.join(dispatcher, 'dispatcher.mjs')).isFile()).toBe(true);
       const statePath = packedSyncStatePath(fixture.root, environment);


### PR DESCRIPTION
## Summary

- make the web cockpit compose live registered repositories independently of launch CWD, with an explicit `--dir` pinning mode
- validate synchronized web plugins from their published hub artifacts and refresh served compositions after sync
- make `doompi sync`, bootstrap lookup, and the managed Pi dispatcher fall back to `~/.pi/.doom` outside repositories
- upgrade older managed dispatcher protocols safely and keep the config package loadable by standalone package API hosts

## Verification

- `pnpm runner:check`
- `pnpm audit:workspace`
- `pnpm fmt:check`
- `pnpm hooks:check`
- `pnpm nx run-many -t build --parallel=3`
- `pnpm examples:check`
- `pnpm nx run-many -t lint --parallel=3`
- `pnpm lint:vibe --preflight-only`
- `pnpm nx run-many -t typecheck --parallel=3`
- `pnpm nx run-many -t test --parallel=1`
- `pnpm cockpit:build`
- `pnpm nx run @agimon-ai/doompi-web:test:e2e`
- `pnpm nx run-many -t test-system --parallel=1`
- `pnpm audit --prod --audit-level high`
- `pnpm audit signatures`
- frozen install with lifecycle scripts disabled
- zizmor 1.29.0 high-confidence, high-severity workflow scan
- TruffleHog 3.97.1 verified-secret scan over this branch

## Manual verification

- synchronized the global composition from outside a repository
- confirmed plain `pi` outside a repository accepts a DoomPi extension flag
- confirmed agirepo Voice enters autonomous capture in the browser
- confirmed TUI Voice transcription succeeds
