### PR TITLE
fix(doompi-web): dedupe sealed transport runtime

### DIFF
--- a/packages/clients/doompi-web/src/adapters/webBundler.ts
+++ b/packages/clients/doompi-web/src/adapters/webBundler.ts
@@ -12,6 +12,9 @@ const DEDUPED_RUNTIMES = [
   '@tanstack/store',
   '@tanstack/react-store',
   '@agimon-ai/doompi-web-components',
+  // The sealed transport is a module singleton whose nonce counters every
+  // plugin shares; a second copy would start counting at zero.
+  '@agimon-ai/doompi-web-security',
   // CodeMirror's state and view are singletons in all but name: a document
   // built against one copy is rejected by an editor from the other, and a
   // grammar chunk resolved separately from the editor is exactly how a second

--- a/packages/clients/doompi-web/src/adapters/webComposition.ts
+++ b/packages/clients/doompi-web/src/adapters/webComposition.ts
@@ -11,7 +11,7 @@ const INDEX_FILE = 'index.html';
 const HUB_ROUTES_FILE = 'hub.routes.mjs';
 const SESSION_ROUTES_FILE = 'session.routes.mjs';
 const COMPOSITIONS_DIRECTORY = 'compositions';
-const COMPOSITION_CACHE_VERSION = 2;
+const COMPOSITION_CACHE_VERSION = 3;
 export interface ResolvedWebComposition {
   /** The synchronized repositories represented in this cockpit bundle. */
   repositoryRoots: readonly string[];

--- a/packages/clients/doompi-web/tests/fixtures/security-singleton-plugin/package.json
+++ b/packages/clients/doompi-web/tests/fixtures/security-singleton-plugin/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@agimon-ai/doompi-security-singleton-fixture",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@agimon-ai/doompi-web-security": "0.0.1-alpha.7"
+  },
+  "doompiWeb": {
+    "pluginId": "security-singleton-probe",
+    "client": "./src/exports/webClient.ts"
+  }
+}

--- a/packages/clients/doompi-web/tests/fixtures/security-singleton-plugin/src/exports/webClient.ts
+++ b/packages/clients/doompi-web/tests/fixtures/security-singleton-plugin/src/exports/webClient.ts
@@ -1,0 +1,8 @@
+import { sealedTransport } from '@agimon-ai/doompi-web-security/browser';
+
+export const webPlugin = {
+  id: 'security-singleton-probe',
+  start() {
+    sealedTransport.active();
+  },
+};

--- a/packages/clients/doompi-web/tests/integration/webBundler.test.ts
+++ b/packages/clients/doompi-web/tests/integration/webBundler.test.ts
@@ -9,6 +9,8 @@ import { loadHubChannels } from '../../src/adapters/webHubPluginLoader.ts';
 const workflowRoot = fileURLToPath(new URL('../../../../minor/doompi-workflow', import.meta.url));
 const planRoot = fileURLToPath(new URL('../../../../minor/doompi-plan', import.meta.url));
 const teamRoot = fileURLToPath(new URL('../../../../../layers/team/doompi-team', import.meta.url));
+const securityPackageRoot = fileURLToPath(new URL('../../../../core/doompi-web-security', import.meta.url));
+const securitySingletonFixtureRoot = fileURLToPath(new URL('../fixtures/security-singleton-plugin', import.meta.url));
 
 function bundledJsHas(assetsDir: string, needle: string): boolean {
   return fs
@@ -33,6 +35,55 @@ function brokenPackage(manifest: Record<string, unknown>): string {
   cleanups.push(() => fs.rmSync(root, { recursive: true, force: true }));
   fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(manifest));
   return root;
+}
+
+interface InstalledSecuritySingletonPlugin {
+  pluginRoot: string;
+  physicalSecurityRoot: string;
+  publicSecurityRoot: string;
+}
+
+/** Reproduces an installed plugin resolving its own physical security package copy. */
+function installedSecuritySingletonPlugin(): InstalledSecuritySingletonPlugin {
+  const pluginRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-web-security-singleton-'));
+  cleanups.push(() => fs.rmSync(pluginRoot, { recursive: true, force: true }));
+  fs.cpSync(securitySingletonFixtureRoot, pluginRoot, { recursive: true });
+
+  const sourceManifestPath = path.join(securityPackageRoot, 'package.json');
+  const sourceManifest = JSON.parse(fs.readFileSync(sourceManifestPath, 'utf8')) as {
+    version?: unknown;
+    exports?: Record<string, unknown>;
+  };
+  if (typeof sourceManifest.version !== 'string') throw new Error('The security fixture needs a package version.');
+  const physicalSecurityRoot = path.join(
+    pluginRoot,
+    'node_modules',
+    '.pnpm',
+    `@agimon-ai+doompi-web-security@${sourceManifest.version}`,
+    'node_modules',
+    '@agimon-ai',
+    'doompi-web-security',
+  );
+  fs.mkdirSync(physicalSecurityRoot, { recursive: true });
+  fs.copyFileSync(sourceManifestPath, path.join(physicalSecurityRoot, 'package.json'));
+  fs.cpSync(path.join(securityPackageRoot, 'dist'), path.join(physicalSecurityRoot, 'dist'), { recursive: true });
+
+  const wrapperPath = path.join(physicalSecurityRoot, 'dist', 'browser-probe.mjs');
+  fs.writeFileSync(
+    wrapperPath,
+    "globalThis['__doompi_physical_security_copy__'] = true;\nexport * from './browser.mjs';\n",
+  );
+  const browserExport = sourceManifest.exports?.['./browser'];
+  if (typeof browserExport !== 'object' || browserExport === null || Array.isArray(browserExport)) {
+    throw new Error('The security fixture needs the ./browser export.');
+  }
+  (browserExport as Record<string, unknown>).import = './dist/browser-probe.mjs';
+  fs.writeFileSync(path.join(physicalSecurityRoot, 'package.json'), `${JSON.stringify(sourceManifest, null, 2)}\n`);
+
+  const publicSecurityRoot = path.join(pluginRoot, 'node_modules', '@agimon-ai', 'doompi-web-security');
+  fs.mkdirSync(path.dirname(publicSecurityRoot), { recursive: true });
+  fs.symlinkSync(physicalSecurityRoot, publicSecurityRoot, 'dir');
+  return { pluginRoot, physicalSecurityRoot, publicSecurityRoot };
 }
 
 afterEach(() => {
@@ -99,6 +150,22 @@ describe('the sync-time cockpit bundler', () => {
       'workflow_runs',
       'workflow_catalog',
     ]);
+  });
+
+  it('resolves an installed plugin to the host sealed transport singleton', { timeout: 120_000 }, async () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-web-security-bundle-'));
+    cleanups.push(() => fs.rmSync(outDir, { recursive: true, force: true }));
+    const installed = installedSecuritySingletonPlugin();
+
+    expect(fs.realpathSync(installed.publicSecurityRoot)).toBe(fs.realpathSync(installed.physicalSecurityRoot));
+    expect(fs.realpathSync(installed.physicalSecurityRoot)).not.toBe(fs.realpathSync(securityPackageRoot));
+
+    const result = await bundleCockpitWeb({ pluginRoots: [installed.pluginRoot], outDir });
+
+    expect(result.pluginIds).toContain('security-singleton-probe');
+    expect(bundledJsHas(result.assetsDir, 'security-singleton-probe')).toBe(true);
+    expect(bundledJsHas(result.assetsDir, '__doompi_physical_security_copy__')).toBe(false);
+    expect(bundledJsHas(result.assetsDir, '@agimon-ai/doompi-web-security/browser')).toBe(false);
   });
 
   it('serves zero channels for assets without a registry, since nothing is built in', async () => {

--- a/packages/clients/doompi-web/vite.config.ts
+++ b/packages/clients/doompi-web/vite.config.ts
@@ -54,7 +54,7 @@ export default defineConfig(({ command }) => {
         '@agimon-ai/doompi-web-components',
         // The sealed transport is a module singleton whose nonce counters every
         // plugin shares; a second copy would start counting at zero.
-        '@agimon-ai/doompi-web-security/browser',
+        '@agimon-ai/doompi-web-security',
         // CodeMirror's state and view are singletons in all but name: a
         // document built against one copy is rejected by an editor from the
         // other.

--- a/templates/doom-web/scaffold.yaml
+++ b/templates/doom-web/scaffold.yaml
@@ -182,6 +182,8 @@ boilerplate:
       - tests/e2e/workflows.spec.ts
       - tests/fixtures/crash-plugin/package.json
       - tests/fixtures/crash-plugin/web/index.tsx
+      - tests/fixtures/security-singleton-plugin/package.json
+      - tests/fixtures/security-singleton-plugin/src/exports/webClient.ts
       - tests/integration/bridge.test.ts
       - tests/integration/hub.test.ts
       - tests/integration/packageApi.test.ts

--- a/templates/doom-web/src/adapters/webBundler.ts.liquid
+++ b/templates/doom-web/src/adapters/webBundler.ts.liquid
@@ -12,6 +12,15 @@ const DEDUPED_RUNTIMES = [
   '@tanstack/store',
   '@tanstack/react-store',
   '@agimon-ai/doompi-web-components',
+  // The sealed transport is a module singleton whose nonce counters every
+  // plugin shares; a second copy would start counting at zero.
+  '@agimon-ai/doompi-web-security',
+  // CodeMirror's state and view are singletons in all but name: a document
+  // built against one copy is rejected by an editor from the other, and a
+  // grammar chunk resolved separately from the editor is exactly how a second
+  // copy appears.
+  '@codemirror/state',
+  '@codemirror/view',
 ];
 
 export interface BundleCockpitWebOptions {

--- a/templates/doom-web/tests/fixtures/security-singleton-plugin/package.json.liquid
+++ b/templates/doom-web/tests/fixtures/security-singleton-plugin/package.json.liquid
@@ -1,0 +1,12 @@
+{
+  "name": "@agimon-ai/doompi-security-singleton-fixture",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@agimon-ai/doompi-web-security": "0.0.1-alpha.7"
+  },
+  "doompiWeb": {
+    "pluginId": "security-singleton-probe",
+    "client": "./src/exports/webClient.ts"
+  }
+}

--- a/templates/doom-web/tests/fixtures/security-singleton-plugin/src/exports/webClient.ts.liquid
+++ b/templates/doom-web/tests/fixtures/security-singleton-plugin/src/exports/webClient.ts.liquid
@@ -1,0 +1,8 @@
+import { sealedTransport } from '@agimon-ai/doompi-web-security/browser';
+
+export const webPlugin = {
+  id: 'security-singleton-probe',
+  start() {
+    sealedTransport.active();
+  },
+};

--- a/templates/doom-web/tests/integration/webBundler.test.ts.liquid
+++ b/templates/doom-web/tests/integration/webBundler.test.ts.liquid
@@ -9,6 +9,10 @@ import { loadHubChannels } from '../../src/adapters/webHubPluginLoader.ts';
 const workflowRoot = fileURLToPath(new URL('../../../doompi-workflow', import.meta.url));
 const planRoot = fileURLToPath(new URL('../../../doompi-plan', import.meta.url));
 const teamRoot = fileURLToPath(new URL('../../../../../layers/team/doompi-team', import.meta.url));
+const securityPackageRoot = fileURLToPath(new URL('../../../../core/doompi-web-security', import.meta.url));
+const securitySingletonFixtureRoot = fileURLToPath(
+  new URL('../fixtures/security-singleton-plugin', import.meta.url),
+);
 
 function bundledJsHas(assetsDir: string, needle: string): boolean {
   return fs
@@ -33,6 +37,55 @@ function brokenPackage(manifest: Record<string, unknown>): string {
   cleanups.push(() => fs.rmSync(root, { recursive: true, force: true }));
   fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(manifest));
   return root;
+}
+
+interface InstalledSecuritySingletonPlugin {
+  pluginRoot: string;
+  physicalSecurityRoot: string;
+  publicSecurityRoot: string;
+}
+
+/** Reproduces an installed plugin resolving its own physical security package copy. */
+function installedSecuritySingletonPlugin(): InstalledSecuritySingletonPlugin {
+  const pluginRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-web-security-singleton-'));
+  cleanups.push(() => fs.rmSync(pluginRoot, { recursive: true, force: true }));
+  fs.cpSync(securitySingletonFixtureRoot, pluginRoot, { recursive: true });
+
+  const sourceManifestPath = path.join(securityPackageRoot, 'package.json');
+  const sourceManifest = JSON.parse(fs.readFileSync(sourceManifestPath, 'utf8')) as {
+    version?: unknown;
+    exports?: Record<string, unknown>;
+  };
+  if (typeof sourceManifest.version !== 'string') throw new Error('The security fixture needs a package version.');
+  const physicalSecurityRoot = path.join(
+    pluginRoot,
+    'node_modules',
+    '.pnpm',
+    `@agimon-ai+doompi-web-security@${sourceManifest.version}`,
+    'node_modules',
+    '@agimon-ai',
+    'doompi-web-security',
+  );
+  fs.mkdirSync(physicalSecurityRoot, { recursive: true });
+  fs.copyFileSync(sourceManifestPath, path.join(physicalSecurityRoot, 'package.json'));
+  fs.cpSync(path.join(securityPackageRoot, 'dist'), path.join(physicalSecurityRoot, 'dist'), { recursive: true });
+
+  const wrapperPath = path.join(physicalSecurityRoot, 'dist', 'browser-probe.mjs');
+  fs.writeFileSync(
+    wrapperPath,
+    "globalThis['__doompi_physical_security_copy__'] = true;\nexport * from './browser.mjs';\n",
+  );
+  const browserExport = sourceManifest.exports?.['./browser'];
+  if (typeof browserExport !== 'object' || browserExport === null || Array.isArray(browserExport)) {
+    throw new Error('The security fixture needs the ./browser export.');
+  }
+  (browserExport as Record<string, unknown>).import = './dist/browser-probe.mjs';
+  fs.writeFileSync(path.join(physicalSecurityRoot, 'package.json'), `${JSON.stringify(sourceManifest, null, 2)}\n`);
+
+  const publicSecurityRoot = path.join(pluginRoot, 'node_modules', '@agimon-ai', 'doompi-web-security');
+  fs.mkdirSync(path.dirname(publicSecurityRoot), { recursive: true });
+  fs.symlinkSync(physicalSecurityRoot, publicSecurityRoot, 'dir');
+  return { pluginRoot, physicalSecurityRoot, publicSecurityRoot };
 }
 
 afterEach(() => {
@@ -93,6 +146,22 @@ describe('the sync-time cockpit bundler', () => {
     // The hub loads the plugin's built channel from the registry the bundle carries.
     const channels = await loadHubChannels(result.assetsDir, (message) => notices.push(message));
     expect(channels.map((channel) => channel.frameType)).toEqual(['subagent_runs', 'workflow_runs']);
+  });
+
+  it('resolves an installed plugin to the host sealed transport singleton', { timeout: 120_000 }, async () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-web-security-bundle-'));
+    cleanups.push(() => fs.rmSync(outDir, { recursive: true, force: true }));
+    const installed = installedSecuritySingletonPlugin();
+
+    expect(fs.realpathSync(installed.publicSecurityRoot)).toBe(fs.realpathSync(installed.physicalSecurityRoot));
+    expect(fs.realpathSync(installed.physicalSecurityRoot)).not.toBe(fs.realpathSync(securityPackageRoot));
+
+    const result = await bundleCockpitWeb({ pluginRoots: [installed.pluginRoot], outDir });
+
+    expect(result.pluginIds).toContain('security-singleton-probe');
+    expect(bundledJsHas(result.assetsDir, 'security-singleton-probe')).toBe(true);
+    expect(bundledJsHas(result.assetsDir, '__doompi_physical_security_copy__')).toBe(false);
+    expect(bundledJsHas(result.assetsDir, '@agimon-ai/doompi-web-security/browser')).toBe(false);
   });
 
   it('serves zero channels for assets without a registry, since nothing is built in', async () => {

--- a/templates/doom-web/vite.config.ts.liquid
+++ b/templates/doom-web/vite.config.ts.liquid
@@ -46,7 +46,21 @@ export default defineConfig(({ command }) => {
     resolve: {
       // One instance of each shared runtime even when a plugin package declares
       // its own copies for typechecking.
-      dedupe: ['react', 'react-dom', '@tanstack/store', '@tanstack/react-store', '@agimon-ai/doompi-web-components'],
+      dedupe: [
+        'react',
+        'react-dom',
+        '@tanstack/store',
+        '@tanstack/react-store',
+        '@agimon-ai/doompi-web-components',
+        // The sealed transport is a module singleton whose nonce counters every
+        // plugin shares; a second copy would start counting at zero.
+        '@agimon-ai/doompi-web-security',
+        // CodeMirror's state and view are singletons in all but name: a
+        // document built against one copy is rejected by an editor from the
+        // other.
+        '@codemirror/state',
+        '@codemirror/view',
+      ],
       alias: dev.alias,
     },
     build: {


### PR DESCRIPTION
## Summary
- dedupe the sealed transport by its normalized root package identity
- add a physical installed-package regression for singleton resolution
- invalidate cached union bundles and align the doom-web template

## Verification
- focused bundler and composition tests
- affected Nx lint, typecheck, build, and test
- deterministic vibe-lint preflight
- git diff --check