### PR TITLE
feat(root): add the log issues panel, context dock, and tool cost

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,8 @@ release-artifacts
 .pi
 .codex-local
 logs
+**/logs
 tmp
+**/tmp
 *.log
 .claude/settings.local.json

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "audit:workspace": "node scripts/audit-workspace.mjs",
     "build": "nx run-many -t build",
     "cockpit": "pnpm cockpit:build && pnpm doompi-web",
-    "cockpit:build": "nx run-many -t build -p @agimon-ai/doompi @agimon-ai/doompi-server @agimon-ai/doompi-web @agimon-ai/doompi-file-edit @agimon-ai/doompi-mcp @agimon-ai/doompi-task @agimon-ai/doompi-team @agimon-ai/doompi-voice @agimon-ai/doompi-workflow @agimon-ai/doompi-user-feedback",
+    "cockpit:build": "nx run-many -t build -p @agimon-ai/doompi @agimon-ai/doompi-server @agimon-ai/doompi-web @agimon-ai/doompi-file-edit @agimon-ai/doompi-log @agimon-ai/doompi-mcp @agimon-ai/doompi-task @agimon-ai/doompi-team @agimon-ai/doompi-voice @agimon-ai/doompi-workflow @agimon-ai/doompi-user-feedback",
     "examples:check": "node scripts/check-examples.mjs",
     "hooks:check": "node scripts/emit-hooks.mjs --check",
     "hooks:write": "node scripts/emit-hooks.mjs --write",

--- a/packages/clients/doompi-web/src/adapters/sessionHub.ts
+++ b/packages/clients/doompi-web/src/adapters/sessionHub.ts
@@ -22,6 +22,7 @@ import {
   HISTORY_PAGE_SIZE,
   HISTORY_PAGE_TYPE,
   type HistoryPageFrame,
+  CONTEXT_ENTRY_TYPE,
   MINOR_MODE_ENTRY_TYPE,
   SESSION_BACKLOG_TYPE,
   type SessionBacklogFrame,
@@ -212,19 +213,26 @@ function renderableJournalEntries(frame: SessionFrame, limit: number): Record<st
   if (!Array.isArray(entries)) return [];
 
   const messages: Record<string, unknown>[] = [];
-  let minorModes: Record<string, unknown> | undefined;
+  // Both are projections rather than events, so only the last one matters and
+  // replaying every copy would grow the backlog for no added meaning.
+  const projections = new Map<string, Record<string, unknown>>();
   for (const entry of entries) {
     if (typeof entry !== 'object' || entry === null) continue;
     const candidate = entry as Record<string, unknown>;
     if (candidate.type === 'message') messages.push(candidate);
-    else if (candidate.type === 'custom' && candidate.customType === MINOR_MODE_ENTRY_TYPE) minorModes = candidate;
+    else if (
+      candidate.type === 'custom' &&
+      (candidate.customType === MINOR_MODE_ENTRY_TYPE || candidate.customType === CONTEXT_ENTRY_TYPE)
+    ) {
+      projections.set(String(candidate.customType), candidate);
+    }
   }
 
   // The ring is bounded and live frames must still fit, so only the tail of a
   // long transcript is published on attach; the rest is retained for the page
   // to page back through rather than dropped on the floor.
   const kept = messages.length > limit ? messages.slice(-limit) : messages;
-  return minorModes === undefined ? kept : [...kept, minorModes];
+  return projections.size === 0 ? kept : [...kept, ...projections.values()];
 }
 
 /**
@@ -259,7 +267,9 @@ function journalMessages(frame: SessionFrame): Record<string, unknown>[] {
  * re-reading it only replaces a projection, so a refresh cannot double it.
  */
 function isUnreportedEntry(entry: Record<string, unknown>): boolean {
-  if (entry.type === 'custom') return entry.customType === MINOR_MODE_ENTRY_TYPE;
+  if (entry.type === 'custom') {
+    return entry.customType === MINOR_MODE_ENTRY_TYPE || entry.customType === CONTEXT_ENTRY_TYPE;
+  }
   const message = entry.message;
   if (typeof message !== 'object' || message === null) return false;
   return (message as { role?: unknown }).role === 'user';

--- a/packages/clients/doompi-web/src/types/hub.ts
+++ b/packages/clients/doompi-web/src/types/hub.ts
@@ -113,6 +113,15 @@ export const HUB_RESYNCED_TYPE = 'hub_resynced';
 export const MINOR_MODE_ENTRY_TYPE = 'doom-minor-modes';
 
 /**
+ * The custom session entry DoomPi journals describing what the session is
+ * composed of: which mode admitted each tool and skill, and what each costs.
+ *
+ * Schemas are deliberately absent. Only names, kinds, owners and integer token
+ * counts travel, so republishing the whole composition stays cheap.
+ */
+export const CONTEXT_ENTRY_TYPE = 'doom-context';
+
+/**
  * The custom session entry doompi-domain journals once Pi has rebuilt its
  * resource catalog for a reload; it mirrors DOOM_RESOURCE_CATALOG_ENTRY_TYPE in
  * doompi-extension-contracts.
@@ -146,6 +155,39 @@ export interface MinorModeProjection {
   version: 1;
   revision: number;
   modes: MinorModeRecordProjection[];
+}
+
+export type ContextGroupKind = 'major' | 'minor' | 'domain' | 'core';
+export type ContextItemSource = 'extension' | 'mcp' | 'plugin' | 'core';
+
+export interface ContextItemProjection {
+  name: string;
+  itemKind: 'tool' | 'skill';
+  source: ContextItemSource;
+  owner: string;
+  tokens: number;
+  active: boolean;
+}
+
+export interface ContextGroupProjection {
+  id: string;
+  label: string;
+  kind: ContextGroupKind;
+  items: ContextItemProjection[];
+  /** What the group costs now: active items only. */
+  tokens: number;
+  /** What its gated items would add if switched on. */
+  inactiveTokens: number;
+}
+
+export interface ContextProjection {
+  version: 1;
+  revision: number;
+  groups: ContextGroupProjection[];
+  totalTokens: number;
+  inactiveTokens: number;
+  /** Names the tokenizer, because the figures are indicative, not billed. */
+  estimator: string;
 }
 export const SUBSCRIBE_TYPE = 'subscribe';
 export const UNSUBSCRIBE_TYPE = 'unsubscribe';

--- a/packages/clients/doompi-web/src/web/features/activity/ActivityDock.tsx
+++ b/packages/clients/doompi-web/src/web/features/activity/ActivityDock.tsx
@@ -1,4 +1,4 @@
-import { Button, EmptyState, Kbd, SectionLabel, StatusBadge } from '@agimon-ai/doompi-web-components';
+import { Button, EmptyState, Kbd, StatusBadge } from '@agimon-ai/doompi-web-components';
 import { useStore } from '@tanstack/react-store';
 import { PluginSurface } from '../../components/PluginSurface.tsx';
 import { type ActivityGroup, useActivityGroups } from '../../lib/composition.ts';
@@ -6,23 +6,30 @@ import { activityGroupSlot, HOST_SLOTS, slotFills } from '../../lib/pluginRegist
 import { usePluginSlotProps } from '../../stores/usePluginSlotProps.ts';
 import { useActiveSession } from '../../stores/sessionStore.ts';
 import { sessionsStore } from '../../stores/sessionsStore.ts';
+import { uiStore } from '../../stores/uiStore.ts';
+import { ContextPanel } from './ContextPanel.tsx';
+import { DockTabs } from './DockTabs.tsx';
 
 /**
- * Asynchronous work that outlives the turn that started it.
+ * The column for everything that is not the transcript.
  *
- * Agents, runners, and workflows deliberately live outside the transcript, so
- * they get a surface that does not scroll away. The host owns only the frame:
- * which groups exist, their key chips, and what they render come from the
- * packages that declare them. Each declared group opens the keyed slot
- * activity.<name>; the sections any plugin registers under that name render
- * there, in slot order, and a group nobody fills shows the one-line summary
- * the session's footer publishes.
+ * It has two faces. `activity` is asynchronous work that outlives the turn that
+ * started it: agents, runners, and workflows deliberately live outside the
+ * transcript, so they get a surface that does not scroll away. `context` is the
+ * composition that work runs under, and what carrying it costs.
+ *
+ * On the activity face the host owns only the frame: which groups exist, their
+ * key chips, and what they render come from the packages that declare them.
+ * Each declared group opens the keyed slot activity.<name>; the sections any
+ * plugin registers under that name render there, in slot order, and a group
+ * nobody fills shows the one-line summary the session's footer publishes.
  */
 export function ActivityDock({ onClose, onOpenContent }: { onClose: () => void; onOpenContent: () => void }) {
   const activeId = useStore(sessionsStore, (state) => state.activeId);
   const statuses = useActiveSession((state) => state.statuses);
   const widgets = useActiveSession((state) => state.widgets);
   const slotProps = usePluginSlotProps(activeId, onOpenContent);
+  const tab = useStore(uiStore, (state) => state.dockTab);
   const groups = useActivityGroups(statuses, widgets, activeId);
   const ordinaryGroups = groups.filter((group) => group.placement !== 'bottom');
   const pinnedGroups = groups.filter((group) => group.placement === 'bottom');
@@ -35,8 +42,10 @@ export function ActivityDock({ onClose, onOpenContent }: { onClose: () => void; 
     >
       <div className="flex h-12 shrink-0 items-center justify-between border-b border-doom-border px-4">
         <div className="flex items-center gap-2">
-          <SectionLabel className="text-doom-hi">activity</SectionLabel>
-          {busy > 0 ? (
+          <DockTabs />
+          {/* The count belongs to the activity face; on the context face it
+              would be a number about a list the reader is not looking at. */}
+          {busy > 0 && tab === 'activity' ? (
             <StatusBadge tone="running" size="xs" data-testid="activity-busy" className="normal-case">
               {busy} running
             </StatusBadge>
@@ -47,40 +56,46 @@ export function ActivityDock({ onClose, onOpenContent }: { onClose: () => void; 
         </Button>
       </div>
 
-      <div data-testid="activity-scroll" className="min-h-0 flex-1 overflow-y-auto">
-        {groups.length === 0 ? (
-          <EmptyState
-            data-testid="activity-empty"
-            className="px-4 py-5"
-            title="nothing supervised yet"
-            description="a package's group appears here once its extension reports in."
-          />
-        ) : null}
-        {ordinaryGroups.length > 0 ? (
-          <div className="flex flex-col">
-            {ordinaryGroups.map((group) => (
-              <ActivityGroupView key={group.name} group={group} slotProps={slotProps} />
-            ))}
+      {tab === 'context' ? (
+        <ContextPanel />
+      ) : (
+        <>
+          <div data-testid="activity-scroll" className="min-h-0 flex-1 overflow-y-auto">
+            {groups.length === 0 ? (
+              <EmptyState
+                data-testid="activity-empty"
+                className="px-4 py-5"
+                title="nothing supervised yet"
+                description="a package's group appears here once its extension reports in."
+              />
+            ) : null}
+            {ordinaryGroups.length > 0 ? (
+              <div className="flex flex-col">
+                {ordinaryGroups.map((group) => (
+                  <ActivityGroupView key={group.name} group={group} slotProps={slotProps} />
+                ))}
+              </div>
+            ) : null}
+
+            <PluginSurface slot={HOST_SLOTS.activity} sessionId={activeId} />
           </div>
-        ) : null}
 
-        <PluginSurface slot={HOST_SLOTS.activity} sessionId={activeId} />
-      </div>
+          {pinnedGroups.length > 0 ? (
+            <div data-testid="activity-pinned" className="shrink-0">
+              {pinnedGroups.map((group) => (
+                <ActivityGroupView key={group.name} group={group} slotProps={slotProps} />
+              ))}
+            </div>
+          ) : null}
 
-      {pinnedGroups.length > 0 ? (
-        <div data-testid="activity-pinned" className="shrink-0">
-          {pinnedGroups.map((group) => (
-            <ActivityGroupView key={group.name} group={group} slotProps={slotProps} />
-          ))}
-        </div>
-      ) : null}
-
-      <div className="border-t border-doom-border px-4 py-3">
-        <span className="text-[9px] leading-relaxed text-doom-faint">
-          each group is rendered by the package that owns it; the session's summary line stands in until that package
-          publishes per-run detail
-        </span>
-      </div>
+          <div className="border-t border-doom-border px-4 py-3">
+            <span className="text-[9px] leading-relaxed text-doom-faint">
+              each group is rendered by the package that owns it; the session's summary line stands in until that
+              package publishes per-run detail
+            </span>
+          </div>
+        </>
+      )}
     </aside>
   );
 }

--- a/packages/clients/doompi-web/src/web/features/activity/ContextPanel.tsx
+++ b/packages/clients/doompi-web/src/web/features/activity/ContextPanel.tsx
@@ -1,0 +1,110 @@
+import { EmptyState } from '@agimon-ai/doompi-web-components';
+import { type ContextGroup, type ContextItemSource, contextGroups, totalTokens } from '../../lib/contextComposition.ts';
+import { useActiveSession } from '../../stores/sessionStore.ts';
+
+/** Short enough to sit in a fixed column without wrapping the tool's own name. */
+const SOURCE_LABEL: Record<ContextItemSource, string> = {
+  extension: 'ext',
+  mcp: 'mcp',
+  plugin: 'plug',
+  core: 'core',
+};
+
+/** The tilde is the whole caveat in one character: this is arithmetic, not a bill. */
+function tokens(value: number | null): string {
+  return value === null ? '—' : `~${value.toLocaleString()}`;
+}
+
+/**
+ * What the session is carrying.
+ *
+ * Every tool and skill in here is spending context before the first message,
+ * so the surface is built around the one question worth asking of it: what is
+ * this costing, and which mode do I switch off to stop paying it. It reads
+ * only; switching stays with the composer chips that already own it.
+ */
+export function ContextPanel() {
+  const statuses = useActiveSession((state) => state.statuses);
+  const widgets = useActiveSession((state) => state.widgets);
+  const projection = useActiveSession((state) => state.minorModes);
+  const groups = contextGroups(statuses, widgets, projection);
+  const total = totalTokens(groups);
+
+  return (
+    <div data-testid="context-panel" className="flex min-h-0 flex-1 flex-col">
+      <div data-testid="context-scroll" className="min-h-0 flex-1 overflow-y-auto">
+        {groups.length === 0 ? (
+          <EmptyState
+            data-testid="context-empty"
+            className="px-4 py-5"
+            title="no composition yet"
+            description="the session reports its major mode, minor modes, and domains once it has started."
+          />
+        ) : (
+          <div className="flex flex-col">
+            {groups.map((group) => (
+              <ContextGroupView key={`${group.kind}:${group.id}`} group={group} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="shrink-0 border-t border-doom-border px-4 py-3">
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] font-bold text-doom-text">total</span>
+          <span data-testid="context-total" className="text-[10px] font-bold text-doom-text">
+            {tokens(total)}
+          </span>
+        </div>
+        <span className="text-[9px] leading-relaxed text-doom-faint">
+          estimated · gpt-tokenizer BPE · not a billed total
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function ContextGroupView({ group }: { group: ContextGroup }) {
+  return (
+    <div
+      data-testid={`context-group-${group.id}`}
+      data-kind={group.kind}
+      className="flex flex-col gap-1 border-b border-doom-border-soft px-3 py-3"
+    >
+      {/* The same head the activity dock uses, for the same reason: the glyph
+          says "section", so a mode never reads as one more row among the tools
+          it brought with it. */}
+      <div className="flex items-center gap-2 px-1">
+        <span aria-hidden className="text-[11px] font-bold text-doom-faint">
+          #
+        </span>
+        <span className="flex-1 text-[11px] font-bold text-doom-text">{group.label}</span>
+        <span className="text-[8px] font-bold tracking-widest text-doom-violet uppercase">{group.kind}</span>
+        <span data-testid={`context-subtotal-${group.id}`} className="w-14 text-right text-[10px] text-doom-dim">
+          {tokens(group.tokens)}
+        </span>
+      </div>
+
+      {group.items.length === 0 ? (
+        <p data-testid={`context-pending-${group.id}`} className="px-1 text-[10px] text-doom-faint">
+          {group.detail || 'no tools or skills reported'}
+        </p>
+      ) : (
+        group.items.map((item) => (
+          <div
+            key={`${item.itemKind}:${item.name}`}
+            data-testid={`context-row-${item.name}`}
+            data-active={item.active}
+            className="flex items-center gap-2 px-1"
+          >
+            <span className={`flex-1 truncate text-[10px] ${item.active ? 'text-doom-text' : 'text-doom-faint'}`}>
+              {item.name}
+            </span>
+            <span className="text-[9px] text-doom-faint">{SOURCE_LABEL[item.source]}</span>
+            <span className="w-14 text-right text-[10px] text-doom-dim">{tokens(item.tokens)}</span>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/packages/clients/doompi-web/src/web/features/activity/ContextPanel.tsx
+++ b/packages/clients/doompi-web/src/web/features/activity/ContextPanel.tsx
@@ -1,5 +1,14 @@
 import { EmptyState } from '@agimon-ai/doompi-web-components';
-import { type ContextGroup, type ContextItemSource, contextGroups, totalTokens } from '../../lib/contextComposition.ts';
+import {
+  type ContextGroup,
+  type ContextItemSource,
+  contextGroups,
+  inactiveTotal,
+  ownerLabel,
+  ownersOf,
+  projectedGroups,
+  totalTokens,
+} from '../../lib/contextComposition.ts';
 import { useActiveSession } from '../../stores/sessionStore.ts';
 
 /** Short enough to sit in a fixed column without wrapping the tool's own name. */
@@ -20,15 +29,21 @@ function tokens(value: number | null): string {
  *
  * Every tool and skill in here is spending context before the first message,
  * so the surface is built around the one question worth asking of it: what is
- * this costing, and which mode do I switch off to stop paying it. It reads
- * only; switching stays with the composer chips that already own it.
+ * this costing, and what do I switch off to stop paying it. Modes head the
+ * groups because a mode is what you switch; packages head the rows inside them
+ * because a package is what you add or remove. It reads only; switching stays
+ * with the composer chips that already own it.
  */
 export function ContextPanel() {
   const statuses = useActiveSession((state) => state.statuses);
   const widgets = useActiveSession((state) => state.widgets);
   const projection = useActiveSession((state) => state.minorModes);
-  const groups = contextGroups(statuses, widgets, projection);
+  const context = useActiveSession((state) => state.context);
+  // The runtime's grouping wins once it arrives; the status line only has to
+  // carry the surface until the session has reported its inventory.
+  const groups = context ? projectedGroups(context) : contextGroups(statuses, widgets, projection);
   const total = totalTokens(groups);
+  const idle = inactiveTotal(groups);
 
   return (
     <div data-testid="context-panel" className="flex min-h-0 flex-1 flex-col">
@@ -51,13 +66,21 @@ export function ContextPanel() {
 
       <div className="shrink-0 border-t border-doom-border px-4 py-3">
         <div className="flex items-center justify-between">
-          <span className="text-[10px] font-bold text-doom-text">total</span>
+          <span className="text-[10px] font-bold text-doom-text">active</span>
           <span data-testid="context-total" className="text-[10px] font-bold text-doom-text">
             {tokens(total)}
           </span>
         </div>
+        {idle > 0 ? (
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] text-doom-faint">inactive</span>
+            <span data-testid="context-inactive" className="text-[10px] text-doom-faint">
+              {`+${tokens(idle)}`}
+            </span>
+          </div>
+        ) : null}
         <span className="text-[9px] leading-relaxed text-doom-faint">
-          estimated · gpt-tokenizer BPE · not a billed total
+          {`estimated · ${context?.estimator ?? 'gpt-tokenizer'} BPE · not a billed total`}
         </span>
       </div>
     </div>
@@ -90,18 +113,37 @@ function ContextGroupView({ group }: { group: ContextGroup }) {
           {group.detail || 'no tools or skills reported'}
         </p>
       ) : (
-        group.items.map((item) => (
-          <div
-            key={`${item.itemKind}:${item.name}`}
-            data-testid={`context-row-${item.name}`}
-            data-active={item.active}
-            className="flex items-center gap-2 px-1"
-          >
-            <span className={`flex-1 truncate text-[10px] ${item.active ? 'text-doom-text' : 'text-doom-faint'}`}>
-              {item.name}
-            </span>
-            <span className="text-[9px] text-doom-faint">{SOURCE_LABEL[item.source]}</span>
-            <span className="w-14 text-right text-[10px] text-doom-dim">{tokens(item.tokens)}</span>
+        ownersOf(group).map((owner) => (
+          <div key={owner.owner} className="flex flex-col">
+            {/* The package heads its own rows, so the source tag sits here
+                rather than repeating on every tool that shares it. */}
+            <div
+              data-testid={`context-owner-${owner.owner}`}
+              title={owner.owner}
+              className="flex items-center gap-2 px-1 pt-1"
+            >
+              <span className="flex-1 truncate text-[10px] text-doom-dim">{ownerLabel(owner.owner)}</span>
+              <span className="text-[9px] text-doom-faint">{SOURCE_LABEL[owner.source]}</span>
+              <span className="w-14 text-right text-[10px] text-doom-dim">{tokens(owner.tokens)}</span>
+            </div>
+            {owner.items.map((item) => (
+              <div
+                key={`${item.itemKind}:${item.name}`}
+                data-testid={`context-row-${item.name}`}
+                data-active={item.active}
+                className="flex items-center gap-2 py-px pr-1 pl-4"
+              >
+                <span className={`flex-1 truncate text-[10px] ${item.active ? 'text-doom-text' : 'text-doom-faint'}`}>
+                  {item.name}
+                </span>
+                <span
+                  title={item.active ? undefined : 'not sent to the model; costs nothing until switched on'}
+                  className={`w-14 text-right text-[10px] ${item.active ? 'text-doom-dim' : 'text-doom-faint'}`}
+                >
+                  {item.active ? tokens(item.tokens) : `(${tokens(item.tokens)})`}
+                </span>
+              </div>
+            ))}
           </div>
         ))
       )}

--- a/packages/clients/doompi-web/src/web/features/activity/DockTabs.tsx
+++ b/packages/clients/doompi-web/src/web/features/activity/DockTabs.tsx
@@ -1,0 +1,39 @@
+import { Button, SectionLabel } from '@agimon-ai/doompi-web-components';
+import { useStore } from '@tanstack/react-store';
+import { type DockTab, setDockTab, uiStore } from '../../stores/uiStore.ts';
+
+const TABS: readonly DockTab[] = ['activity', 'context'];
+
+/**
+ * The dock's two faces.
+ *
+ * These read as section headings rather than as a control strip, because the
+ * dock has always been headed by one tracked-out label and the eye already
+ * looks there for "what am I seeing". The selected face keeps the bright
+ * colour the single label used to carry, so nothing new has to be learned.
+ */
+export function DockTabs() {
+  const active = useStore(uiStore, (state) => state.dockTab);
+
+  return (
+    <div className="flex items-center gap-3" role="tablist" aria-label="dock view">
+      {TABS.map((tab) => (
+        <Button
+          key={tab}
+          variant="ghost"
+          size="xs"
+          role="tab"
+          aria-selected={tab === active}
+          data-testid={`dock-tab-${tab}`}
+          data-active={tab === active}
+          onClick={() => setDockTab(tab)}
+          className="h-auto rounded-none px-0 py-0 hover:bg-transparent"
+        >
+          <SectionLabel className={tab === active ? 'text-doom-hi' : 'text-doom-faint hover:text-doom-dim'}>
+            {tab}
+          </SectionLabel>
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/packages/clients/doompi-web/src/web/features/session/Timeline.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/Timeline.tsx
@@ -3,6 +3,7 @@ import {
   ChevronDownIcon,
   EmptyState,
   ExternalLinkIcon,
+  MessageItemGroup,
   Separator,
   StreamCursor,
 } from '@agimon-ai/doompi-web-components';
@@ -12,7 +13,13 @@ import type { Store } from '@tanstack/store';
 import { useActivityGroups } from '../../lib/composition.ts';
 import { parseFileMentions } from '../../lib/fileMentions.ts';
 import { pluginToolRenderer } from '../../lib/pluginRegistry.ts';
-import { isSupportedImageMimeType, type SessionState, type TimelineEntry } from '../../lib/sessionModel.ts';
+import {
+  isSupportedImageMimeType,
+  type SessionState,
+  type TimelineEntry,
+  type ToolEntry,
+} from '../../lib/sessionModel.ts';
+import { groupSummary, groupTone, timelineUnits } from '../../lib/timelineGroups.ts';
 import {
   requestOlderHistory,
   sessionStoreFor,
@@ -84,6 +91,44 @@ function ToolEntryRow({
       <div className="min-w-0 flex-1">
         <ToolCard entry={entry} sessionId={sessionId} />
       </div>
+    </div>
+  );
+}
+
+/**
+ * A run of calls to one tool, under one frame and one gutter label. The rows
+ * inside are the same cards the tool renders on its own; the group only takes
+ * their border, so each call still opens and closes by itself.
+ */
+function ToolGroupRow({
+  name,
+  entries,
+  sessionId,
+}: {
+  name: string;
+  entries: readonly ToolEntry[];
+  sessionId: string | null;
+}) {
+  return (
+    <div
+      data-testid="entry-tool-row"
+      data-tool-presentation="tool"
+      className="flex flex-col gap-1 sm:flex-row sm:gap-3"
+    >
+      <Gutter label="tool" tone="text-doom-faint" />
+      <MessageItemGroup
+        data-testid="entry-tool-group"
+        data-tool-name={name}
+        data-tool-count={entries.length}
+        tone={groupTone(entries)}
+        title={name}
+        summary={`· ${groupSummary(entries)}`}
+        className="min-w-0 flex-1"
+      >
+        {entries.map((entry) => (
+          <ToolCard key={entry.id} entry={entry} sessionId={sessionId} />
+        ))}
+      </MessageItemGroup>
     </div>
   );
 }
@@ -228,6 +273,17 @@ export function Transcript({
     const shown = entries.filter((entry) => entry.kind !== 'queued');
     return limit === undefined ? shown : shown.slice(-limit);
   }, [entries, limit]);
+  const toolStatuses = useActiveSession((state) => state.statuses);
+  // A tool that presents itself as a message has no frame to share, so only
+  // the card-shaped ones are gathered into runs.
+  const units = useMemo(
+    () =>
+      timelineUnits(
+        visibleEntries,
+        (name) => (pluginToolRenderer(name, toolStatuses)?.timelinePresentation ?? 'tool') === 'tool',
+      ),
+    [visibleEntries, toolStatuses],
+  );
   const scroller = useRef<HTMLDivElement>(null);
   // The transcript's height as of the last entry. Whether to follow the newest
   // line is decided against this rather than against a scroll event, because
@@ -359,7 +415,7 @@ export function Transcript({
             : 'flex flex-1 flex-col gap-[18px] overflow-y-auto px-2 py-4 sm:px-[26px] sm:py-[22px]'
         }
       >
-        {visibleEntries.map((entry, index) => (
+        {units.map((unit) => (
           // Entries above the live tail are skipped for layout and paint until
           // they are scrolled near. A long transcript is thousands of markdown
           // blocks, diffs and tool cards, and laying all of them out on every
@@ -368,14 +424,18 @@ export function Transcript({
           // order of magnitude and a list that guesses them wrong moves the
           // reader's place under them.
           <div
-            key={entry.id}
+            key={unit.kind === 'group' ? `group-${unit.entries[0]?.id ?? ''}` : unit.entry.id}
             className={
-              index < visibleEntries.length - LIVE_TAIL_ENTRIES
+              unit.index < visibleEntries.length - LIVE_TAIL_ENTRIES
                 ? '[contain-intrinsic-size:auto_64px] [content-visibility:auto]'
                 : undefined
             }
           >
-            <Entry entry={entry} sessionId={sessionId} />
+            {unit.kind === 'group' ? (
+              <ToolGroupRow name={unit.name} entries={unit.entries} sessionId={sessionId} />
+            ) : (
+              <Entry entry={unit.entry} sessionId={sessionId} />
+            )}
           </div>
         ))}
         {backgroundWorkActive ? <BackgroundWorkNotice /> : null}

--- a/packages/clients/doompi-web/src/web/features/settings/SettingsPanelHost.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/SettingsPanelHost.tsx
@@ -1,0 +1,36 @@
+import { sealedHttpSession } from '../../lib/sealedSession.ts';
+import { fetchWithStepUp } from '../../lib/stepUp.ts';
+import type { InstalledSettingsPanel } from '../../lib/pluginRegistry.ts';
+
+/**
+ * The frame around a settings page a package draws itself.
+ *
+ * The host keeps the heading here rather than leaving it to the plugin, so a
+ * self-drawn page carries the same label and detail the menu showed and the
+ * reader does not have to trust each package to repeat them. Everything below
+ * the heading belongs to the package.
+ *
+ * The transport is the host's for the same reason the repository panel's is:
+ * only the host knows whether the page is being read over a tunnel, and a
+ * plugin calling bare fetch would send plaintext to the relay.
+ */
+
+const requestThroughSealedSession = (input: string, init?: RequestInit): Promise<Response> =>
+  sealedHttpSession.fetch(input, init);
+
+interface SettingsPanelHostProps {
+  panel: InstalledSettingsPanel;
+}
+
+export function SettingsPanelHost({ panel }: SettingsPanelHostProps) {
+  const Panel = panel.component;
+  return (
+    <div className="flex flex-col gap-3" data-testid={`settings-panel-${panel.id}`}>
+      <header className="flex min-w-0 flex-wrap items-center gap-2">
+        <span className="text-[12px] font-bold text-doom-hi">{panel.label}</span>
+        <span className="min-w-0 basis-full text-[10px] text-doom-faint sm:basis-auto sm:flex-1">{panel.detail}</span>
+      </header>
+      <Panel request={requestThroughSealedSession} requestWithStepUp={fetchWithStepUp} />
+    </div>
+  );
+}

--- a/packages/clients/doompi-web/src/web/lib/composition.ts
+++ b/packages/clients/doompi-web/src/web/lib/composition.ts
@@ -314,6 +314,21 @@ export function fileLinkFor(sessionId: string | null, path: string): TransientTa
 }
 
 /**
+ * The tab a path the caller is sure about opens: a tool call's path argument,
+ * not a token spotted in prose.
+ *
+ * A source that offers `openPath` answers here, and it may claim a file the
+ * session never changed, which `resolve` deliberately will not. Sources
+ * without it fall back to the same guess prose gets.
+ */
+export function fileTabForPath(sessionId: string | null, path: string): TransientTab | undefined {
+  for (const source of pluginFileLinks()) {
+    const tab = source.openPath?.(sessionId, path) ?? source.resolve(sessionId, path);
+    if (tab !== undefined) return tab;
+  }
+  return undefined;
+}
+/**
  * Resolves the paths a message names against the plugins that track them.
  *
  * The resolver's identity is stable while the linkable set is, so a component

--- a/packages/clients/doompi-web/src/web/lib/contextComposition.ts
+++ b/packages/clients/doompi-web/src/web/lib/contextComposition.ts
@@ -1,4 +1,4 @@
-import type { MinorModeProjection } from '../../types/hub.ts';
+import type { ContextProjection, MinorModeProjection } from '../../types/hub.ts';
 import { minorModes } from './composition.ts';
 import { parseSelection } from './statusLine.ts';
 
@@ -38,8 +38,10 @@ export interface ContextGroup {
   /** A short qualifier shown beside the label, e.g. a pending switch. */
   detail: string;
   items: ContextItem[];
-  /** Subtotal across `items`, or null when no item carries a figure. */
+  /** Subtotal across active items, or null when no item carries a figure. */
   tokens: number | null;
+  /** What the group's gated items would add if switched on. */
+  inactiveTokens: number;
 }
 
 function bySource(left: ContextItem, right: ContextItem): number {
@@ -54,7 +56,7 @@ function subtotal(items: readonly ContextItem[]): number | null {
 
 function group(id: string, label: string, kind: ContextGroupKind, detail: string, items: ContextItem[]): ContextGroup {
   const sorted = [...items].sort(bySource);
-  return { id, label, kind, detail, items: sorted, tokens: subtotal(sorted) };
+  return { id, label, kind, detail, items: sorted, tokens: subtotal(sorted), inactiveTokens: 0 };
 }
 
 /**
@@ -113,8 +115,86 @@ export function contextGroups(
   return groups.sort((left, right) => KIND_ORDER[left.kind] - KIND_ORDER[right.kind]);
 }
 
+/**
+ * The runtime's own grouping, used as published.
+ *
+ * Once the session reports a composition it already knows which mode admitted
+ * each tool, which is a join the page cannot make for itself. Re-deriving it
+ * here from status strings would only be able to disagree.
+ */
+export function projectedGroups(projection: ContextProjection): ContextGroup[] {
+  return projection.groups.map((group) => ({
+    id: group.id,
+    label: group.label,
+    kind: group.kind,
+    detail: '',
+    inactiveTokens: group.inactiveTokens,
+    items: group.items.map((item) => ({
+      name: item.name,
+      itemKind: item.itemKind,
+      source: item.source,
+      owner: item.owner,
+      tokens: item.tokens,
+      active: item.active,
+    })),
+    tokens: group.tokens,
+  }));
+}
+
 /** The whole composition's estimate, or null while nothing is priced. */
 export function totalTokens(groups: readonly ContextGroup[]): number | null {
   const priced = groups.filter((entry) => entry.tokens !== null);
   return priced.length === 0 ? null : priced.reduce((total, entry) => total + (entry.tokens ?? 0), 0);
+}
+
+/**
+ * One package, server, or plugin inside a mode, with what it costs.
+ *
+ * A mode can admit two dozen tools from a dozen packages, and a flat list of
+ * those names says nothing about which dependency to reconsider. The package is
+ * the unit that gets added or removed, so it is the unit worth totalling.
+ */
+export interface ContextOwner {
+  owner: string;
+  /** Every tool a single owner registers shares one source kind. */
+  source: ContextItemSource;
+  items: ContextItem[];
+  tokens: number;
+  inactiveTokens: number;
+}
+
+/** The scope is noise once the rows beneath already name the package. */
+export function ownerLabel(owner: string): string {
+  return owner.startsWith('@') ? (owner.split('/').pop() ?? owner) : owner;
+}
+
+export function ownersOf(group: ContextGroup): ContextOwner[] {
+  const byOwner = new Map<string, ContextOwner>();
+  for (const item of group.items) {
+    const existing = byOwner.get(item.owner);
+    if (existing) {
+      existing.items.push(item);
+      existing.tokens += item.active ? (item.tokens ?? 0) : 0;
+      existing.inactiveTokens += item.active ? 0 : (item.tokens ?? 0);
+      continue;
+    }
+    byOwner.set(item.owner, {
+      owner: item.owner,
+      source: item.source,
+      items: [item],
+      tokens: item.active ? (item.tokens ?? 0) : 0,
+      inactiveTokens: item.active ? 0 : (item.tokens ?? 0),
+    });
+  }
+  for (const entry of byOwner.values()) entry.items.sort((left, right) => left.name.localeCompare(right.name));
+  return [...byOwner.values()].sort(
+    (left, right) =>
+      SOURCE_ORDER[left.source] - SOURCE_ORDER[right.source] ||
+      ownerLabel(left.owner).localeCompare(ownerLabel(right.owner)),
+  );
+}
+
+/** What every gated item across the composition would add if switched on. */
+export function inactiveTotal(groups: readonly ContextGroup[]): number {
+  return groups.reduce((total, entry) => total + entry.inactiveTokens, 0);
 }

--- a/packages/clients/doompi-web/src/web/lib/contextComposition.ts
+++ b/packages/clients/doompi-web/src/web/lib/contextComposition.ts
@@ -1,0 +1,120 @@
+import type { MinorModeProjection } from '../../types/hub.ts';
+import { minorModes } from './composition.ts';
+import { parseSelection } from './statusLine.ts';
+
+/**
+ * What the session is composed of, as opposed to what it is doing.
+ *
+ * The activity dock answers "what is running"; this answers "what is loaded and
+ * what does carrying it cost". A group is a mode, because a mode is the thing a
+ * reader can actually switch off: grouping by source would name the mechanism
+ * rather than the decision. Rows inside a group are ordered by source kind so
+ * the session's own extensions read before anything a server or plugin added.
+ */
+export type ContextGroupKind = 'major' | 'minor' | 'domain' | 'core';
+
+export type ContextItemSource = 'extension' | 'mcp' | 'plugin' | 'core';
+
+/** Extensions first: they are the session's own, and the eye starts there. */
+const SOURCE_ORDER: Record<ContextItemSource, number> = { extension: 0, mcp: 1, plugin: 2, core: 3 };
+
+const KIND_ORDER: Record<ContextGroupKind, number> = { major: 0, minor: 1, domain: 2, core: 3 };
+
+export interface ContextItem {
+  name: string;
+  itemKind: 'tool' | 'skill';
+  source: ContextItemSource;
+  /** The package or server that registered it. */
+  owner: string;
+  /** Estimated tokens, or null while the runtime has not reported a figure. */
+  tokens: number | null;
+  active: boolean;
+}
+
+export interface ContextGroup {
+  id: string;
+  label: string;
+  kind: ContextGroupKind;
+  /** A short qualifier shown beside the label, e.g. a pending switch. */
+  detail: string;
+  items: ContextItem[];
+  /** Subtotal across `items`, or null when no item carries a figure. */
+  tokens: number | null;
+}
+
+function bySource(left: ContextItem, right: ContextItem): number {
+  return SOURCE_ORDER[left.source] - SOURCE_ORDER[right.source] || left.name.localeCompare(right.name);
+}
+
+/** A group with nothing priced reports null rather than a confident zero. */
+function subtotal(items: readonly ContextItem[]): number | null {
+  const priced = items.filter((item) => item.tokens !== null);
+  return priced.length === 0 ? null : priced.reduce((total, item) => total + (item.tokens ?? 0), 0);
+}
+
+function group(id: string, label: string, kind: ContextGroupKind, detail: string, items: ContextItem[]): ContextGroup {
+  const sorted = [...items].sort(bySource);
+  return { id, label, kind, detail, items: sorted, tokens: subtotal(sorted) };
+}
+
+/**
+ * The composition the session is running under.
+ *
+ * Until the runtime publishes its inventory every group is empty, which is the
+ * honest reading: the modes are known from the footer the session already
+ * publishes, the tools they brought are not.
+ */
+export function contextGroups(
+  statuses: Record<string, string>,
+  widgets: readonly string[],
+  projection: MinorModeProjection | null = null,
+  items: readonly ContextItem[] = [],
+  attribution: Readonly<Record<string, string>> = {},
+): ContextGroup[] {
+  const selection = parseSelection(statuses['doom-major-mode'] ?? '');
+  const byGroup = new Map<string, ContextItem[]>();
+  for (const item of items) {
+    const key = attribution[item.name] ?? 'core';
+    const bucket = byGroup.get(key);
+    if (bucket) bucket.push(item);
+    else byGroup.set(key, [item]);
+  }
+  const take = (key: string): ContextItem[] => byGroup.get(key) ?? [];
+
+  const groups: ContextGroup[] = [];
+
+  if (selection.majorMode) {
+    groups.push(
+      group(
+        selection.majorMode,
+        selection.majorMode,
+        'major',
+        selection.pending ? 'switching' : '',
+        take(selection.majorMode),
+      ),
+    );
+  }
+
+  for (const mode of minorModes(statuses, widgets, projection)) {
+    if (mode.availability !== 'on') continue;
+    groups.push(group(mode.id, mode.name, 'minor', mode.detail, take(mode.id)));
+  }
+
+  for (const domain of [...selection.domains].sort((left, right) => left.localeCompare(right))) {
+    groups.push(group(domain, domain, 'domain', '', take(domain)));
+  }
+
+  // Pi's own tools, and anything the runtime could not attribute. An
+  // unattributed tool is still costing context, so it is listed rather than
+  // dropped for failing to name a sponsor.
+  const orphans = take('core');
+  if (orphans.length > 0) groups.push(group('core', 'core', 'core', '', orphans));
+
+  return groups.sort((left, right) => KIND_ORDER[left.kind] - KIND_ORDER[right.kind]);
+}
+
+/** The whole composition's estimate, or null while nothing is priced. */
+export function totalTokens(groups: readonly ContextGroup[]): number | null {
+  const priced = groups.filter((entry) => entry.tokens !== null);
+  return priced.length === 0 ? null : priced.reduce((total, entry) => total + (entry.tokens ?? 0), 0);
+}

--- a/packages/clients/doompi-web/src/web/lib/pluginRegistry.ts
+++ b/packages/clients/doompi-web/src/web/lib/pluginRegistry.ts
@@ -5,6 +5,7 @@ import type {
   MinorModeContribution,
   PaletteCommandContribution,
   RepositorySettingsPanelContribution,
+  SettingsPanelContribution,
   SettingsSectionContribution,
   SelectionAxisContribution,
   SessionChannelContribution,
@@ -98,6 +99,7 @@ interface RegistryState {
   minorModes: MinorModeContribution[];
   activityGroups: ActivityGroupContribution[];
   settingsSections: SettingsSectionContribution[];
+  settingsPanels: InstalledSettingsPanel[];
   toolRenderers: Map<string, ToolRendererContribution>;
   toolMatchers: ToolRendererContribution[];
   slots: Map<string, SlotDeclaration>;
@@ -117,6 +119,7 @@ function emptyState(): RegistryState {
     minorModes: [],
     activityGroups: [],
     settingsSections: [],
+    settingsPanels: [],
     toolRenderers: new Map(),
     toolMatchers: [],
     slots: new Map(),
@@ -335,9 +338,16 @@ export function installWebPlugins(plugins: readonly WebPluginDefinition[]): void
     for (const tab of plugin.tabs ?? []) {
       if (claim(owners.tab, 'tab', tab.id, plugin.id)) state.tabs.push(tab);
     }
+    // A panel and a section both become a /settings/:id route, so the two
+    // share one id namespace rather than racing to own the same URL.
     for (const section of plugin.settingsSections ?? []) {
       if (claim(owners['settings-section'], 'settings-section', section.id, plugin.id)) {
         state.settingsSections.push(section);
+      }
+    }
+    for (const panel of plugin.settingsPanels ?? []) {
+      if (claim(owners['settings-section'], 'settings-section', panel.id, plugin.id)) {
+        state.settingsPanels.push({ pluginId: plugin.id, ...panel });
       }
     }
     for (const channel of plugin.channels ?? []) {
@@ -455,6 +465,15 @@ export function webTabs(): readonly TabContribution[] {
  */
 export function pluginSettingsSections(): readonly SettingsSectionContribution[] {
   return state.settingsSections;
+}
+
+export interface InstalledSettingsPanel extends SettingsPanelContribution {
+  pluginId: string;
+}
+
+/** The settings pages plugins draw themselves, in install order; the reader sorts them with the sections. */
+export function pluginSettingsPanels(): readonly InstalledSettingsPanel[] {
+  return state.settingsPanels;
 }
 
 /** The fills placed into one slot, in slot order; empty for a slot nobody declared. */

--- a/packages/clients/doompi-web/src/web/lib/pluginSlotProps.ts
+++ b/packages/clients/doompi-web/src/web/lib/pluginSlotProps.ts
@@ -1,5 +1,6 @@
 import type { SlotDataFill, SlotDeclaration, TransientTab, WebPluginSlotProps } from '@agimon-ai/doompi-web-contracts';
 import { createElement, type ReactNode } from 'react';
+import { fileTabForPath } from './composition.ts';
 import { slotFills } from './pluginRegistry.ts';
 import { renderThread } from './threadRenderer.ts';
 import { sendFrame } from './transport.ts';
@@ -27,6 +28,9 @@ export function pluginSlotProps(
     openTab,
     openTransientTab: tabs.open,
     closeTransientTab: tabs.close,
+    // Asked per render rather than bound to a snapshot: which plugin claims a
+    // path is a property of what is installed, and the answer is cheap.
+    fileTabFor: (path) => fileTabForPath(sessionId, path),
     appendComposerDraft,
     sendSessionFrame: sendFrame,
     statuses,

--- a/packages/clients/doompi-web/src/web/lib/sessionModel.ts
+++ b/packages/clients/doompi-web/src/web/lib/sessionModel.ts
@@ -1,5 +1,11 @@
 import type { ToolResultView } from '@agimon-ai/doompi-web-contracts';
-import { DIALOG_ANSWERED_TYPE, MINOR_MODE_ENTRY_TYPE, type MinorModeProjection } from '../../types/hub.ts';
+import {
+  CONTEXT_ENTRY_TYPE,
+  type ContextProjection,
+  DIALOG_ANSWERED_TYPE,
+  MINOR_MODE_ENTRY_TYPE,
+  type MinorModeProjection,
+} from '../../types/hub.ts';
 import { BUILTIN_COMMANDS } from './commands.ts';
 
 export type EntryKind = 'user' | 'assistant' | 'tool' | 'notice';
@@ -138,6 +144,8 @@ export interface SessionState {
   editorTextRequest: EditorTextRequest | null;
   /** The runtime's minor-mode catalog as last journaled, or null before it reports. */
   minorModes: MinorModeProjection | null;
+  /** What the session is composed of, as last journaled, or null before it reports. */
+  context: ContextProjection | null;
   /** Tool calls seen since the current run began, reported when it settles. */
   toolsThisRun: number;
   /**
@@ -185,6 +193,7 @@ export const initialSessionState: SessionState = {
   dialog: null,
   editorTextRequest: null,
   minorModes: null,
+  context: null,
   toolsThisRun: 0,
   restoredIds: [],
   pendingUserEntries: [],
@@ -771,6 +780,11 @@ export function reduceSession(state: SessionState, frame: Frame, options: Reduce
         const data = isRecord(entry.data) ? entry.data : undefined;
         if (!data || !Array.isArray(data.modes)) return state;
         return { ...state, minorModes: data as unknown as MinorModeProjection };
+      }
+      if (entry.type === 'custom' && entry.customType === CONTEXT_ENTRY_TYPE) {
+        const data = isRecord(entry.data) ? entry.data : undefined;
+        if (!data || !Array.isArray(data.groups)) return state;
+        return { ...state, context: data as unknown as ContextProjection };
       }
       // A journalled user message is a transcript entry the protocol already
       // publishes; the catalog above is DoomPi's own and always applies.

--- a/packages/clients/doompi-web/src/web/lib/settingsSections.ts
+++ b/packages/clients/doompi-web/src/web/lib/settingsSections.ts
@@ -1,8 +1,10 @@
 import type { SettingsSectionContribution } from '@agimon-ai/doompi-web-contracts';
 import {
   pluginRepositorySettingsPanels,
+  pluginSettingsPanels,
   pluginSettingsSections,
   type InstalledRepositorySettingsPanel,
+  type InstalledSettingsPanel,
 } from './pluginRegistry.ts';
 
 /**
@@ -25,6 +27,8 @@ export interface SettingsSection {
   contribution?: SettingsSectionContribution;
   /** Package panel hosted inside the repository workspace. */
   repositoryPanel?: InstalledRepositorySettingsPanel;
+  /** A page the contributing package draws itself, rather than fields the host renders. */
+  panel?: InstalledSettingsPanel;
 }
 
 const GENERAL_SETTINGS_SECTIONS: readonly SettingsSection[] = [
@@ -75,7 +79,12 @@ const REPOSITORY_SECTION_PREFIX = 'repository-';
 export const DEFAULT_SETTINGS_SECTION = GENERAL_SETTINGS_SECTIONS[0]!.id;
 export const DEFAULT_REPOSITORY_SETTINGS_SECTION = REPOSITORY_DEFAULTS_SECTION.id;
 
-function byMenuOrder(left: SettingsSectionContribution, right: SettingsSectionContribution): number {
+interface MenuOrdered {
+  id: string;
+  order?: number;
+}
+
+function byMenuOrder(left: MenuOrdered, right: MenuOrdered): number {
   return (
     (left.order ?? DEFAULT_CONTRIBUTED_ORDER) - (right.order ?? DEFAULT_CONTRIBUTED_ORDER) ||
     left.id.localeCompare(right.id)
@@ -106,6 +115,15 @@ export function settingsSections(workspace?: SettingsWorkspace): readonly Settin
     workspace: 'repository' as const,
     contribution,
   }));
+  // A self-drawn page has no scope to switch: it reports rather than writes,
+  // so it appears once, in the general workspace, and not as a repository copy.
+  const panels = [...pluginSettingsPanels()].sort(byMenuOrder).map((panel) => ({
+    id: panel.id,
+    label: panel.label,
+    detail: panel.detail,
+    workspace: 'general' as const,
+    panel,
+  }));
   const repositoryPanels = pluginRepositorySettingsPanels().map((repositoryPanel) => ({
     id: `${REPOSITORY_SECTION_PREFIX}${repositoryPanel.pluginId}`,
     label: repositoryPanel.label,
@@ -116,6 +134,7 @@ export function settingsSections(workspace?: SettingsWorkspace): readonly Settin
   const all = [
     ...GENERAL_SETTINGS_SECTIONS,
     ...contributed,
+    ...panels,
     REPOSITORY_DEFAULTS_SECTION,
     ...repositoryPanels,
     ...contributedForRepository,

--- a/packages/clients/doompi-web/src/web/lib/timelineGroups.ts
+++ b/packages/clients/doompi-web/src/web/lib/timelineGroups.ts
@@ -1,0 +1,91 @@
+import type { StatusTone } from '@agimon-ai/doompi-web-components';
+import type { TimelineEntry, ToolEntry } from './sessionModel.ts';
+
+/**
+ * Runs of the same tool, gathered so the transcript draws one frame instead of
+ * five.
+ *
+ * An agent rarely calls a tool once: it reads four files, or runs five
+ * commands, and each call arrives as its own entry. Rendered one card apiece
+ * that reads as repetition rather than as progress, so adjacent calls of the
+ * same tool are handed to the timeline as a single unit. Grouping is decided
+ * here, on the entry list alone, so it can be tested without a browser and the
+ * component stays a renderer.
+ */
+
+/** Two calls are the fewest that can read as a repetition, so a lone call keeps its card. */
+const MIN_GROUP = 2;
+
+export interface SingleUnit {
+  readonly kind: 'single';
+  readonly entry: TimelineEntry;
+  /** The entry's index in the source list, for the timeline's live-tail window. */
+  readonly index: number;
+}
+
+export interface GroupUnit {
+  readonly kind: 'group';
+  readonly name: string;
+  readonly entries: readonly ToolEntry[];
+  /** The index of the last entry in the run, so a group is skipped only once it is fully above the tail. */
+  readonly index: number;
+}
+
+export type TimelineUnit = SingleUnit | GroupUnit;
+
+function isTool(entry: TimelineEntry | undefined): entry is ToolEntry {
+  return entry?.kind === 'tool';
+}
+
+/**
+ * The entries as units to render.
+ *
+ * `groupable` decides which tool names may be gathered: a tool whose renderer
+ * presents itself as a message, not a card, has no frame to share and stays on
+ * its own. Only adjacent entries group, so anything between two calls, an
+ * assistant reply or a notice, ends the run and keeps the transcript in order.
+ */
+export function timelineUnits(
+  entries: readonly TimelineEntry[],
+  groupable: (name: string) => boolean,
+): readonly TimelineUnit[] {
+  const units: TimelineUnit[] = [];
+  let index = 0;
+  while (index < entries.length) {
+    const entry = entries[index];
+    if (entry === undefined) break;
+    if (!isTool(entry) || !groupable(entry.name)) {
+      units.push({ kind: 'single', entry, index });
+      index += 1;
+      continue;
+    }
+    const run: ToolEntry[] = [entry];
+    let next = index + 1;
+    while (next < entries.length) {
+      const candidate = entries[next];
+      if (!isTool(candidate) || candidate.name !== entry.name) break;
+      run.push(candidate);
+      next += 1;
+    }
+    if (run.length < MIN_GROUP) units.push({ kind: 'single', entry, index });
+    else units.push({ kind: 'group', name: entry.name, entries: run, index: next - 1 });
+    index = next;
+  }
+  return units;
+}
+
+/**
+ * The group's own outcome: the worst thing in it. A run that is still going
+ * reads as running, a run with a failure in it reads as failed, and only a run
+ * where everything landed reads as ok.
+ */
+export function groupTone(entries: readonly ToolEntry[]): StatusTone {
+  if (entries.some((entry) => entry.running)) return 'running';
+  if (entries.some((entry) => entry.isError)) return 'error';
+  return 'ok';
+}
+
+/** `5 calls`, the line beside the tool's name in the group header. */
+export function groupSummary(entries: readonly ToolEntry[]): string {
+  return `${String(entries.length)} call${entries.length === 1 ? '' : 's'}`;
+}

--- a/packages/clients/doompi-web/src/web/routes/SettingsPage.tsx
+++ b/packages/clients/doompi-web/src/web/routes/SettingsPage.tsx
@@ -11,6 +11,7 @@ import { RepositoryWorkspace } from '../features/settings/RepositoryWorkspace.ts
 import { ProviderSettings } from '../features/settings/ProviderSettings.tsx';
 import { RemoteControlSettings } from '../features/settings/RemoteControlSettings.tsx';
 import { SettingsMenu } from '../features/settings/SettingsMenu.tsx';
+import { SettingsPanelHost } from '../features/settings/SettingsPanelHost.tsx';
 import {
   DEFAULT_REPOSITORY_SETTINGS_SECTION,
   DEFAULT_SETTINGS_SECTION,
@@ -136,6 +137,7 @@ export function SettingsPage() {
               {current?.contribution === undefined ? null : (
                 <ContributedSettings section={current.contribution} scope="global" />
               )}
+              {current?.panel === undefined ? null : <SettingsPanelHost panel={current.panel} />}
             </section>
           </div>
         )}

--- a/packages/clients/doompi-web/src/web/stores/uiStore.ts
+++ b/packages/clients/doompi-web/src/web/stores/uiStore.ts
@@ -2,10 +2,22 @@ import { Store } from '@tanstack/store';
 
 /** Where the page remembers its chrome layout; one key per machine. */
 const DOCK_STORAGE_KEY = 'doompi.web.dock';
+const DOCK_TAB_STORAGE_KEY = 'doompi.web.dock-tab';
+
+/**
+ * Which face of the dock is showing.
+ *
+ * `activity` is asynchronous work that outlives the turn; `context` is the
+ * composition that work runs under. Both answer "what is this session doing",
+ * so they share one column rather than competing for it.
+ */
+export type DockTab = 'activity' | 'context';
 
 export interface UiState {
   /** Whether the activity dock is shown; survives route changes and reloads. */
   dockOpen: boolean;
+  /** Which dock tab is selected; survives route changes and reloads. */
+  dockTab: DockTab;
 }
 
 function readDock(): boolean {
@@ -16,12 +28,29 @@ function readDock(): boolean {
   }
 }
 
-export const uiStore = new Store<UiState>({ dockOpen: readDock() });
+function readDockTab(): DockTab {
+  try {
+    return window.localStorage.getItem(DOCK_TAB_STORAGE_KEY) === 'context' ? 'context' : 'activity';
+  } catch {
+    return 'activity';
+  }
+}
+
+export const uiStore = new Store<UiState>({ dockOpen: readDock(), dockTab: readDockTab() });
 
 export function setDockOpen(open: boolean): void {
   uiStore.setState((state) => (state.dockOpen === open ? state : { ...state, dockOpen: open }));
   try {
     window.localStorage.setItem(DOCK_STORAGE_KEY, open ? 'open' : 'closed');
+  } catch {
+    // A layout preference is a convenience; losing it costs one click.
+  }
+}
+
+export function setDockTab(tab: DockTab): void {
+  uiStore.setState((state) => (state.dockTab === tab ? state : { ...state, dockTab: tab }));
+  try {
+    window.localStorage.setItem(DOCK_TAB_STORAGE_KEY, tab);
   } catch {
     // A layout preference is a convenience; losing it costs one click.
   }

--- a/packages/clients/doompi-web/tests/e2e/activity.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/activity.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '../support/cockpit.ts';
-import { writeRunnerRecord } from '../support/runnerRuns.ts';
+import { appendRunnerLog, writeRunnerRecord } from '../support/runnerRuns.ts';
 import { writeWorkflowRun } from '../support/workflowRuns.ts';
 
 // The dock's groups are declared by doompi-team, doompi-runner, and
@@ -168,6 +168,8 @@ test('the runners group lists only what is up now, and a row opens its log', asy
       exit: { reason: 'completed', code: 1, signal: null, finishedAt: new Date().toISOString() },
     },
   });
+  // A runner that has not written anything yet still has to say what it is.
+  writeRunnerRecord(cockpit.runnerStore, 's1', { id: 'runner-quiet', name: 'quiet', command: 'pnpm build' });
 
   await page.goto(cockpit.url);
   await cockpit.session.waitForAttach();
@@ -177,7 +179,20 @@ test('the runners group lists only what is up now, and a row opens its log', asy
   await expect(row).toBeVisible();
   await expect(row).toHaveAttribute('data-runner-tone', 'running');
   await expect(row).toContainText('api');
-  await expect(row).toContainText('pnpm dev --filter api');
+  // A running row shows what the runner is doing, not what it was asked to do:
+  // the command never changes, and the last log line is the progress.
+  const detail = page.getByTestId('activity-runner-detail-runner-api');
+  await expect(detail).toHaveAttribute('data-detail', 'tail');
+  await expect(detail).toHaveText('GET /missing 404');
+
+  // The line follows the log, so a row left open keeps up with the run.
+  appendRunnerLog(cockpit.runnerStore, 's1', 'runner-api', 'GET /health 200\nPOST /orders 201\n');
+  await expect(detail).toHaveText('POST /orders 201');
+
+  // Until the first line lands, the command is what the row has to say.
+  const quiet = page.getByTestId('activity-runner-detail-runner-quiet');
+  await expect(quiet).toHaveAttribute('data-detail', 'command');
+  await expect(quiet).toHaveText('pnpm build');
   await expect(page.getByTestId('activity-runner-runner-old')).toHaveCount(0);
   await expect(page.getByTestId('activity-summary-runners')).toBeHidden();
 

--- a/packages/clients/doompi-web/tests/e2e/context.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/context.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '../support/cockpit.ts';
+
+// The context face reads the same footer status line the composer chips read,
+// so these drive it the way DoomPi really publishes it rather than seeding a
+// store directly.
+const status = (statusKey: string, statusText?: string) => ({
+  type: 'extension_ui_request',
+  id: `st-${statusKey}-${Math.random()}`,
+  method: 'setStatus',
+  statusKey,
+  ...(statusText === undefined ? {} : { statusText }),
+});
+
+const SELECTION = '[copilot]:development,testing';
+
+test('opens on activity and offers context beside it', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+
+  await expect(page.getByTestId('activity-dock')).toBeVisible();
+  await expect(page.getByTestId('dock-tab-activity')).toHaveAttribute('data-active', 'true');
+  await expect(page.getByTestId('dock-tab-context')).toHaveAttribute('data-active', 'false');
+  await expect(page.getByTestId('activity-scroll')).toBeVisible();
+  await expect(page.getByTestId('context-panel')).toBeHidden();
+});
+
+test('swaps the dock body for the composition without losing the dock', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+
+  await page.getByTestId('dock-tab-context').click();
+
+  await expect(page.getByTestId('context-panel')).toBeVisible();
+  await expect(page.getByTestId('activity-scroll')).toBeHidden();
+  // The frame survives the swap: the dock and its hide control are host-owned.
+  await expect(page.getByTestId('activity-dock')).toBeVisible();
+  await expect(page.getByTestId('activity-close')).toBeVisible();
+});
+
+test('groups the active major mode and its domains under # heads', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForAttach();
+
+  cockpit.session.emit(status('doom-major-mode', SELECTION));
+  await page.getByTestId('dock-tab-context').click();
+
+  await expect(page.getByTestId('context-group-copilot')).toBeVisible();
+  await expect(page.getByTestId('context-group-development')).toBeVisible();
+  await expect(page.getByTestId('context-group-testing')).toBeVisible();
+  await expect(page.getByTestId('context-group-copilot')).toHaveAttribute('data-kind', 'major');
+  await expect(page.getByTestId('context-group-development')).toHaveAttribute('data-kind', 'domain');
+  await expect(page.getByTestId('context-empty')).toBeHidden();
+});
+
+test('says so plainly when the session has published no composition', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+
+  await page.getByTestId('dock-tab-context').click();
+
+  await expect(page.getByTestId('context-empty')).toBeVisible();
+});
+
+test('reports the estimate as an estimate', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForAttach();
+
+  cockpit.session.emit(status('doom-major-mode', SELECTION));
+  await page.getByTestId('dock-tab-context').click();
+
+  // Nothing is priced until the runtime publishes an inventory, and an em dash
+  // is the honest reading of that rather than a confident zero.
+  await expect(page.getByTestId('context-total')).toHaveText('—');
+  await expect(page.getByTestId('context-panel')).toContainText('not a billed total');
+});

--- a/packages/clients/doompi-web/tests/e2e/settings.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/settings.spec.ts
@@ -178,3 +178,33 @@ test.describe('with the synced bundle', () => {
     await expect(page.getByTestId('settings-plugin-diagnostics-empty')).toBeVisible();
   });
 });
+
+// The metrics page is contributed by doompi-log, so it exists only in the
+// synced-style bundle the Playwright global setup composes from every
+// workspace plugin. The package's own dist ships the shell with an empty
+// plugin registry.
+test.describe('with the synced bundle, which carries the doompi-log metrics page', () => {
+  test.use({ assets: 'synced' });
+
+  test('opens the metrics page and settles on a state it can name', async ({ page, cockpit }) => {
+    await page.goto(cockpit.url);
+    await cockpit.session.waitForAttach();
+
+    await page.getByTestId('settings-open').click();
+    await page.getByTestId('settings-section-metrics').click();
+    await expect(page).toHaveURL(/\/settings\/metrics$/);
+
+    // The page is drawn by the package rather than rendered from declared
+    // fields, so reaching it exercises the whole settings-panel contribution.
+    await expect(page.getByTestId('settings-panel-metrics')).toBeVisible();
+    await expect(page.getByTestId('metrics-panel')).toBeVisible();
+
+    // Whether a log sink runs is a property of the machine, not of the
+    // cockpit, so this asserts the page reaches a state it can explain rather
+    // than pinning one of them. An unexplained error is the actual failure.
+    await expect(page.getByTestId('metrics-empty').or(page.getByTestId('metrics-group-bars'))).toBeVisible({
+      timeout: FIRST_READ_MS,
+    });
+    await expect(page.getByTestId('metrics-error')).toHaveCount(0);
+  });
+});

--- a/packages/clients/doompi-web/tests/e2e/toolRenderers.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/toolRenderers.spec.ts
@@ -440,3 +440,32 @@ test('a run of calls to one tool shares a frame, and a lone call keeps its card'
   await expect(page.getByTestId('entry-tool-group')).toHaveCount(1);
   await expect(page.getByTestId('entry-tool')).toHaveCount(4);
 });
+
+/**
+ * The path in a call header is the shortest way to the file itself.
+ *
+ * A read is the case that has to work without the file-edit timeline: the
+ * session never changed this file, so the only thing that can open it is the
+ * preview route, bounded by the working directory. What this suite proves is
+ * the click and the tab it raises. It cannot prove what the tab then shows,
+ * because the fixture's session API socket serves the runner route and nothing
+ * else, so the preview request has no route to reach; the route itself is
+ * covered against a real filesystem in doompi-file-edit's own tests.
+ */
+test('a read call opens its file from the path in the header', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForAttach();
+  cockpit.session.emit({
+    type: 'tool_execution_start',
+    toolCallId: 'call-link',
+    toolName: 'read',
+    args: { path: 'src/Unchanged.ts' },
+  });
+
+  await page.getByTestId('tool-call-read').getByTestId('tool-path').click();
+  await expect(page.getByTestId('files-preview-panel')).toBeVisible();
+  await expect(page.getByTestId('files-preview-breadcrumb')).toContainText('src/Unchanged.ts');
+  // The tab is the file's own, not the changed-file tab, which this file has no
+  // history for.
+  await expect(page).toHaveURL(/\/files-file-[^/]+-preview$/u);
+});

--- a/packages/clients/doompi-web/tests/e2e/toolRenderers.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/toolRenderers.spec.ts
@@ -29,6 +29,10 @@ test('a plugin renders the call and result of the tool it owns', async ({ page, 
     toolCallId: 'call-1',
     partialResult: { content: [{ type: 'text', text: 'running 4 tests' }] },
   });
+  // The bash card is a header row until it is opened, so the streamed tail
+  // only exists once the item is expanded.
+  await expect(page.getByTestId('tool-result-bash')).toHaveCount(0);
+  await page.getByTestId('tool-expand').click();
   await expect(page.getByTestId('tool-result-bash')).toContainText('running 4 tests');
 
   cockpit.session.emit({
@@ -108,12 +112,14 @@ test('the expand toggle hands the plugin renderer its expanded state', async ({ 
     isError: false,
   });
 
-  // Collapsed, the bash card keeps the tail end of the log, as the TUI does.
-  const result = page.getByTestId('tool-result-bash');
-  await expect(result).toContainText('line 30');
-  await expect(result).not.toContainText(/\bline 1\b/);
+  // Collapsed, the bash card is header only; expanding it shows the command as
+  // it was run and the whole tail the frame carried.
+  await expect(page.getByTestId('tool-result-bash')).toHaveCount(0);
   await page.getByTestId('tool-expand').click();
-  await expect(result).toContainText(/\bline 1\b/);
+  const output = page.getByTestId('tool-result-bash-output');
+  await expect(page.getByTestId('tool-result-bash-command')).toContainText('seq 30');
+  await expect(output).toContainText(/\bline 1\b/);
+  await expect(output).toContainText('line 30');
 });
 
 test('the read plugin renders anchored text and attached images', async ({ page, cockpit }) => {
@@ -340,4 +346,97 @@ test('every migrated tool renders a plugin item, never the host fallback', async
     await expect(items.nth(index), entry.tool).toHaveAttribute('data-tool-renderer', 'plugin');
     await expect(items.nth(index), entry.tool).toHaveAttribute('data-tool-state', 'ok');
   }
+});
+
+test('code results wear the editor grammar and log output keeps its own colours', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForAttach();
+
+  const source = ['// a comment', 'const x = 1;'].join('\n');
+  cockpit.session.emit({
+    type: 'tool_execution_start',
+    toolCallId: 'hl-read',
+    toolName: 'read',
+    args: { path: 'src/a.ts' },
+  });
+  cockpit.session.emit({
+    type: 'tool_execution_end',
+    toolCallId: 'hl-read',
+    result: { content: [{ type: 'text', text: '1#abc|// a comment\n2#abd|const x = 1;' }] },
+    isError: false,
+  });
+
+  // The grammar loads in its own chunk, so the plain text paints first and the
+  // colours arrive after; the palette is the editor's, named as theme tokens.
+  const comment = page.locator('[data-testid="tool-result-read"] span[style*="--doom-faint"]');
+  await expect(comment).toHaveText('// a comment');
+
+  // A runner's log keeps the colours the command wrote, so the card renders
+  // them instead of printing the escape sequences as text.
+  const ESC = '\u001B[';
+  const tail = `${ESC}31mError:${ESC}39m no such flag`;
+  cockpit.session.emit({
+    type: 'tool_execution_start',
+    toolCallId: 'hl-bash',
+    toolName: 'bash',
+    args: { command: `echo ${source.length}` },
+  });
+  cockpit.session.emit({
+    type: 'tool_execution_end',
+    toolCallId: 'hl-bash',
+    result: { content: [{ type: 'text', text: tail }], details: { tail, tailLines: 1, exitCode: 0 } },
+    isError: false,
+  });
+  await page.getByTestId('tool-expand').last().click();
+  await expect(page.locator('[data-testid="tool-result-bash-output"] span.text-doom-red')).toHaveText('Error:');
+  await expect(page.getByTestId('tool-result-bash-output')).not.toContainText('[31m');
+});
+
+test('a run of calls to one tool shares a frame, and a lone call keeps its card', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForAttach();
+
+  const call = (id: string, command: string, isError = false): void => {
+    cockpit.session.emit({ type: 'tool_execution_start', toolCallId: id, toolName: 'bash', args: { command } });
+    cockpit.session.emit({
+      type: 'tool_execution_end',
+      toolCallId: id,
+      result: {
+        content: [{ type: 'text', text: 'done' }],
+        details: { tail: 'done', tailLines: 1, exitCode: isError ? 1 : 0 },
+      },
+      isError,
+    });
+  };
+  call('grp-1', 'pnpm lint');
+  call('grp-2', 'pnpm typecheck', true);
+  call('grp-3', 'pnpm test');
+
+  // One frame for the run, and the run reports the worst thing in it.
+  const group = page.getByTestId('entry-tool-group');
+  await expect(group).toHaveCount(1);
+  await expect(group).toHaveAttribute('data-tool-count', '3');
+  await expect(group).toContainText('3 calls');
+  await expect(group.getByTestId('entry-tool')).toHaveCount(3);
+
+  // A row inside the group drops the tool name the group already states, and
+  // stays quiet unless its own outcome differs from the run's.
+  await expect(group.getByTestId('tool-status')).toHaveCount(1);
+  await expect(group.getByTestId('tool-status')).toHaveText('ERROR');
+  await expect(group.getByTestId('entry-tool').first()).not.toContainText('bash');
+
+  // Each row still opens on its own.
+  await group.getByTestId('tool-expand').first().click();
+  await expect(group.getByTestId('tool-result-bash-command').first()).toContainText('pnpm lint');
+
+  // Anything between two calls ends the run, and a single call is still a card.
+  cockpit.session.emit({ type: 'tool_execution_start', toolCallId: 'solo', toolName: 'read', args: { path: 'a.ts' } });
+  cockpit.session.emit({
+    type: 'tool_execution_end',
+    toolCallId: 'solo',
+    result: { content: [{ type: 'text', text: '1#abc|const x = 1;' }] },
+    isError: false,
+  });
+  await expect(page.getByTestId('entry-tool-group')).toHaveCount(1);
+  await expect(page.getByTestId('entry-tool')).toHaveCount(4);
 });

--- a/packages/clients/doompi-web/tests/support/runnerRuns.ts
+++ b/packages/clients/doompi-web/tests/support/runnerRuns.ts
@@ -62,6 +62,32 @@ export function appendRunnerLog(storeDir: string, sessionId: string, runId: stri
 export function startRunnerApiSocket(storeDir: string, sessionId: string, socketPath: string): () => Promise<void> {
   const server = http.createServer((incoming, outgoing) => {
     const url = new URL(incoming.url ?? '/', 'http://session.local');
+    const streaming = /^\/api\/plugin\/runner\/runners\/([^/]+)\/log\/stream$/u.exec(url.pathname);
+    if (streaming) {
+      // The follow half of the same contract: server-sent events carrying the
+      // lines written after `from`, polled off the file the way the real route
+      // tails it. Only what the cockpit reads is implemented.
+      const runId = decodeURIComponent(streaming[1] ?? '');
+      const logPath = path.join(storeDir, sessionId, 'logs', `${runId}.log`);
+      let offset = Number.parseInt(url.searchParams.get('from') ?? '0', 10) || 0;
+      outgoing.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+      const timer = setInterval(() => {
+        const size = fs.existsSync(logPath) ? fs.statSync(logPath).size : 0;
+        if (size <= offset) return;
+        const handle = fs.openSync(logPath, 'r');
+        const buffer = Buffer.alloc(size - offset);
+        fs.readSync(handle, buffer, 0, buffer.length, offset);
+        fs.closeSync(handle);
+        offset = size;
+        const lines = buffer
+          .toString('utf8')
+          .split('\n')
+          .filter((line) => line !== '');
+        if (lines.length > 0) outgoing.write(`event: append\ndata: ${JSON.stringify({ lines })}\n\n`);
+      }, 50);
+      incoming.on('close', () => clearInterval(timer));
+      return;
+    }
     const match = /^\/api\/plugin\/runner\/runners\/([^/]+)\/log$/u.exec(url.pathname);
     if (!match) {
       outgoing.writeHead(404, { 'content-type': 'application/json' });

--- a/packages/clients/doompi-web/tests/unit/contextComposition.test.ts
+++ b/packages/clients/doompi-web/tests/unit/contextComposition.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { type ContextItem, contextGroups, totalTokens } from '../../src/web/lib/contextComposition.ts';
+
+// The same live capture the status-line parser is tested against, so the
+// grouping is driven by what DoomPi really publishes rather than a guess.
+const LIVE_STATUS =
+  '\u001B[38;2;81;175;239m[copilot]\u001B[39m\u001B[38;2;91;98;104m:\u001B[39m\u001B[38;2;156;160;164mdevelopment,testing\u001B[39m';
+
+const statuses = (raw: string): Record<string, string> => ({ 'doom-major-mode': raw });
+
+function item(name: string, source: ContextItem['source'], tokens: number | null): ContextItem {
+  return { name, itemKind: 'tool', source, owner: 'pkg', tokens, active: true };
+}
+
+describe('contextGroups', () => {
+  it('reads the major mode and its domains from the footer status line', () => {
+    const groups = contextGroups(statuses(LIVE_STATUS), []);
+    expect(groups.map((group) => [group.kind, group.label])).toEqual([
+      ['major', 'copilot'],
+      ['domain', 'development'],
+      ['domain', 'testing'],
+    ]);
+  });
+
+  it('marks a pending major-mode switch without inventing a second group', () => {
+    const pending = '\u001B[38;2;236;190;123m[minimal]\u001B[39m\u001B[38;2;156;160;164mdevelopment\u001B[39m';
+    const groups = contextGroups(statuses(pending), []);
+    expect(groups[0]).toMatchObject({ kind: 'major', label: 'minimal', detail: 'switching' });
+  });
+
+  it('reports no groups when the session has published nothing', () => {
+    expect(contextGroups({}, [])).toEqual([]);
+  });
+
+  it('orders rows inside a group by source kind, then by name', () => {
+    const items = [
+      item('zeta_mcp', 'mcp', 10),
+      item('alpha_plugin', 'plugin', 10),
+      item('beta_ext', 'extension', 10),
+      item('alpha_ext', 'extension', 10),
+    ];
+    const attribution = Object.fromEntries(items.map((entry) => [entry.name, 'copilot']));
+    const groups = contextGroups(statuses(LIVE_STATUS), [], null, items, attribution);
+    expect(groups[0]?.items.map((entry) => entry.name)).toEqual(['alpha_ext', 'beta_ext', 'zeta_mcp', 'alpha_plugin']);
+  });
+
+  it('subtotals a group and totals the composition', () => {
+    const items = [item('read', 'extension', 180), item('bash', 'extension', 240), item('scaffold', 'mcp', 910)];
+    const groups = contextGroups(statuses(LIVE_STATUS), [], null, items, {
+      read: 'copilot',
+      bash: 'copilot',
+      scaffold: 'development',
+    });
+    expect(groups.find((group) => group.id === 'copilot')?.tokens).toBe(420);
+    expect(groups.find((group) => group.id === 'development')?.tokens).toBe(910);
+    expect(totalTokens(groups)).toBe(1330);
+  });
+
+  it('lists an unattributed tool under core rather than dropping it', () => {
+    const groups = contextGroups(statuses(LIVE_STATUS), [], null, [item('mystery', 'core', 55)], {});
+    const core = groups.at(-1);
+    expect(core).toMatchObject({ kind: 'core', id: 'core' });
+    expect(core?.items.map((entry) => entry.name)).toEqual(['mystery']);
+  });
+
+  it('reports null rather than a confident zero when nothing is priced', () => {
+    const groups = contextGroups(statuses(LIVE_STATUS), [], null, [item('read', 'extension', null)], {
+      read: 'copilot',
+    });
+    expect(groups[0]?.tokens).toBeNull();
+    expect(totalTokens(groups)).toBeNull();
+  });
+});

--- a/packages/clients/doompi-web/tests/unit/contextComposition.test.ts
+++ b/packages/clients/doompi-web/tests/unit/contextComposition.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { type ContextItem, contextGroups, totalTokens } from '../../src/web/lib/contextComposition.ts';
+import {
+  type ContextItem,
+  contextGroups,
+  ownerLabel,
+  ownersOf,
+  totalTokens,
+} from '../../src/web/lib/contextComposition.ts';
 
 // The same live capture the status-line parser is tested against, so the
 // grouping is driven by what DoomPi really publishes rather than a guess.
@@ -69,5 +75,63 @@ describe('contextGroups', () => {
     });
     expect(groups[0]?.tokens).toBeNull();
     expect(totalTokens(groups)).toBeNull();
+  });
+});
+
+function owned(name: string, owner: string, source: ContextItem['source'], tokens: number, active = true): ContextItem {
+  return { name, itemKind: 'tool', source, owner, tokens, active };
+}
+
+describe('ownersOf', () => {
+  it("gathers a mode's rows under the package that registered them", () => {
+    const items = [
+      owned('task', '@agimon-ai/doompi-task', 'extension', 2482),
+      owned('subagent', '@agimon-ai/doompi-team', 'extension', 758),
+      owned('intercom', '@agimon-ai/doompi-team', 'extension', 257),
+    ];
+    const attribution = Object.fromEntries(items.map((entry) => [entry.name, 'copilot']));
+    const [group] = contextGroups(statuses(LIVE_STATUS), [], null, items, attribution);
+    const owners = ownersOf(group!);
+
+    expect(owners.map((entry) => entry.owner)).toEqual(['@agimon-ai/doompi-task', '@agimon-ai/doompi-team']);
+    expect(owners[1]?.items.map((entry) => entry.name)).toEqual(['intercom', 'subagent']);
+    expect(owners[1]?.tokens).toBe(1015);
+  });
+
+  it('orders packages by source kind before name', () => {
+    const items = [
+      owned('scaffold', 'scaffold-mcp', 'mcp', 10),
+      owned('review', 'testing', 'plugin', 10),
+      owned('bash', '@agimon-ai/doompi-runner', 'extension', 10),
+    ];
+    const attribution = Object.fromEntries(items.map((entry) => [entry.name, 'copilot']));
+    const [group] = contextGroups(statuses(LIVE_STATUS), [], null, items, attribution);
+
+    expect(ownersOf(group!).map((entry) => entry.source)).toEqual(['extension', 'mcp', 'plugin']);
+  });
+
+  // A gated tool belongs to its package but is not being paid for, so the
+  // package subtotal has to keep the two apart exactly as the group total does.
+  it('splits a package subtotal into paid and gated', () => {
+    const items = [
+      owned('narrate', '@agimon-ai/doompi-voice', 'extension', 336, false),
+      owned('use_voice_tools', '@agimon-ai/doompi-voice', 'extension', 391, false),
+    ];
+    const attribution = Object.fromEntries(items.map((entry) => [entry.name, 'copilot']));
+    const [group] = contextGroups(statuses(LIVE_STATUS), [], null, items, attribution);
+    const [voice] = ownersOf(group!);
+
+    expect(voice?.tokens).toBe(0);
+    expect(voice?.inactiveTokens).toBe(727);
+  });
+});
+
+describe('ownerLabel', () => {
+  it('drops the scope, which the rows beneath already imply', () => {
+    expect(ownerLabel('@agimon-ai/doompi-team')).toBe('doompi-team');
+  });
+
+  it('leaves an unscoped server or plugin name alone', () => {
+    expect(ownerLabel('scaffold-mcp')).toBe('scaffold-mcp');
   });
 });

--- a/packages/clients/doompi-web/tests/unit/pluginRegistry.test.ts
+++ b/packages/clients/doompi-web/tests/unit/pluginRegistry.test.ts
@@ -170,6 +170,55 @@ describe('the web plugin registry', () => {
     ]);
   });
 
+  it('places a self-drawn page in the general workspace only, in menu order', () => {
+    installWebPlugins([
+      defineWebPlugin({
+        id: 'log',
+        settingsPanels: [{ id: 'metrics', label: 'metrics', detail: 'tokens and cost', component: Panel }],
+      }),
+      defineWebPlugin({
+        id: 'planning',
+        settingsSections: [{ id: 'planning', label: 'planning', detail: 'plan models', fields: [] }],
+      }),
+    ]);
+
+    expect(settingsSections('general').map((section) => section.id)).toEqual([
+      'providers',
+      'appearance',
+      'notifications',
+      'remote',
+      'plugins',
+      'planning',
+      'metrics',
+    ]);
+    // A drawn page reports rather than writes, so unlike a contributed section
+    // it has no repository copy to offer.
+    expect(settingsSections('repository').map((section) => section.id)).toEqual([
+      'repositories',
+      'repository-planning',
+    ]);
+    expect(settingsSections('general').find((section) => section.id === 'metrics')?.panel?.pluginId).toBe('log');
+  });
+
+  it('refuses a panel whose id a section already claimed', () => {
+    installWebPlugins([
+      defineWebPlugin({
+        id: 'planning',
+        settingsSections: [{ id: 'metrics', label: 'metrics', detail: 'fields', fields: [] }],
+      }),
+      defineWebPlugin({
+        id: 'log',
+        settingsPanels: [{ id: 'metrics', label: 'metrics', detail: 'drawn', component: Panel }],
+      }),
+    ]);
+
+    // Both would route at /settings/metrics, so the second is a diagnostic and
+    // the first keeps the id.
+    expect(settingsSections('general').filter((section) => section.id === 'metrics')).toHaveLength(1);
+    expect(settingsSections('general').find((section) => section.id === 'metrics')?.panel).toBeUndefined();
+    expect(webPluginDiagnostics().map((diagnostic) => diagnostic.kind)).toContain('duplicate-settings-section');
+  });
+
   it('collects leader bindings in install order and refuses keys the TUI would', () => {
     const group = { key: 'w', label: 'workflows' };
     installWebPlugins([

--- a/packages/clients/doompi-web/tests/unit/timelineGroups.test.ts
+++ b/packages/clients/doompi-web/tests/unit/timelineGroups.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { TimelineEntry, ToolEntry } from '../../src/web/lib/sessionModel.ts';
+import { groupSummary, groupTone, timelineUnits } from '../../src/web/lib/timelineGroups.ts';
+
+function tool(id: string, name: string, state: Partial<ToolEntry> = {}): ToolEntry {
+  return {
+    kind: 'tool',
+    id,
+    toolCallId: id,
+    name,
+    args: {},
+    argSummary: '',
+    result: null,
+    output: '',
+    isError: false,
+    running: false,
+    ...state,
+  };
+}
+
+const assistant: TimelineEntry = { kind: 'assistant', id: 'a1', text: 'hi', thinking: '', streaming: false };
+const always = (): boolean => true;
+
+describe('timelineUnits', () => {
+  it('gathers adjacent calls to the same tool into one unit', () => {
+    const units = timelineUnits([tool('1', 'bash'), tool('2', 'bash'), tool('3', 'bash')], always);
+    expect(units).toHaveLength(1);
+    expect(units[0]).toMatchObject({ kind: 'group', name: 'bash', index: 2 });
+    expect(units[0]?.kind === 'group' ? units[0].entries.map((entry) => entry.id) : []).toEqual(['1', '2', '3']);
+  });
+
+  it('leaves a lone call as its own card, because one card is not a repetition', () => {
+    const units = timelineUnits([tool('1', 'bash')], always);
+    expect(units).toEqual([{ kind: 'single', entry: expect.objectContaining({ id: '1' }), index: 0 }]);
+  });
+
+  it('breaks a run at anything between the calls, so the transcript keeps its order', () => {
+    const units = timelineUnits([tool('1', 'bash'), assistant, tool('3', 'bash'), tool('4', 'bash')], always);
+    expect(units.map((unit) => unit.kind)).toEqual(['single', 'single', 'group']);
+    expect(units[2]).toMatchObject({ index: 3 });
+  });
+
+  it('breaks a run when the tool changes', () => {
+    const units = timelineUnits([tool('1', 'read'), tool('2', 'read'), tool('3', 'bash')], always);
+    expect(units.map((unit) => unit.kind)).toEqual(['group', 'single']);
+  });
+
+  it('never groups a tool the caller rules out, such as one that renders as a message', () => {
+    const units = timelineUnits([tool('1', 'voice'), tool('2', 'voice')], (name) => name !== 'voice');
+    expect(units.map((unit) => unit.kind)).toEqual(['single', 'single']);
+  });
+
+  it('indexes each unit by its last entry, so the live-tail window measures the whole run', () => {
+    const units = timelineUnits([assistant, tool('2', 'bash'), tool('3', 'bash')], always);
+    expect(units.map((unit) => unit.index)).toEqual([0, 2]);
+  });
+
+  it('has nothing to say about an empty transcript', () => {
+    expect(timelineUnits([], always)).toEqual([]);
+  });
+});
+
+describe('groupTone', () => {
+  it('reads as the worst outcome in the run', () => {
+    expect(groupTone([tool('1', 'bash'), tool('2', 'bash')])).toBe('ok');
+    expect(groupTone([tool('1', 'bash'), tool('2', 'bash', { isError: true })])).toBe('error');
+    // Still going outranks a failure already in the run: the run is not over.
+    expect(groupTone([tool('1', 'bash', { isError: true }), tool('2', 'bash', { running: true })])).toBe('running');
+  });
+});
+
+describe('groupSummary', () => {
+  it('counts the calls, and says call rather than calls for one', () => {
+    expect(groupSummary([tool('1', 'bash'), tool('2', 'bash')])).toBe('2 calls');
+    expect(groupSummary([tool('1', 'bash')])).toBe('1 call');
+  });
+});

--- a/packages/core/doompi-config/src/adapters/domains.ts
+++ b/packages/core/doompi-config/src/adapters/domains.ts
@@ -210,6 +210,10 @@ export function resolvePluginEntries(
       entries.push({
         name: pluginName,
         directory,
+        // The domain is only in scope here. `resolvePluginDirectories` keeps
+        // just the path, so anything downstream that wants to say which domain
+        // brought a plugin has to be told now or not at all.
+        domain: domainName,
         source: plugin.source,
         ...(plugin.manifest ? { manifest: plugin.manifest } : {}),
         ...(plugin.manifest?.agentPluginSchema === SUPPORTED_AGENT_PLUGIN_SCHEMA

--- a/packages/core/doompi-config/src/adapters/harnessState.ts
+++ b/packages/core/doompi-config/src/adapters/harnessState.ts
@@ -26,6 +26,10 @@ export const FILE_ONLY_STATE_FIELDS: ReadonlySet<keyof HarnessState> = new Set([
   'profileEnvironment',
   'pluginHooks',
   'mcpProjection',
+  // One entry per composed package. Nothing that spawns a process needs it,
+  // and putting a map that size in front of every exec would cost far more
+  // than the one surface that reads it is worth.
+  'packageAttribution',
 ]);
 
 export type HarnessStateParseReporter = (key: string, error: unknown) => void;

--- a/packages/core/doompi-config/src/exports/index.ts
+++ b/packages/core/doompi-config/src/exports/index.ts
@@ -155,6 +155,7 @@ export {
   type HarnessState,
   type IDoomConfigLoader,
   type IDoomConfigService,
+  type PackageAttribution,
   type PlanningAgentConfig,
   type PlanningModeConfig,
   type PlanningThinkingLevel,

--- a/packages/core/doompi-config/src/exports/types.ts
+++ b/packages/core/doompi-config/src/exports/types.ts
@@ -19,6 +19,7 @@ export {
   type HarnessState,
   type IDoomConfigLoader,
   type IDoomConfigService,
+  type PackageAttribution,
   type PlanningAgentConfig,
   type PlanningModeConfig,
   type PlanningThinkingLevel,

--- a/packages/core/doompi-config/src/types/config.ts
+++ b/packages/core/doompi-config/src/types/config.ts
@@ -146,6 +146,16 @@ export interface PluginHookSource {
   configPath: string;
 }
 
+/** What admitted a package into the composition. */
+export interface PackageAttribution {
+  /** `major` for a layer package, `domain` for a plugin a domain carries. */
+  kind: 'major' | 'domain';
+  /** The major mode name, or the domain name. */
+  mode: string;
+  /** The layer the package was listed under; absent for a domain plugin. */
+  layer?: string;
+}
+
 export interface HarnessState {
   root?: string;
   /** The one named major mode this session runs under. */
@@ -154,6 +164,17 @@ export interface HarnessState {
   domains: string[];
   /** The layer components the major mode resolved to. */
   layers: string[];
+  /**
+   * Which mode, layer, or domain admitted each package, keyed by the package
+   * name exactly as its manifest spells it.
+   *
+   * The composition resolves this on its way to a flat list of entry paths and
+   * has no further use for it, so without somewhere to put it the causal link
+   * between a mode and the tools it brought is lost the moment the session
+   * starts. A surface that reports what the session is carrying has to be able
+   * to say what asked for it.
+   */
+  packageAttribution?: Record<string, PackageAttribution>;
   /** Canonical identity shared by launch, sync, children, and reload. */
   compositionFingerprint?: string;
   profile?: string;

--- a/packages/core/doompi-config/src/types/domains.ts
+++ b/packages/core/doompi-config/src/types/domains.ts
@@ -83,6 +83,8 @@ export interface PluginEntry {
   /** Catalog identifier when the entry came from domains.yaml. */
   name?: string;
   directory: string;
+  /** The domain that admitted this plugin; absent for an explicit directory. */
+  domain?: string;
   /** Omitted for legacy programmatic callers that already supply a directory. */
   source?: PluginSource;
   /** Manifest metadata retained so resource adapters can apply schema-gated plugin contracts. */

--- a/packages/core/doompi-config/tests/domains.test.ts
+++ b/packages/core/doompi-config/tests/domains.test.ts
@@ -125,6 +125,7 @@ aliases:
       {
         name: 'one',
         directory: path.join(root, 'plugins', 'one'),
+        domain: 'development',
         source: { type: 'local', path: path.join(root, 'plugins', 'one') },
         skills: ['typescript'],
         agents: ['reviewer'],
@@ -134,6 +135,7 @@ aliases:
       {
         name: 'two',
         directory: path.join(root, 'plugins', 'two'),
+        domain: 'qa',
         source: { type: 'local', path: path.join(root, 'plugins', 'two') },
       },
     ]);

--- a/packages/core/doompi-config/tests/setup.ts
+++ b/packages/core/doompi-config/tests/setup.ts
@@ -128,7 +128,9 @@ describe('Doom configuration', () => {
     // Everything except the documents only the file carries, which every
     // spawned process and every hook would otherwise copy in its environment.
     expect(readHarnessState(environment)).toEqual({ ...state, profileEnvironment: {}, pluginHooks: [] });
-    expect(FILE_ONLY_STATE_FIELDS).toEqual(new Set(['profileEnvironment', 'pluginHooks', 'mcpProjection']));
+    expect(FILE_ONLY_STATE_FIELDS).toEqual(
+      new Set(['profileEnvironment', 'pluginHooks', 'mcpProjection', 'packageAttribution']),
+    );
 
     projectHarnessEnvironment({ personaFile: undefined, profile: undefined }, environment);
     expect(environment).not.toHaveProperty(HARNESS_STATE_KEYS.personaFile);
@@ -143,6 +145,7 @@ describe('Doom configuration', () => {
       root: '/repo',
       profileEnvironment: { MODE: 'strict' },
       pluginHooks: [{ pluginRoot: '/plugin', configPath: '/plugin/hooks.json' }],
+      packageAttribution: { '@agimon-ai/doompi-team': { kind: 'major' as const, mode: 'copilot', layer: 'team' } },
       mcpProjection: {
         version: 1 as const,
         enabled: false,

--- a/packages/core/doompi-skill/src/adapters/skillCatalog.ts
+++ b/packages/core/doompi-skill/src/adapters/skillCatalog.ts
@@ -19,6 +19,14 @@ export interface SkillEntry {
   /** Package name for an extension, plugin directory name, or `.claude/skills`. */
   owner: string;
   modelInvocable: boolean;
+  /**
+   * What removing this skill would save from the `<available_skills>` block.
+   *
+   * Marginal rather than proportional: the block has fixed framing that no
+   * single skill pays for, so the useful figure is what actually goes away.
+   * Bodies are excluded because they load on demand and are not a resting cost.
+   */
+  promptTokens?: number;
 }
 
 export interface SkillOwnerNode {
@@ -216,6 +224,19 @@ export async function buildSkillCatalog(options: SkillCatalogOptions): Promise<S
 
   const countTokens = await counter();
   const prompt = formatSkillsForPrompt(loaded);
+  const framingTokens = countTokens(formatSkillsForPrompt([]));
+  const marginal = new Map<string, number>();
+  for (const skill of loaded) {
+    marginal.set(skill.name, Math.max(0, countTokens(formatSkillsForPrompt([skill])) - framingTokens));
+  }
+  for (const group of groups) {
+    for (const owner of group.owners) {
+      for (const skill of owner.skills) {
+        const tokens = marginal.get(skill.name);
+        if (tokens !== undefined) skill.promptTokens = tokens;
+      }
+    }
+  }
   let bodyTokens = 0;
   for (const skill of loaded) {
     try {

--- a/packages/core/doompi-ui/src/adapters/pi/extension.ts
+++ b/packages/core/doompi-ui/src/adapters/pi/extension.ts
@@ -30,7 +30,7 @@ import { LeaderHints } from '../../tui/leaderHints.ts';
 import { DEFAULT_THEME_NAME } from '../../tui/theme.ts';
 import { openToolsOverlay } from '../../tui/toolsOverlay.ts';
 import { createUiTelemetry, UI_EVENT, type UiTelemetry } from '../telemetry/logSinkTelemetry.ts';
-import { extensionName, extensionToolSource } from './extensionName.ts';
+import { extensionName, extensionPackageName, extensionToolSource } from './extensionName.ts';
 import { registerBuiltinToolUi } from './toolOverrides.ts';
 
 const LEADER_WIDGET_KEY = 'doom-pi-leader';
@@ -124,6 +124,7 @@ function doomPiUiPlugin(cordis: Context, { pi, telemetry, hostMode }: UiPluginOp
         activeTools: pi.getActiveTools(),
         ...(mcpServers ? { mcpServers } : {}),
         resolveExtensionName: extensionName,
+        resolveExtensionPackageName: extensionPackageName,
         resolveExtensionToolSource: (toolName) => extensionToolSource(pi, toolName),
       });
       await openToolsOverlay(ctx, sources);

--- a/packages/core/doompi-ui/src/adapters/pi/extensionName.ts
+++ b/packages/core/doompi-ui/src/adapters/pi/extensionName.ts
@@ -13,6 +13,9 @@ import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 /** Results are stable for the life of a session, and every source hits the same few dirs. */
 const cache = new Map<string, string>();
+// Wrapped, because "no package above this path" is a real answer worth caching
+// and a bare undefined cannot be told apart from a miss.
+const packageCache = new Map<string, { readonly name: string | undefined }>();
 const TOOL_SOURCE_REGISTRY_KEY = '__doompiExtensionToolSources__' as const;
 
 type RegisteredTool = Parameters<ExtensionAPI['registerTool']>[0];
@@ -88,4 +91,21 @@ export function extensionName(entryPath: string): string {
   const resolved = name ? (name.split('/').pop() ?? name) : path.basename(entryPath, path.extname(entryPath));
   cache.set(entryPath, resolved);
   return resolved;
+}
+
+/**
+ * The package name exactly as a manifest spells it, scope and all.
+ *
+ * `extensionName` drops the scope because a tree reads better without it, but
+ * that makes it useless as a key: `.doom/modes.yaml` names packages as
+ * `@agimon-ai/doompi-team`, so joining a registered tool back to the layer that
+ * admitted it needs the unshortened name. Attribution and display are different
+ * jobs, so they get different functions rather than one lossy one.
+ */
+export function extensionPackageName(entryPath: string): string | undefined {
+  const cached = packageCache.get(entryPath);
+  if (cached !== undefined) return cached.name;
+  const name = packageName(path.dirname(entryPath));
+  packageCache.set(entryPath, { name });
+  return name;
 }

--- a/packages/core/doompi-ui/src/exports/extensionName.ts
+++ b/packages/core/doompi-ui/src/exports/extensionName.ts
@@ -1,1 +1,6 @@
-export { extensionName, extensionToolSource, withExtensionSource } from '../adapters/pi/extensionName.ts';
+export {
+  extensionName,
+  extensionPackageName,
+  extensionToolSource,
+  withExtensionSource,
+} from '../adapters/pi/extensionName.ts';

--- a/packages/core/doompi-ui/src/exports/toolInventory.ts
+++ b/packages/core/doompi-ui/src/exports/toolInventory.ts
@@ -6,3 +6,4 @@ export {
   type ToolSource,
   type ToolSourceKind,
 } from '../services/tools/toolInventory.ts';
+export { type CountTokens, type ToolCost, tokensForSource, tokensForTool } from '../services/tools/toolCost.ts';

--- a/packages/core/doompi-ui/src/services/tools/toolCost.ts
+++ b/packages/core/doompi-ui/src/services/tools/toolCost.ts
@@ -1,0 +1,66 @@
+import type { ToolEntry, ToolSource } from './toolInventory.ts';
+
+/**
+ * What one tool costs before anything is asked of it.
+ *
+ * A tool is sent to the model twice over. Its schema travels in the tool list,
+ * and its prose travels in the system prompt: Pi's `BuildSystemPromptOptions`
+ * takes `toolSnippets` keyed by tool name and `promptGuidelines` appended to the
+ * default guidelines, separately from the tools themselves. Pricing only the
+ * schema would undercount every tool that carries either, so the two are counted
+ * apart and reported together.
+ *
+ * The tokenizer is injected rather than imported, matching how MCP schema
+ * pricing already takes a `countTokens`. This module stays free of any opinion
+ * about which vocabulary the caller's model actually uses.
+ */
+export interface ToolCost {
+  /** The tool-list payload: name, description, and parameter schema. */
+  schemaTokens: number;
+  /** The system-prompt payload: snippet and guideline bullets. */
+  promptTokens: number;
+  totalTokens: number;
+}
+
+export type CountTokens = (text: string) => number;
+
+/** Mirrors the wire shape MCP advertises, so both estimates stay comparable. */
+function schemaPayload(entry: ToolEntry): string {
+  return JSON.stringify({
+    name: entry.name,
+    ...(entry.description === undefined ? {} : { description: entry.description }),
+    ...(entry.parameters === undefined ? {} : { parameters: entry.parameters }),
+  });
+}
+
+function promptPayload(entry: ToolEntry): string {
+  return [entry.promptSnippet ?? '', ...(entry.promptGuidelines ?? [])].filter(Boolean).join('\n');
+}
+
+export function tokensForTool(entry: ToolEntry, countTokens: CountTokens): ToolCost {
+  const schemaTokens = countTokens(schemaPayload(entry));
+  const prompt = promptPayload(entry);
+  const promptTokens = prompt.length === 0 ? 0 : countTokens(prompt);
+  return { schemaTokens, promptTokens, totalTokens: schemaTokens + promptTokens };
+}
+
+/**
+ * Every tool in a source, and what the source costs in total.
+ *
+ * An inactive tool is still priced: it is in the composition, and the point of
+ * the figure is to show what the composition costs. Whether the model may call
+ * it is a separate question from whether it is being paid for.
+ */
+export function tokensForSource(
+  source: ToolSource,
+  countTokens: CountTokens,
+): { tools: ReadonlyMap<string, ToolCost>; totalTokens: number } {
+  const tools = new Map<string, ToolCost>();
+  let totalTokens = 0;
+  for (const entry of source.tools) {
+    const cost = tokensForTool(entry, countTokens);
+    tools.set(entry.name, cost);
+    totalTokens += cost.totalTokens;
+  }
+  return { tools, totalTokens };
+}

--- a/packages/core/doompi-ui/src/services/tools/toolInventory.ts
+++ b/packages/core/doompi-ui/src/services/tools/toolInventory.ts
@@ -6,6 +6,8 @@ export interface ToolEntry {
   name: string;
   description?: string;
   parameters?: unknown;
+  /** One-line snippet Pi keys by tool name in the system prompt. */
+  promptSnippet?: string;
   promptGuidelines?: readonly string[];
   active: boolean;
 }
@@ -18,6 +20,14 @@ export interface ToolSource {
   status?: string;
   /** The registering file for extension sources. */
   detail?: string;
+  /**
+   * Package name as its manifest spells it, scope included.
+   *
+   * `label` is shortened for reading. Attribution joins against `.doom`
+   * configuration, which names packages in full, so the unshortened name is
+   * carried separately rather than recovered from the label.
+   */
+  packageName?: string;
   tools: readonly ToolEntry[];
 }
 
@@ -28,6 +38,7 @@ export interface ToolInfo {
   name: string;
   description?: string;
   parameters?: unknown;
+  promptSnippet?: string;
   promptGuidelines?: readonly string[];
   sourceInfo: { path: string; source?: string };
 }
@@ -38,6 +49,8 @@ export interface ToolInventoryInput {
   /** Absent when the MCP adapter is not loaded or has not published yet. */
   mcpServers?: readonly McpServerStatus[];
   resolveExtensionName?: (entryPath: string) => string;
+  /** Unshortened package name for the same entry path, for attribution. */
+  resolveExtensionPackageName?: (entryPath: string) => string | undefined;
   resolveExtensionToolSource?: (toolName: string) => string | undefined;
 }
 
@@ -69,6 +82,7 @@ function toEntry(tool: ToolInfo, activeTools: ReadonlySet<string>): ToolEntry {
     name: tool.name,
     ...(tool.description ? { description: tool.description } : {}),
     ...(tool.parameters === undefined ? {} : { parameters: tool.parameters }),
+    ...(tool.promptSnippet ? { promptSnippet: tool.promptSnippet } : {}),
     ...(tool.promptGuidelines?.length ? { promptGuidelines: tool.promptGuidelines } : {}),
     active: activeTools.has(tool.name),
   };
@@ -110,7 +124,7 @@ export function buildToolSources(input: ToolInventoryInput): readonly ToolSource
   const owningServer = serverByTool(servers);
   const core: ToolEntry[] = [];
   const mcpTools = new Map<string, ToolEntry[]>();
-  const extensions = new Map<string, { label: string; detail: string; tools: ToolEntry[] }>();
+  const extensions = new Map<string, { label: string; detail: string; packageName?: string; tools: ToolEntry[] }>();
 
   for (const tool of input.tools) {
     const entry = toEntry(tool, activeTools);
@@ -141,7 +155,13 @@ export function buildToolSources(input: ToolInventoryInput): readonly ToolSource
       const name = structuralSource
         ? (input.resolveExtensionName?.(key) ?? tool.sourceInfo.source ?? key)
         : (tool.sourceInfo.source ?? key);
-      extensions.set(key, { label: sourceLabel(name, 'extension'), detail: key, tools: [entry] });
+      const scoped = input.resolveExtensionPackageName?.(key);
+      extensions.set(key, {
+        label: sourceLabel(name, 'extension'),
+        detail: key,
+        ...(scoped ? { packageName: scoped } : {}),
+        tools: [entry],
+      });
     }
   }
 
@@ -169,6 +189,7 @@ export function buildToolSources(input: ToolInventoryInput): readonly ToolSource
       label: group.label,
       kind: 'extension',
       detail: group.detail,
+      ...(group.packageName ? { packageName: group.packageName } : {}),
       tools: group.tools.sort(byName),
     });
   }

--- a/packages/core/doompi-ui/src/web/WriteToolMessage.tsx
+++ b/packages/core/doompi-ui/src/web/WriteToolMessage.tsx
@@ -4,6 +4,7 @@ import {
   MessageItemHeader,
   MessageItemStatus,
   SyntaxLine,
+  ToolPathLink,
   toolTone,
   useSyntaxLines,
 } from '@agimon-ai/doompi-web-components';
@@ -43,8 +44,19 @@ function WritePreview({ view, path }: { view: WriteCallView; path: string }) {
  * TUI folds into its call: ten lines, or all of them once the item expands.
  * A failure shows the tool's message in red instead.
  */
-export function WriteToolMessage({ args, result, output, running, isError }: ToolMessageRenderProps) {
+export function WriteToolMessage({
+  args,
+  result,
+  output,
+  running,
+  isError,
+  fileTabFor,
+  openTransientTab,
+}: ToolMessageRenderProps) {
   const collapsed = writeCallView(args, false);
+  // The header names a file the tool is writing, so the reader can open it
+  // rather than hunt for it; nothing installed to show files leaves it as text.
+  const tab = fileTabFor(collapsed.path);
   return (
     <MessageItem tone={toolTone({ running, isError })} expandable={collapsed.hidden > 0}>
       {({ expanded }) => {
@@ -53,7 +65,10 @@ export function WriteToolMessage({ args, result, output, running, isError }: Too
           <>
             <MessageItemHeader title="write">
               <span data-testid="tool-call-write" className="flex min-w-0 flex-1 items-center gap-2">
-                <span className="truncate text-doom-text">{view.path}</span>
+                <ToolPathLink
+                  path={view.path}
+                  {...(tab === undefined ? {} : { onOpen: () => openTransientTab(tab) })}
+                />
                 <span className="shrink-0 text-doom-faint">· {view.size}</span>
               </span>
             </MessageItemHeader>

--- a/packages/core/doompi-ui/src/web/WriteToolMessage.tsx
+++ b/packages/core/doompi-ui/src/web/WriteToolMessage.tsx
@@ -3,10 +3,39 @@ import {
   MessageItemBody,
   MessageItemHeader,
   MessageItemStatus,
+  SyntaxLine,
   toolTone,
+  useSyntaxLines,
 } from '@agimon-ai/doompi-web-components';
 import type { ToolMessageRenderProps } from '@agimon-ai/doompi-web-contracts';
-import { resultText, writeCallView } from './builtinToolView.ts';
+import { resultText, type WriteCallView, writeCallView } from './builtinToolView.ts';
+
+/**
+ * The numbered preview, coloured as the file it is about to become.
+ *
+ * Its own component so the highlighting hook has somewhere to live: the body
+ * around it is picked inside a render prop. The preview is a prefix of the
+ * content, so it parses as the file it came from up to wherever it was cut.
+ */
+function WritePreview({ view, path }: { view: WriteCallView; path: string }) {
+  const spans = useSyntaxLines(view.preview.map((line) => line.text).join('\n'), { path });
+  return (
+    <>
+      {view.preview.map((line, index) => (
+        <span key={line.number} className="flex gap-2">
+          <span className="shrink-0 text-right text-doom-faint" style={{ width: `${String(view.gutter)}ch` }}>
+            {line.number}
+          </span>
+          <SyntaxLine
+            spans={spans?.[index]}
+            text={line.text}
+            className="min-w-0 whitespace-pre-wrap break-words text-doom-text"
+          />
+        </span>
+      ))}
+    </>
+  );
+}
 
 /**
  * The write tool's timeline item: `path · N chars` in the header. Pi's write
@@ -41,14 +70,7 @@ export function WriteToolMessage({ args, result, output, running, isError }: Too
               ) : null
             ) : (
               <MessageItemBody data-testid="tool-result-write" className="flex flex-col font-mono">
-                {view.preview.map((line) => (
-                  <span key={line.number} className="flex gap-2">
-                    <span className="shrink-0 text-right text-doom-faint" style={{ width: `${String(view.gutter)}ch` }}>
-                      {line.number}
-                    </span>
-                    <span className="min-w-0 whitespace-pre-wrap break-words text-doom-text">{line.text}</span>
-                  </span>
-                ))}
+                <WritePreview view={view} path={view.path} />
                 {view.hidden > 0 ? <MessageItemStatus expands>{view.hidden} more lines</MessageItemStatus> : null}
                 {running ? <MessageItemStatus tone="running">running</MessageItemStatus> : null}
               </MessageItemBody>

--- a/packages/core/doompi-ui/tests/extensionName.test.ts
+++ b/packages/core/doompi-ui/tests/extensionName.test.ts
@@ -3,7 +3,12 @@ import os from 'node:os';
 import path from 'node:path';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { afterAll, describe, expect, it, vi } from 'vitest';
-import { extensionName, extensionToolSource, withExtensionSource } from '../src/exports/extensionName.ts';
+import {
+  extensionName,
+  extensionPackageName,
+  extensionToolSource,
+  withExtensionSource,
+} from '../src/exports/extensionName.ts';
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'doom-extension-name-'));
 
@@ -48,5 +53,29 @@ describe('extensionName', () => {
 
     expect(registerTool).toHaveBeenCalledWith(tool);
     expect(extensionToolSource(pi, tool.name)).toBe(entry);
+  });
+});
+
+describe('extensionPackageName', () => {
+  // `.doom/modes.yaml` names packages with their scope, so attribution has to
+  // read the manifest name whole. `extensionName` shortens it for display, and
+  // joining on that instead would miss every scoped package silently.
+  it('keeps the scope that extensionName drops', () => {
+    write('packages/scoped-attr/package.json', JSON.stringify({ name: '@agimon-ai/doompi-team' }));
+    const entry = write('packages/scoped-attr/extensions/pi.ts');
+
+    expect(extensionPackageName(entry)).toBe('@agimon-ai/doompi-team');
+    expect(extensionName(entry)).toBe('doompi-team');
+  });
+
+  it('reports nothing when no manifest sits above the entry', () => {
+    const orphan = path.join(os.tmpdir(), `doom-orphan-${process.pid}`, 'pi.ts');
+    fs.mkdirSync(path.dirname(orphan), { recursive: true });
+    fs.writeFileSync(orphan, '');
+
+    // An answer of "no package" is cached like any other, so a second call
+    // must not read the disk again and must not change its mind.
+    expect(extensionPackageName(orphan)).toBe(extensionPackageName(orphan));
+    fs.rmSync(path.dirname(orphan), { recursive: true, force: true });
   });
 });

--- a/packages/core/doompi-ui/tests/toolCost.test.ts
+++ b/packages/core/doompi-ui/tests/toolCost.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { type ToolEntry, type ToolSource, tokensForSource, tokensForTool } from '../src/exports/toolInventory.ts';
+
+// One token per character keeps the arithmetic checkable by hand; the real
+// tokenizer is injected by the caller and is not this module's concern.
+const countChars = (text: string): number => text.length;
+
+function entry(overrides: Partial<ToolEntry> = {}): ToolEntry {
+  return { name: 'read', description: 'Reads a file', active: true, ...overrides };
+}
+
+describe('tokensForTool', () => {
+  it('prices the tool-list payload from name, description, and parameters', () => {
+    const tool = entry({ parameters: { type: 'object' } });
+    const expected = JSON.stringify({
+      name: 'read',
+      description: 'Reads a file',
+      parameters: { type: 'object' },
+    }).length;
+
+    expect(tokensForTool(tool, countChars)).toEqual({
+      schemaTokens: expected,
+      promptTokens: 0,
+      totalTokens: expected,
+    });
+  });
+
+  // The trap this function exists to avoid. Pi takes `toolSnippets` and
+  // `promptGuidelines` as system-prompt inputs, separately from the tool list,
+  // so a schema-only estimate silently undercounts any tool carrying prose.
+  it('counts the system-prompt payload that never appears in the schema', () => {
+    const bare = tokensForTool(entry(), countChars);
+    const chatty = tokensForTool(entry({ promptSnippet: 'abc', promptGuidelines: ['de', 'f'] }), countChars);
+
+    expect(chatty.schemaTokens).toBe(bare.schemaTokens);
+    // 'abc\nde\nf' is eight characters, joined with one newline per bullet.
+    expect(chatty.promptTokens).toBe(8);
+    expect(chatty.totalTokens).toBe(bare.schemaTokens + 8);
+  });
+
+  it('charges nothing for prose a tool does not carry', () => {
+    expect(tokensForTool(entry({ promptGuidelines: [] }), countChars).promptTokens).toBe(0);
+  });
+
+  it('omits absent fields rather than pricing the word undefined', () => {
+    const nameOnly = tokensForTool({ name: 'x', active: true }, countChars);
+
+    expect(nameOnly.schemaTokens).toBe(JSON.stringify({ name: 'x' }).length);
+  });
+});
+
+describe('tokensForSource', () => {
+  it('prices every tool and sums the source', () => {
+    const source: ToolSource = {
+      key: 'core',
+      label: 'pi · core',
+      kind: 'core',
+      tools: [entry({ name: 'read' }), entry({ name: 'bash', promptSnippet: 'runs' })],
+    };
+    const { tools, totalTokens } = tokensForSource(source, countChars);
+
+    expect([...tools.keys()]).toEqual(['read', 'bash']);
+    expect(tools.get('bash')?.promptTokens).toBe(4);
+    expect(totalTokens).toBe((tools.get('read')?.totalTokens ?? 0) + (tools.get('bash')?.totalTokens ?? 0));
+  });
+
+  // An inactive tool still occupies the composition, and the figure is about
+  // what the composition costs rather than what the model may call.
+  it('prices an inactive tool too', () => {
+    const source: ToolSource = {
+      key: 'core',
+      label: 'pi · core',
+      kind: 'core',
+      tools: [entry({ name: 'read', active: false })],
+    };
+
+    expect(tokensForSource(source, countChars).totalTokens).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/doompi-web-components/src/components/AnsiText.tsx
+++ b/packages/core/doompi-web-components/src/components/AnsiText.tsx
@@ -1,0 +1,84 @@
+import { type ComponentProps, Fragment, useMemo } from 'react';
+import { type AnsiSpan, ansiSpans } from '../lib/ansiSpans.ts';
+import { cn } from '../lib/cn.ts';
+
+/**
+ * Terminal output with the colours it was written in.
+ *
+ * Both readers of terminal text render it the same way, so the mapping from a
+ * span's attributes to classes lives here rather than in each of them: a
+ * captured workflow screen is a line at a time, and a runner log is a block.
+ * Parsing is synchronous and cheap; text with no escapes in it takes a path
+ * that allocates nothing.
+ *
+ * DESIGN PATTERNS:
+ * - Named colours arrive as theme classes from `ansiSpans`; only 256-colour
+ *   and truecolour, which no token stands for, come through as a style.
+ * - One element per line, so wrapping and selection behave as they do in a pre.
+ *
+ * AVOID:
+ * - Carrying attributes across lines. A captured screen and a bounded log tail
+ *   both start mid-stream.
+ */
+
+function spanClassName(span: AnsiSpan): string {
+  return cn(
+    span.className,
+    span.bold === true && 'font-bold',
+    span.faint === true && 'opacity-60',
+    span.italic === true && 'italic',
+    span.underline === true && 'underline',
+    span.inverse === true && 'bg-doom-text text-doom-deep',
+  );
+}
+
+function AnsiSpans({ spans }: { spans: readonly AnsiSpan[] }) {
+  return (
+    <>
+      {spans.map((span, index) => (
+        <span
+          key={index}
+          className={spanClassName(span)}
+          style={span.color === undefined ? undefined : { color: span.color }}
+        >
+          {span.text}
+        </span>
+      ))}
+    </>
+  );
+}
+
+export interface AnsiLineProps extends Omit<ComponentProps<'span'>, 'children'> {
+  /** One line of terminal output, escapes and all. */
+  line: string;
+}
+
+/** One line, for a caller that already lays out a screen row by row. */
+export function AnsiLine({ line, className, ...props }: AnsiLineProps) {
+  const spans = useMemo(() => ansiSpans(line), [line]);
+  return (
+    <span data-slot="ansi-line" className={className} {...props}>
+      <AnsiSpans spans={spans} />
+    </span>
+  );
+}
+
+export interface AnsiTextProps extends Omit<ComponentProps<'pre'>, 'children'> {
+  /** Terminal output, newline separated, escapes and all. */
+  text: string;
+}
+
+/** A block of terminal output: a log tail, or anything else that arrives whole. */
+export function AnsiText({ text, ...props }: AnsiTextProps) {
+  const lines = useMemo(() => text.split('\n').map((line) => ansiSpans(line)), [text]);
+  return (
+    <pre data-slot="ansi-text" {...props}>
+      {lines.map((spans, index) => (
+        <Fragment key={index}>
+          {index > 0 ? '\n' : null}
+          <AnsiSpans spans={spans} />
+        </Fragment>
+      ))}
+    </pre>
+  );
+}

--- a/packages/core/doompi-web-components/src/components/HashlineLines.tsx
+++ b/packages/core/doompi-web-components/src/components/HashlineLines.tsx
@@ -1,19 +1,72 @@
-import type { ComponentProps } from 'react';
+import { type ComponentProps, useEffect, useMemo, useState } from 'react';
 import { cn } from '../lib/cn.ts';
+import { type HashlineGroup, hashlineGroups, hashlineGroupsKey } from '../lib/hashlineHighlight.ts';
 import type { PresentedLine } from '../lib/hashlineView.ts';
+import { detectGrammar, highlightToLines, type SyntaxSpan } from '../lib/syntaxHighlight.ts';
+import { SyntaxLine } from './SyntaxText.tsx';
 
 /**
  * The anchored body shared by hashline results: a file heading per group, a
  * right-aligned line-number gutter, and a `>>` marker on grep matches. The
  * gutter width is a style, not a class, because it follows the widest number.
+ *
+ * The anchored lines are coloured with the editor's grammars when the body
+ * names a file, or when `path` names one for a result that does not. Colour
+ * arrives a frame or two late and never blocks the text: an unhighlighted body
+ * is the same body without the colours.
  */
 export interface HashlineLinesProps extends ComponentProps<'div'> {
   lines: readonly PresentedLine[];
   /** Width of the line-number column, in characters, from `hashlineBody`. */
   gutter: number;
+  /** The file a body of bare anchored lines came from, for highlighting. */
+  path?: string | undefined;
 }
 
-export function HashlineLines({ className, lines, gutter, ...props }: HashlineLinesProps) {
+const NO_SPANS: ReadonlyMap<number, readonly SyntaxSpan[]> = new Map();
+
+/**
+ * Spans per presented-line index, once every file's run has parsed. The result
+ * is stored with the body it belongs to, so a body that has changed since
+ * reads as plain rather than wearing the previous body's colours.
+ */
+function useHashlineSpans(groups: readonly HashlineGroup[]): ReadonlyMap<number, readonly SyntaxSpan[]> {
+  const key = hashlineGroupsKey(groups);
+  const [done, setDone] = useState<{ key: string; spans: ReadonlyMap<number, readonly SyntaxSpan[]> } | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    let live = true;
+    const next = new Map<number, readonly SyntaxSpan[]>();
+    const work = groups.map(async (group) => {
+      const grammar = detectGrammar({ path: group.path, text: group.text });
+      if (grammar === undefined) return;
+      const highlighted = await highlightToLines(group.text, grammar);
+      if (highlighted === undefined) return;
+      for (const [offset, index] of group.indices.entries()) {
+        const line = highlighted[offset];
+        if (line !== undefined) next.set(index, line);
+      }
+    });
+    // One state write for the whole body, so a many-file grep result does not
+    // repaint once per file. A grammar that fails to load leaves its run plain.
+    void Promise.allSettled(work).then(() => {
+      if (live && next.size > 0) setDone({ key, spans: next });
+    });
+    return () => {
+      live = false;
+    };
+    // The groups are rebuilt every render; their key is what actually changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  return done?.key === key ? done.spans : NO_SPANS;
+}
+
+export function HashlineLines({ className, lines, gutter, path, ...props }: HashlineLinesProps) {
+  const groups = useMemo(() => hashlineGroups(lines, path), [lines, path]);
+  const spans = useHashlineSpans(groups);
   // Bound to a name rather than written inline: this file ships as a scaffold
   // template too, and an inline style object opens with the same two braces
   // Liquid reads as an output tag, which fails to render.
@@ -46,11 +99,11 @@ export function HashlineLines({ className, lines, gutter, ...props }: HashlineLi
             <span className="shrink-0 text-right text-doom-faint" style={gutterStyle}>
               {value.line}
             </span>
-            <span
+            <SyntaxLine
+              spans={spans.get(index)}
+              text={value.content}
               className={`min-w-0 whitespace-pre-wrap break-words ${value.marker === 'match' ? 'text-doom-hi' : 'text-doom-text'}`}
-            >
-              {value.content}
-            </span>
+            />
           </span>
         );
       })}

--- a/packages/core/doompi-web-components/src/components/MessageItem.tsx
+++ b/packages/core/doompi-web-components/src/components/MessageItem.tsx
@@ -34,8 +34,22 @@ export function useMessageItem(): MessageItemState {
   return useContext(MessageItemContext);
 }
 
+/**
+ * The group an item is a row of, or null for an item that is a card of its
+ * own. A row drops the frame the group already draws and keeps its tone as an
+ * edge down its left side, and it stops repeating what the group's header has
+ * said once: the tool's name, and an outcome the whole run shares.
+ */
+const MessageItemGroupContext = createContext<{ tone: StatusTone } | null>(null);
+
 /** The frame, wearing the edge STATUS_EDGE names for the tone, so the two never drift apart. */
 export const messageItemVariants = cva('overflow-hidden rounded-md border bg-doom-panel transition-colors', {
+  variants: { tone: STATUS_EDGE },
+  defaultVariants: { tone: 'neutral' },
+});
+
+/** The same tone as a row: no card, one coloured edge, and the group's separators between rows. */
+export const messageItemRowVariants = cva('overflow-hidden border-l-2 transition-colors', {
   variants: { tone: STATUS_EDGE },
   defaultVariants: { tone: 'neutral' },
 });
@@ -63,6 +77,8 @@ export function MessageItem({
   ...props
 }: MessageItemProps) {
   const [own, setOwn] = useState(defaultExpanded);
+  const group = useContext(MessageItemGroupContext);
+  const grouped = group !== null;
   const current = expanded ?? own;
   const state: MessageItemState = {
     tone: tone ?? 'neutral',
@@ -79,12 +95,58 @@ export function MessageItem({
       <div
         data-slot="message-item"
         data-expanded={current}
-        className={cn(messageItemVariants({ tone }), className)}
+        data-grouped={grouped}
+        className={cn(grouped ? messageItemRowVariants({ tone }) : messageItemVariants({ tone }), className)}
         {...props}
       >
         {typeof children === 'function' ? children(state) : children}
       </div>
     </MessageItemContext.Provider>
+  );
+}
+
+export interface MessageItemGroupProps
+  extends Omit<ComponentProps<'div'>, 'title'>, VariantProps<typeof messageItemVariants> {
+  /** The bold label at the left of the group header: the tool the run belongs to. */
+  title: ReactNode;
+  /** The line beside it, such as how many calls the group holds. */
+  summary?: ReactNode;
+  /** The badge text; defaults to the tone's label, null hides the badge. */
+  badge?: ReactNode | null;
+  children?: ReactNode;
+}
+
+/**
+ * One frame around a run of items that belong together.
+ *
+ * A transcript that calls the same tool five times in a row is five identical
+ * frames, five gutter labels and five gaps, and the repetition reads louder
+ * than the commands do. The group draws the frame once and each item inside it
+ * becomes a row: same header, same expand, no card of its own. The tone still
+ * belongs to the row, as an edge, so a failure in the middle of a run is not
+ * flattened into the group's own outcome.
+ */
+export function MessageItemGroup({
+  className,
+  tone,
+  title,
+  summary,
+  badge,
+  children,
+  ...props
+}: MessageItemGroupProps) {
+  const label = badge === undefined ? STATUS_LABEL[tone ?? 'neutral'] : badge;
+  return (
+    <MessageItemGroupContext.Provider value={{ tone: tone ?? 'neutral' }}>
+      <div data-slot="message-item-group" className={cn(messageItemVariants({ tone }), className)} {...props}>
+        <div className="flex min-h-8 items-center gap-2 border-doom-border-soft border-b px-[11px] text-[11px] text-doom-dim">
+          <span className="shrink-0 font-bold text-doom-hi">{title}</span>
+          <span className="min-w-0 flex-1 truncate text-doom-faint">{summary}</span>
+          {label !== null && label !== '' ? <StatusBadge tone={tone ?? 'neutral'}>{label}</StatusBadge> : null}
+        </div>
+        <div className="flex flex-col divide-y divide-doom-border-soft">{children}</div>
+      </div>
+    </MessageItemGroupContext.Provider>
   );
 }
 
@@ -112,17 +174,30 @@ export interface MessageItemHeaderProps extends Omit<ComponentProps<'div'>, 'tit
   children?: ReactNode;
 }
 
-/** The title row: label, summary, the tone's badge, and the expand toggle when the item is expandable. */
+/** Inside a group these two are the quiet outcome: the group's header has already said it. */
+const SILENT_IN_GROUP: ReadonlySet<StatusTone> = new Set<StatusTone>(['ok', 'neutral']);
+
+/**
+ * The title row: label, summary, the tone's badge, and the expand toggle when
+ * the item is expandable.
+ *
+ * A row inside a group says less. The group's header has already named the
+ * tool and stated the run's outcome, so the row drops its title and speaks up
+ * only when something went wrong or is still going: five OK badges down a run
+ * of five are noise, and the one ERROR among them is the point.
+ */
 export function MessageItemHeader({ className, title, badge, children, ...props }: MessageItemHeaderProps) {
   const { tone, expandable, expanded, toggle } = useMessageItem();
-  const label = badge === undefined ? STATUS_LABEL[tone] : badge;
+  const group = useContext(MessageItemGroupContext);
+  const defaultLabel = group !== null && SILENT_IN_GROUP.has(tone) ? null : STATUS_LABEL[tone];
+  const label = badge === undefined ? defaultLabel : badge;
   return (
     <div
       data-slot="message-item-header"
       className={cn('flex min-h-8 items-center gap-2 px-[11px] text-[11px] text-doom-dim', className)}
       {...props}
     >
-      <span className="shrink-0 font-bold text-doom-hi">{title}</span>
+      {group === null ? <span className="shrink-0 font-bold text-doom-hi">{title}</span> : null}
       <div data-slot="message-item-summary" className="flex min-w-0 flex-1 items-center gap-2">
         {children}
       </div>

--- a/packages/core/doompi-web-components/src/components/SyntaxText.tsx
+++ b/packages/core/doompi-web-components/src/components/SyntaxText.tsx
@@ -1,0 +1,116 @@
+import { type ComponentProps, Fragment, useEffect, useState } from 'react';
+import { cn } from '../lib/cn.ts';
+import type { GrammarKey } from '../lib/editorLanguage.ts';
+import {
+  detectGrammar,
+  highlightToLines,
+  type SyntaxLines,
+  type SyntaxSpan,
+  syntaxStyleOf,
+} from '../lib/syntaxHighlight.ts';
+
+/**
+ * Read-only code with the editor's colours.
+ *
+ * Two shapes over one hook, because the cards need both: `SyntaxText` for a
+ * block of code that owns its own element, and `SyntaxLine` for a card that
+ * already renders a line at a time next to a gutter. Highlighting is
+ * asynchronous, so both show the plain text first and swap in spans once the
+ * grammar has loaded; a result that never highlights simply stays plain.
+ *
+ * DESIGN PATTERNS:
+ * - Plain text is the fallback, never a spinner: colour is decoration.
+ * - The hook keys on the text, so a streaming result re-highlights as it grows.
+ *
+ * AVOID:
+ * - Highlighting one line at a time. A line is not a parse unit; pass the whole
+ *   block to `useSyntaxLines` and render the line you want out of the result.
+ */
+
+export interface SyntaxQuery {
+  /** The file the code came from, when the tool knows one. */
+  path?: string | undefined;
+  /** Skips detection when the caller already knows the grammar. */
+  grammar?: GrammarKey | undefined;
+}
+
+/**
+ * Colours `text`, or hands back undefined while that is still loading and for
+ * anything with no grammar. Rendering the result is the caller's business.
+ *
+ * The finished spans are stored with the text they belong to, so text that has
+ * changed since reads as plain during render rather than showing the previous
+ * result's colours over the new lines.
+ */
+export function useSyntaxLines(text: string, query: SyntaxQuery = {}): SyntaxLines | undefined {
+  const { path, grammar } = query;
+  const key = grammar ?? detectGrammar({ path, text });
+  const signature = `${key ?? ''}\u0000${text}`;
+  const [done, setDone] = useState<{ signature: string; lines: SyntaxLines } | undefined>(undefined);
+
+  useEffect(() => {
+    if (key === undefined) return;
+    let live = true;
+    void highlightToLines(text, key).then(
+      (result) => {
+        if (live && result !== undefined) setDone({ signature, lines: result });
+      },
+      // A grammar chunk that fails to load leaves the plain text in place: the
+      // card stays readable and the network failure is the browser's to report.
+      () => undefined,
+    );
+    return () => {
+      live = false;
+    };
+  }, [text, key, signature]);
+
+  return done?.signature === signature ? done.lines : undefined;
+}
+
+export interface SyntaxLineProps extends Omit<ComponentProps<'span'>, 'children'> {
+  /** The line's spans from `useSyntaxLines`, or undefined to show `text` plain. */
+  spans?: readonly SyntaxSpan[] | undefined;
+  text: string;
+}
+
+/** One line: coloured when its spans are in, the plain text until then. */
+export function SyntaxLine({ spans, text, ...props }: SyntaxLineProps) {
+  if (spans === undefined) return <span {...props}>{text}</span>;
+  return (
+    <span {...props}>
+      {spans.map((span, index) => (
+        <span key={index} style={syntaxStyleOf(span.token)}>
+          {span.text}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export interface SyntaxTextProps extends Omit<ComponentProps<'pre'>, 'children'>, SyntaxQuery {
+  text: string;
+}
+
+/** A block of code, wrapped rather than clipped, coloured when a grammar is known. */
+export function SyntaxText({ className, text, path, grammar, ...props }: SyntaxTextProps) {
+  const lines = useSyntaxLines(text, { path, grammar });
+  const plain = text.split('\n');
+  return (
+    <pre
+      data-slot="syntax-text"
+      data-highlighted={lines !== undefined}
+      className={cn('whitespace-pre-wrap break-words [overflow-wrap:anywhere] font-mono', className)}
+      {...props}
+    >
+      {(lines ?? plain).map((entry, index) => (
+        <Fragment key={index}>
+          {index > 0 ? '\n' : null}
+          <SyntaxLine
+            spans={typeof entry === 'string' ? undefined : entry}
+            text={typeof entry === 'string' ? entry : ''}
+          />
+        </Fragment>
+      ))}
+    </pre>
+  );
+}

--- a/packages/core/doompi-web-components/src/components/ToolPathLink.tsx
+++ b/packages/core/doompi-web-components/src/components/ToolPathLink.tsx
@@ -1,0 +1,50 @@
+import { cn } from '../lib/cn.ts';
+
+/**
+ * The file path in a tool call's header, as a link when something can open it.
+ *
+ * A read, a write and an edit all put a path in the same place, and a reader
+ * who wants to see that file should not have to go looking for it in a file
+ * list. Whether the path can be opened is not this component's business: the
+ * host resolves it against whatever plugin owns files, and hands the answer
+ * down as `onOpen`. Without one the path stays exactly what it was, plain
+ * text, because a link that opens nothing is worse than no link.
+ */
+
+export interface ToolPathLinkProps {
+  path: string;
+  /** Opens the file; omitted when nothing installed can show it. */
+  onOpen?: () => void;
+  className?: string;
+  /** Defaults to `tool-path`, which is how a test finds the link inside a call header. */
+  'data-testid'?: string;
+}
+
+export function ToolPathLink({
+  path,
+  onOpen,
+  className,
+  'data-testid': testId = 'tool-path',
+  ...props
+}: ToolPathLinkProps) {
+  if (onOpen === undefined) {
+    return (
+      <span data-slot="tool-path" data-testid={testId} className={cn('truncate text-doom-text', className)} {...props}>
+        {path}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      data-slot="tool-path"
+      data-testid={testId}
+      title={`open ${path}`}
+      onClick={onOpen}
+      className={cn('cursor-pointer truncate text-left text-doom-text hover:text-doom-blue hover:underline', className)}
+      {...props}
+    >
+      {path}
+    </button>
+  );
+}

--- a/packages/core/doompi-web-components/src/exports/index.ts
+++ b/packages/core/doompi-web-components/src/exports/index.ts
@@ -1,4 +1,5 @@
 export { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '../components/Accordion.tsx';
+export { AnsiLine, type AnsiLineProps, AnsiText, type AnsiTextProps } from '../components/AnsiText.tsx';
 export { Avatar, AvatarFallback, AvatarImage } from '../components/Avatar.tsx';
 export { Badge, type BadgeProps, type BadgeTone, badgeVariants } from '../components/Badge.tsx';
 export {
@@ -76,6 +77,8 @@ export { MediaPreview, type MediaPreviewProps } from '../components/MediaPreview
 export {
   MessageItem,
   MessageItemBody,
+  MessageItemGroup,
+  type MessageItemGroupProps,
   MessageItemHeader,
   type MessageItemHeaderProps,
   type MessageItemProps,
@@ -83,6 +86,7 @@ export {
   MessageItemStatus,
   type MessageItemStatusProps,
   messageItemStatusVariants,
+  messageItemRowVariants,
   messageItemVariants,
   STATUS_GLYPH,
   STATUS_LABEL,
@@ -157,6 +161,14 @@ export {
 export { StreamCursor } from '../components/StreamCursor.tsx';
 export { Switch } from '../components/Switch.tsx';
 export {
+  SyntaxLine,
+  type SyntaxLineProps,
+  type SyntaxQuery,
+  SyntaxText,
+  type SyntaxTextProps,
+  useSyntaxLines,
+} from '../components/SyntaxText.tsx';
+export {
   NavTab,
   NavTabBadge,
   type NavTabProps,
@@ -180,9 +192,11 @@ export {
   ToastViewport,
 } from '../components/Toast.tsx';
 export * from '../icons/icons.ts';
+export { type AnsiSpan, ansiSpans } from '../lib/ansiSpans.ts';
 export { cn } from '../lib/cn.ts';
 export { type CollapsedLines, collapseLines } from '../lib/collapse.ts';
 export { type GrammarKey, grammarKeyOf } from '../lib/editorLanguage.ts';
+export { type HashlineGroup, hashlineGroups, hashlineGroupsKey } from '../lib/hashlineHighlight.ts';
 export {
   compactDetails,
   GREP_COLLAPSED_LINES,
@@ -201,6 +215,15 @@ export {
   takeTrailingNotice,
 } from '../lib/hashlineView.ts';
 export { mediaKindOf } from '../lib/media.ts';
+export {
+  detectGrammar,
+  type GrammarQuery,
+  highlightToLines,
+  type SyntaxLines,
+  type SyntaxSpan,
+  syntaxStyleOf,
+  type SyntaxToken,
+} from '../lib/syntaxHighlight.ts';
 export { handleOptionListKey, MAX_DIGIT_SHORTCUT, optionListHint, optionMarker } from '../lib/optionList.ts';
 export { CHIP_TO_STATUS, LINE_TONE_TO_STATUS, STATUS_TO_CHIP, STATUS_TO_DOT } from '../lib/tone.ts';
 export { type CodeEditorProps, type EditorSelectionRange, MEDIA_KINDS, type MediaKind } from '../types/editor.ts';

--- a/packages/core/doompi-web-components/src/exports/index.ts
+++ b/packages/core/doompi-web-components/src/exports/index.ts
@@ -191,6 +191,7 @@ export {
   toastVariants,
   ToastViewport,
 } from '../components/Toast.tsx';
+export { ToolPathLink, type ToolPathLinkProps } from '../components/ToolPathLink.tsx';
 export * from '../icons/icons.ts';
 export { type AnsiSpan, ansiSpans } from '../lib/ansiSpans.ts';
 export { cn } from '../lib/cn.ts';

--- a/packages/core/doompi-web-components/src/lib/ansiSpans.ts
+++ b/packages/core/doompi-web-components/src/lib/ansiSpans.ts
@@ -2,10 +2,12 @@
  * The escapes a captured terminal screen carries, turned into spans.
  *
  * WHY THIS EXISTS:
- * tmux captures a pane with `-e`, and cmux's render grid is rebuilt into the
- * same escapes, so what arrives at the cockpit is a terminal's own colour. The
- * browser has no terminal, and the cockpit carries no terminal emulator, so
- * the sequences are read here and rendered as ordinary spans.
+ * Two kinds of output reach the cockpit with a terminal's colour still in it.
+ * A workflow captures a tmux pane with `-e`, and a runner's log file keeps the
+ * palette on purpose, stripping only cursor moves and redraws. The browser has
+ * no terminal, and the cockpit carries no terminal emulator, so the sequences
+ * are read here and rendered as ordinary spans. It lives in the component
+ * library because both readers need it and neither may import the other.
  *
  * WHAT IT UNDERSTANDS:
  * SGR (`ESC [ … m`) only: the eight base colours and their bright forms, 256

--- a/packages/core/doompi-web-components/src/lib/hashlineHighlight.ts
+++ b/packages/core/doompi-web-components/src/lib/hashlineHighlight.ts
@@ -1,0 +1,60 @@
+import type { PresentedLine } from './hashlineView.ts';
+
+/**
+ * Grouping for highlighted hashline bodies.
+ *
+ * A read result is one file and a grep result is many, so the lines a card
+ * shows have to be cut into runs that belong to the same file before any of
+ * them can be parsed. A run is parsed whole because a string or a comment
+ * spans lines, and grep's gaps between context blocks are accepted: an excerpt
+ * is not the file, and colouring it as if it were is close enough to be worth
+ * far more than colouring nothing.
+ */
+
+export interface HashlineGroup {
+  /** The file the run came from, when the body named one. */
+  readonly path: string | undefined;
+  /** Indices into the presented lines, in order, that this run covers. */
+  readonly indices: readonly number[];
+  /** The run's content, newline-joined, ready to parse. */
+  readonly text: string;
+}
+
+/**
+ * Consecutive anchored lines, cut at every file heading and at anything that
+ * is not code. `fallbackPath` names the file for a body that never states one,
+ * which is how a read result arrives.
+ */
+export function hashlineGroups(
+  lines: readonly PresentedLine[],
+  fallbackPath: string | undefined,
+): readonly HashlineGroup[] {
+  const groups: HashlineGroup[] = [];
+  let path = fallbackPath;
+  let indices: number[] = [];
+  let texts: string[] = [];
+
+  const flush = (): void => {
+    if (indices.length > 0) groups.push({ path, indices, text: texts.join('\n') });
+    indices = [];
+    texts = [];
+  };
+
+  for (const [index, line] of lines.entries()) {
+    if (line.type === 'tagged') {
+      indices.push(index);
+      texts.push(line.value.content);
+      continue;
+    }
+    flush();
+    // A heading opens the next file; a plain line is prose between runs.
+    if (line.type === 'file') path = line.path;
+  }
+  flush();
+  return groups;
+}
+
+/** One string that changes whenever the groups would highlight differently. */
+export function hashlineGroupsKey(groups: readonly HashlineGroup[]): string {
+  return groups.map((group) => `${group.path ?? ''}\u0000${group.text}`).join('\u0001');
+}

--- a/packages/core/doompi-web-components/src/lib/syntaxHighlight.ts
+++ b/packages/core/doompi-web-components/src/lib/syntaxHighlight.ts
@@ -1,0 +1,165 @@
+import type { CSSProperties } from 'react';
+import { DOOM_SYNTAX_STYLES } from './editorTheme.ts';
+import { type GrammarKey, grammarKeyOf, loadGrammar } from './editorLanguage.ts';
+
+/**
+ * Static syntax highlighting for read-only code, the timeline's half of the
+ * editor's `syntaxHighlighting`.
+ *
+ * A tool card shows code it cannot edit, so it needs the colours without the
+ * editor: the same grammars `editorLanguage.ts` loads and the same token
+ * palette `editorTheme.ts` names, run once over a string and handed back as
+ * spans. Everything CodeMirror-shaped is behind a dynamic import, so a session
+ * that never opens a code result never downloads a parser, and the caller
+ * always has plain text to show first.
+ */
+
+/** The palette keys a token can land on; the styles themselves are the editor's. */
+export type SyntaxToken = keyof typeof DOOM_SYNTAX_STYLES;
+
+/** One run of same-styled text inside a line. `token` absent means unstyled. */
+export interface SyntaxSpan {
+  text: string;
+  token?: SyntaxToken;
+}
+
+/** Lines of spans, one array per source line, so a gutter can pair with them. */
+export type SyntaxLines = readonly (readonly SyntaxSpan[])[];
+
+/**
+ * Above this the parse costs more than the colour is worth. Tool results are
+ * bounded well below it; a pasted file is not, and blocking the frame to paint
+ * a wall of text nobody reads is the worse outcome.
+ */
+const MAX_HIGHLIGHT_CHARS = 200_000;
+
+/** Only the first line is needed to spot a shebang, and reading more of a big string is waste. */
+const SNIFF_CHARS = 200;
+
+const SHEBANG_GRAMMARS: ReadonlyArray<{ readonly pattern: RegExp; readonly grammar: GrammarKey }> = [
+  { pattern: /^#!.*\b(?:bash|sh|zsh|dash|ksh)\b/, grammar: 'shell' },
+  { pattern: /^#!.*\bpython[\d.]*\b/, grammar: 'python' },
+  { pattern: /^#!.*\b(?:node|bun|deno)\b/, grammar: 'javascript' },
+];
+
+/** JSON is the one shape worth guessing from the body: a document is an object or an array. */
+const JSON_SHAPE = /^\s*[[{][\s\S]*[\]}]\s*$/;
+
+export interface GrammarQuery {
+  /** The file the text came from, when the tool knows one. */
+  path?: string | undefined;
+  /** The text itself, used only when the path settles nothing. */
+  text?: string | undefined;
+}
+
+/**
+ * Which grammar to colour a result with.
+ *
+ * The path decides whenever it can, because a name is evidence and a body is a
+ * guess. Sniffing only answers for text that arrived without a usable name: a
+ * shebang says what runs the script, and a document that opens and closes with
+ * brackets is treated as JSON. Anything else stays plain rather than being
+ * coloured as the wrong language.
+ */
+export function detectGrammar(query: GrammarQuery): GrammarKey | undefined {
+  const byPath = query.path === undefined || query.path.length === 0 ? undefined : grammarKeyOf(query.path);
+  if (byPath !== undefined) return byPath;
+  const text = query.text ?? '';
+  if (text.length === 0) return undefined;
+  const head = text.slice(0, SNIFF_CHARS);
+  if (head.startsWith('#!')) {
+    const firstLine = head.split('\n', 1)[0] ?? '';
+    for (const entry of SHEBANG_GRAMMARS) {
+      if (entry.pattern.test(firstLine)) return entry.grammar;
+    }
+    // A shebang naming something with no grammar here is still a script.
+    return 'shell';
+  }
+  return JSON_SHAPE.test(text) ? 'json' : undefined;
+}
+
+/** The inline style a token wears. Colours come from the editor palette, which names theme tokens. */
+export function syntaxStyleOf(token: SyntaxToken | undefined): CSSProperties | undefined {
+  return token === undefined ? undefined : DOOM_SYNTAX_STYLES[token];
+}
+
+/**
+ * Every tag the palette answers for, in the order the editor lists them. The
+ * class each entry carries is a palette key rather than a CSS class: the
+ * result is rendered as inline styles, so nothing has to be mounted in the
+ * document for a card to show colour.
+ */
+async function doomHighlighter() {
+  const { tagHighlighter, tags } = await import('@lezer/highlight');
+  return tagHighlighter([
+    { tag: tags.comment, class: 'comment' satisfies SyntaxToken },
+    { tag: tags.keyword, class: 'keyword' satisfies SyntaxToken },
+    { tag: [tags.atom, tags.bool, tags.null, tags.self], class: 'constant' satisfies SyntaxToken },
+    { tag: tags.number, class: 'literal' satisfies SyntaxToken },
+    { tag: [tags.string, tags.special(tags.string)], class: 'string' satisfies SyntaxToken },
+    { tag: tags.regexp, class: 'regexp' satisfies SyntaxToken },
+    { tag: [tags.operator, tags.operatorKeyword], class: 'operator' satisfies SyntaxToken },
+    { tag: [tags.punctuation, tags.separator, tags.bracket], class: 'punctuation' satisfies SyntaxToken },
+    { tag: [tags.variableName, tags.definition(tags.variableName)], class: 'variable' satisfies SyntaxToken },
+    { tag: [tags.propertyName, tags.definition(tags.propertyName)], class: 'property' satisfies SyntaxToken },
+    {
+      tag: [tags.function(tags.variableName), tags.function(tags.propertyName)],
+      class: 'callable' satisfies SyntaxToken,
+    },
+    { tag: [tags.typeName, tags.className, tags.namespace], class: 'type' satisfies SyntaxToken },
+    { tag: [tags.tagName, tags.angleBracket], class: 'tag' satisfies SyntaxToken },
+    { tag: tags.attributeName, class: 'attribute' satisfies SyntaxToken },
+    { tag: [tags.meta, tags.processingInstruction, tags.documentMeta], class: 'meta' satisfies SyntaxToken },
+    { tag: tags.heading, class: 'heading' satisfies SyntaxToken },
+    { tag: [tags.link, tags.url], class: 'link' satisfies SyntaxToken },
+    { tag: tags.emphasis, class: 'emphasis' satisfies SyntaxToken },
+    { tag: tags.strong, class: 'strong' satisfies SyntaxToken },
+    { tag: tags.strikethrough, class: 'strikethrough' satisfies SyntaxToken },
+    { tag: tags.invalid, class: 'invalid' satisfies SyntaxToken },
+  ]);
+}
+
+/** The parser behind a grammar. `loadGrammar` hands back an editor extension, which wraps one. */
+async function parserFor(grammar: GrammarKey) {
+  const [{ Language, LanguageSupport }, extension] = await Promise.all([
+    import('@codemirror/language'),
+    loadGrammar(grammar),
+  ]);
+  if (extension instanceof LanguageSupport) return extension.language.parser;
+  if (extension instanceof Language) return extension.parser;
+  return undefined;
+}
+
+/**
+ * Colours `text` as `grammar`, as lines of spans.
+ *
+ * The whole text is parsed at once even though the caller may render it line
+ * by line, because a template literal or a block comment only makes sense with
+ * its neighbours. Text past the size cap, and a grammar whose extension turns
+ * out to carry no parser, come back unhighlighted rather than throwing: colour
+ * is decoration, and the caller already has the plain text on screen.
+ */
+export async function highlightToLines(text: string, grammar: GrammarKey): Promise<SyntaxLines | undefined> {
+  if (text.length === 0 || text.length > MAX_HIGHLIGHT_CHARS) return undefined;
+  const [{ highlightCode }, highlighter, parser] = await Promise.all([
+    import('@lezer/highlight'),
+    doomHighlighter(),
+    parserFor(grammar),
+  ]);
+  if (parser === undefined) return undefined;
+
+  const lines: SyntaxSpan[][] = [[]];
+  highlightCode(
+    text,
+    parser.parse(text),
+    highlighter,
+    (code, classes) => {
+      const current = lines[lines.length - 1];
+      // `classes` is the palette key this module handed the tag highlighter,
+      // or empty for text no tag claimed.
+      current?.push(classes === '' ? { text: code } : { text: code, token: classes as SyntaxToken });
+    },
+    () => lines.push([]),
+  );
+  return lines;
+}

--- a/packages/core/doompi-web-components/tests/components/render.test.tsx
+++ b/packages/core/doompi-web-components/tests/components/render.test.tsx
@@ -29,6 +29,7 @@ import {
   Markdown,
   MessageItem,
   MessageItemBody,
+  MessageItemGroup,
   MessageItemHeader,
   MessageItemStatus,
   MessageLines,
@@ -63,6 +64,8 @@ import {
   StatusBadge,
   StreamCursor,
   Switch,
+  SyntaxLine,
+  SyntaxText,
   Tabs,
   TabsList,
   TabsTrigger,
@@ -256,6 +259,60 @@ describe('primitives', () => {
     expect(out).toContain('native row');
   });
 
+  it('shows code plain before a grammar has answered, and coloured once it has', () => {
+    // The first paint is the text itself: highlighting is asynchronous, so a
+    // card is readable whether or not a parser ever arrives.
+    const plain = html(<SyntaxText text={'const x = 1;\nexport { x };'} path="src/a.ts" />);
+    expect(plain).toContain('const x = 1;');
+    expect(plain).toContain('export { x };');
+    expect(plain).toContain('data-highlighted="false"');
+
+    const coloured = html(
+      <SyntaxLine
+        spans={[{ text: 'const', token: 'keyword' }, { text: ' x = ' }, { text: '1', token: 'literal' }]}
+        text=""
+      />,
+    );
+    expect(coloured).toContain('var(--doom-magenta)');
+    expect(coloured).toContain('var(--doom-orange)');
+    expect(coloured).toContain('const');
+
+    // Without spans the line is its own plain text, which is what every card
+    // renders until its file has parsed.
+    expect(html(<SyntaxLine text="const x = 1;" />)).toContain('const x = 1;');
+  });
+
+  it('turns items into rows inside a group, which says the shared part once', () => {
+    const out = html(
+      <MessageItemGroup tone="error" title="bash" summary="· 2 calls">
+        <MessageItem tone="ok">
+          <MessageItemHeader title="bash">pnpm lint</MessageItemHeader>
+        </MessageItem>
+        <MessageItem tone="error">
+          <MessageItemHeader title="bash">pnpm test</MessageItemHeader>
+        </MessageItem>
+      </MessageItemGroup>,
+    );
+    // The group states the tool and the run's outcome.
+    expect(out).toContain('2 calls');
+    expect(out).toContain('ERROR');
+    // A row keeps its tone as an edge, not as a card of its own.
+    expect(out).toContain('border-l-2');
+    expect(out).toContain('data-grouped="true"');
+    // The tool's name is stated once, by the group, and not again per row.
+    expect(out.match(/>bash<\/span>/g)).toHaveLength(1);
+    expect(out.match(/ERROR/g)).toHaveLength(2);
+    expect(out).not.toContain('>OK<');
+
+    // On its own the same item is a card, with its title and its badge back.
+    const alone = html(
+      <MessageItem tone="ok">
+        <MessageItemHeader title="bash">pnpm lint</MessageItemHeader>
+      </MessageItem>,
+    );
+    expect(alone).toContain('>bash</span>');
+    expect(alone).toContain('OK');
+  });
   it('lends its styling to another element wherever asChild is offered', () => {
     expect(
       html(

--- a/packages/core/doompi-web-components/tests/lib/ansiSpans.test.ts
+++ b/packages/core/doompi-web-components/tests/lib/ansiSpans.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ansiSpans } from '../src/web/ansiSpans.ts';
+import { ansiSpans } from '../../src/lib/ansiSpans.ts';
 
 const ESC = '\x1b';
 

--- a/packages/core/doompi-web-components/tests/lib/hashlineHighlight.test.ts
+++ b/packages/core/doompi-web-components/tests/lib/hashlineHighlight.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { hashlineGroups, hashlineGroupsKey } from '../../src/lib/hashlineHighlight.ts';
+import type { PresentedLine } from '../../src/lib/hashlineView.ts';
+
+const tagged = (line: number, content: string): PresentedLine => ({
+  type: 'tagged',
+  value: { line, content, marker: undefined },
+});
+
+describe('hashlineGroups', () => {
+  it('gives a read body one run under the path the card knows', () => {
+    const groups = hashlineGroups([tagged(1, 'const x = 1;'), tagged(2, 'export { x };')], 'src/a.ts');
+    expect(groups).toEqual([{ path: 'src/a.ts', indices: [0, 1], text: 'const x = 1;\nexport { x };' }]);
+  });
+
+  it('cuts a grep body at every file heading, so each run parses as its own language', () => {
+    const groups = hashlineGroups(
+      [
+        { type: 'file', path: 'src/a.ts' },
+        tagged(1, 'const x = 1;'),
+        { type: 'file', path: 'src/b.py' },
+        tagged(9, 'x = 1'),
+      ],
+      undefined,
+    );
+    expect(groups).toEqual([
+      { path: 'src/a.ts', indices: [1], text: 'const x = 1;' },
+      { path: 'src/b.py', indices: [3], text: 'x = 1' },
+    ]);
+  });
+
+  it('breaks a run at prose, which is not part of the file', () => {
+    const groups = hashlineGroups([tagged(1, 'a'), { type: 'plain', text: '[2 more]' }, tagged(9, 'b')], 'x.ts');
+    expect(groups.map((group) => group.indices)).toEqual([[0], [2]]);
+  });
+
+  it('has no runs for a body with no anchored lines', () => {
+    expect(hashlineGroups([{ type: 'plain', text: 'no matches' }], 'x.ts')).toEqual([]);
+  });
+});
+
+describe('hashlineGroupsKey', () => {
+  it('changes when the text changes and holds when it does not', () => {
+    const one = hashlineGroups([tagged(1, 'a')], 'x.ts');
+    const same = hashlineGroups([tagged(1, 'a')], 'x.ts');
+    const other = hashlineGroups([tagged(1, 'b')], 'x.ts');
+    expect(hashlineGroupsKey(one)).toBe(hashlineGroupsKey(same));
+    expect(hashlineGroupsKey(one)).not.toBe(hashlineGroupsKey(other));
+  });
+});

--- a/packages/core/doompi-web-components/tests/lib/syntaxHighlight.test.ts
+++ b/packages/core/doompi-web-components/tests/lib/syntaxHighlight.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { detectGrammar, highlightToLines, type SyntaxSpan, syntaxStyleOf } from '../../src/lib/syntaxHighlight.ts';
+
+/** The text of a highlighted line, so a case can assert the split without the styles. */
+function textOf(spans: readonly SyntaxSpan[]): string {
+  return spans.map((span) => span.text).join('');
+}
+
+function tokensOf(spans: readonly SyntaxSpan[]): string[] {
+  return spans.filter((span) => span.token !== undefined).map((span) => `${String(span.token)}:${span.text}`);
+}
+
+describe('detectGrammar', () => {
+  it('prefers the path, because a name is evidence and a body is a guess', () => {
+    expect(detectGrammar({ path: 'src/a.ts', text: '{"a":1}' })).toBe('typescript');
+    expect(detectGrammar({ path: 'Dockerfile' })).toBe('dockerfile');
+  });
+
+  it('sniffs a shebang when the path settles nothing', () => {
+    expect(detectGrammar({ text: '#!/usr/bin/env bash\necho hi\n' })).toBe('shell');
+    expect(detectGrammar({ text: '#!/usr/bin/python3\nprint(1)\n' })).toBe('python');
+    expect(detectGrammar({ text: '#!/usr/bin/env node\nconsole.log(1)\n' })).toBe('javascript');
+    // A shebang naming something with no grammar here is still a script.
+    expect(detectGrammar({ text: '#!/usr/bin/env perl\nprint 1;\n' })).toBe('shell');
+  });
+
+  it('sniffs a JSON document by its shape', () => {
+    expect(detectGrammar({ text: '{\n  "a": 1\n}\n' })).toBe('json');
+    expect(detectGrammar({ text: '[1, 2, 3]' })).toBe('json');
+  });
+
+  it('leaves anything it cannot name plain rather than guessing wrong', () => {
+    expect(detectGrammar({})).toBeUndefined();
+    expect(detectGrammar({ text: '' })).toBeUndefined();
+    expect(detectGrammar({ path: 'notes.unknownext', text: 'plain prose' })).toBeUndefined();
+    expect(detectGrammar({ text: 'Tests 11 passed (11)' })).toBeUndefined();
+  });
+});
+
+describe('highlightToLines', () => {
+  it('splits a parsed file into lines of spans that rebuild the source', async () => {
+    const source = 'const x = 1;\n// note\nexport { x };\n';
+    const lines = await highlightToLines(source, 'typescript');
+    expect(lines).toBeDefined();
+    expect((lines ?? []).map(textOf).join('\n')).toBe(source);
+  });
+
+  it('names tokens from the editor palette', async () => {
+    const lines = (await highlightToLines('const x = 1;\n// note\n', 'typescript')) ?? [];
+    expect(tokensOf(lines[0] ?? [])).toContain('keyword:const');
+    expect(tokensOf(lines[0] ?? [])).toContain('literal:1');
+    expect(tokensOf(lines[1] ?? [])).toContain('comment:// note');
+  });
+
+  it('highlights a legacy stream grammar the same way', async () => {
+    const lines = (await highlightToLines('# comment\necho "hi"\n', 'shell')) ?? [];
+    expect(tokensOf(lines[0] ?? [])).toContain('comment:# comment');
+    expect(tokensOf(lines[1] ?? []).join(' ')).toContain('string:"hi"');
+  });
+
+  it('returns nothing for empty text, so the caller keeps its plain render', async () => {
+    await expect(highlightToLines('', 'json')).resolves.toBeUndefined();
+  });
+
+  it('returns nothing past the size cap rather than blocking the frame', async () => {
+    await expect(highlightToLines('a'.repeat(200_001), 'json')).resolves.toBeUndefined();
+  });
+});
+
+describe('syntaxStyleOf', () => {
+  it('answers with the editor palette, and with nothing for an unstyled span', () => {
+    expect(syntaxStyleOf('keyword')).toEqual({ color: 'var(--doom-magenta)' });
+    expect(syntaxStyleOf(undefined)).toBeUndefined();
+  });
+});

--- a/packages/core/doompi-web-contracts/src/exports/index.ts
+++ b/packages/core/doompi-web-contracts/src/exports/index.ts
@@ -34,6 +34,8 @@ export type {
   RepositorySettingsRepository,
   SettingsFieldContribution,
   SettingsFieldOption,
+  SettingsPanelContribution,
+  SettingsPanelProps,
   SettingsSectionContribution,
   SurfaceContribution,
   TabContribution,

--- a/packages/core/doompi-web-contracts/src/services/testing/slotProps.ts
+++ b/packages/core/doompi-web-contracts/src/services/testing/slotProps.ts
@@ -47,6 +47,8 @@ export interface SlotPropsOptions {
   slotData?: Readonly<Record<string, readonly SlotDataFill[]>>;
   /** What `renderThread` returns for a plugin that renders one. */
   thread?: (threadId: string, options?: ThreadViewOptions) => ReactNode;
+  /** The tab a path opens; by default no path opens one, as with no file plugin installed. */
+  fileTab?: (path: string) => TransientTab | undefined;
 }
 
 const DEFAULT_SESSION_ID = 's1';
@@ -65,6 +67,7 @@ export function slotPropsFixture(options: SlotPropsOptions = {}): SlotPropsFixtu
     closeTransientTab: (tabId: string) => {
       actions.push({ action: 'closeTransientTab', target: tabId });
     },
+    fileTabFor: (path: string) => options.fileTab?.(path),
     appendComposerDraft: (text) => {
       actions.push({ action: 'appendComposerDraft', target: props.sessionId, text });
     },

--- a/packages/core/doompi-web-contracts/src/types/webPlugin.ts
+++ b/packages/core/doompi-web-contracts/src/types/webPlugin.ts
@@ -8,10 +8,10 @@ import type { ComponentType, ReactNode } from 'react';
  * declared client entry. The cockpit's bundler compiles that entry into the
  * host bundle, so a plugin's client code may import only react,
  * @tanstack/store, @tanstack/react-store, this contract,
- * @agimon-ai/doompi-web-components, and the package's own web/ and src/types
- * modules; never another plugin, a node builtin, or a server framework, which
- * modules; never another plugin, a node builtin, or a server framework, which
- * the host bundle would swallow. Page-wide state takes the shape
+ * @agimon-ai/doompi-web-components, @agimon-ai/doompi-web-security/browser,
+ * and the package's own web/ and src/types modules; never another plugin, a
+ * node builtin, or a server framework, which the host bundle would swallow.
+ * Page-wide state takes the shape
  * defineGlobalStore gives it; per-session state takes the shape defineSessionStore
  * gives it. Tailwind utility classes must appear as complete literal strings so
  * the host's class scanner can see them.
@@ -215,6 +215,42 @@ export interface SettingsSectionContribution {
   /** Sort position in the settings menu; lower first, id breaks ties. */
   order?: number;
   fields: readonly SettingsFieldContribution[];
+}
+
+/**
+ * Props for a settings page a package draws itself. The transport is the
+ * host's, because only the host knows whether the page is being read over a
+ * tunnel and what to seal.
+ */
+export interface SettingsPanelProps {
+  /** Same-origin request routed through the host's sealed transport when remote. */
+  request: (input: string, init?: RequestInit) => Promise<Response>;
+  /** The same transport, retrying once after the host's fresh passkey gesture. */
+  requestWithStepUp: (input: string, init?: RequestInit) => Promise<Response>;
+}
+
+/**
+ * A settings page a package draws itself, for a page that reports rather
+ * than writes.
+ *
+ * A contributed section is data because the host owns what a plugin cannot:
+ * which file an edit lands in. That reasoning runs out when a page has
+ * nothing to write. A page whose content is a chart, a table, or anything
+ * else the host cannot know the shape of has no keyPath to declare and no
+ * scope to switch, so declaring it as fields would mean inventing a field
+ * kind per picture. Such a page takes a component and the host's transport,
+ * exactly as a repository panel does, and gives up the scope switch and the
+ * write plumbing it would not use. A package that needs both contributes
+ * both, and the two appear in the menu as two pages.
+ */
+export interface SettingsPanelContribution {
+  /** The URL segment (/settings/:id) and testid suffix; unique across plugins. */
+  id: string;
+  label: string;
+  detail: string;
+  /** Sort position in the settings menu; lower first, id breaks ties. */
+  order?: number;
+  component: ComponentType<SettingsPanelProps>;
 }
 export interface SurfaceContribution {
   id: string;
@@ -539,6 +575,12 @@ export interface WebPluginDefinition {
    * owns the scope switch, the repository picker, and every write.
    */
   settingsSections?: SettingsSectionContribution[];
+  /**
+   * Pages this plugin draws itself in cockpit settings, for a page that
+   * reports rather than writes. The host owns the menu entry, the route, and
+   * the transport; the plugin owns everything inside the page.
+   */
+  settingsPanels?: SettingsPanelContribution[];
   /**
    * A package-owned management panel inside the host's repository page. The
    * host owns repository identity and passes only repositories it admitted.

--- a/packages/core/doompi-web-contracts/src/types/webPlugin.ts
+++ b/packages/core/doompi-web-contracts/src/types/webPlugin.ts
@@ -75,6 +75,16 @@ export interface FileLinkSource {
   fingerprint(sessionId: string | null): string;
   /** The tab this path opens, or undefined when the source does not recognise it. */
   resolve(sessionId: string | null, path: string): TransientTab | undefined;
+  /**
+   * The tab a path opens when the caller already knows it names a file, such
+   * as the path argument of a read, write or edit call.
+   *
+   * `resolve` guesses, so it claims only what it is sure of; a tool argument
+   * needs no guess, and a file the session has not changed is still a file the
+   * reader asked to see. A source that has nothing extra to offer omits this
+   * and the host falls back to `resolve`.
+   */
+  openPath?(sessionId: string | null, path: string): TransientTab | undefined;
 }
 /**
  * How a thread is drawn where it is not the whole surface: a card body wants
@@ -95,6 +105,13 @@ export interface WebPluginSlotProps {
   /** Opens the tab for the focused session, or focuses it when one with the same id is already open. */
   openTransientTab: (tab: TransientTab) => void;
   closeTransientTab: (tabId: string) => void;
+  /**
+   * The tab a file path opens, or undefined when no installed plugin can show
+   * it. A component that names a file it is certain about, such as a tool
+   * call's path argument, renders a link when this answers and plain text when
+   * it does not.
+   */
+  fileTabFor: (path: string) => TransientTab | undefined;
   /**
    * The host's live conversation view of one thread of the focused session,
    * rendered like the session's own timeline and subscribed while mounted. A

--- a/packages/core/doompi/src/adapters/composer.ts
+++ b/packages/core/doompi/src/adapters/composer.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from 'node:url';
 import { loadMajorModesConfig, type MajorModesConfig } from '@agimon-ai/doompi-config/majorModes';
 import { withExtensionSource } from '@agimon-ai/doompi-ui/extensionName';
 import { type ExtensionAPI, parseArgs } from '@earendil-works/pi-coding-agent';
-import { PERSONA_ENTRY, resolveExtensionComposition } from '../services/extensionAssembler.ts';
+import { PERSONA_ENTRY, packageAttribution, resolveExtensionComposition } from '../services/extensionAssembler.ts';
 import type { HarnessPreset } from '../types/interfaces/harness';
 import { findSyncedRoot, readBundleStatus } from './bootstrapLocator.ts';
 import { alreadyComposed } from '@agimon-ai/doompi-extension-contracts/child-process';
@@ -298,6 +298,7 @@ export async function composeRuntimeLoadPlan(
     {
       childExtensions: [...composition.childActivation],
       compositionFingerprint: composition.fingerprint,
+      packageAttribution: packageAttribution(composition),
     },
     environment,
   );

--- a/packages/core/doompi/src/adapters/piExtensionDispatcher.ts
+++ b/packages/core/doompi/src/adapters/piExtensionDispatcher.ts
@@ -164,6 +164,19 @@ export function piExtensionDispatcherIsCurrent(piDirectory: string): boolean {
   return fs.lstatSync(path.join(directory, DISPATCHER_ENTRY), { throwIfNoEntry: false })?.isFile() === true;
 }
 
+/** Whether an existing managed dispatcher is stale but safe to upgrade in place. */
+export function piExtensionDispatcherIsUpgradeable(piDirectory: string): boolean {
+  const directory = piExtensionDispatcherPath(piDirectory);
+  const stat = fs.lstatSync(directory, { throwIfNoEntry: false });
+  if (!stat?.isDirectory() || stat.isSymbolicLink()) return false;
+  return upgradeableManagedManifest(directory) && !managedManifest(directory);
+}
+
+/** Installed protocol version of the dispatcher package, if it is DoomPi-owned. */
+export function piExtensionDispatcherVersion(piDirectory: string): number | undefined {
+  return managedManifestVersion(piExtensionDispatcherPath(piDirectory));
+}
+
 function legacyLinkIsManaged(linkPath: string): boolean {
   try {
     return manifestName(fs.realpathSync(linkPath)) === DOOM_PACKAGE_NAME;

--- a/packages/core/doompi/src/commands/syncCommand.ts
+++ b/packages/core/doompi/src/commands/syncCommand.ts
@@ -9,7 +9,12 @@ import { buildHarnessContext } from '../adapters/harnessContext.ts';
 import { ensureLayerPackages, missingLayerPackageSpecifiers } from '../adapters/layerPackageInstaller.ts';
 import { readBootstrapStatus } from '../adapters/bootstrapLocator.ts';
 import { DOOM_PACKAGE_NAME } from '../adapters/doomPackage.ts';
-import { doomPiPackageRoot, piExtensionAliasIsCurrent } from '../adapters/piExtensionAlias.ts';
+import { doomPiPackageRoot, piExtensionAliasIsCurrent, writePiExtensionAlias } from '../adapters/piExtensionAlias.ts';
+import {
+  PI_DISPATCHER_VERSION,
+  piExtensionDispatcherIsUpgradeable,
+  piExtensionDispatcherVersion,
+} from '../adapters/piExtensionDispatcher.ts';
 import {
   mergePiSettings,
   piAgentDirectory,
@@ -202,6 +207,23 @@ export function selectionCompositionFingerprint(
   }).fingerprint;
 }
 
+/** Settings, dispatcher and theme differences an init would fix, independent of sync state. */
+function piIntegrationDrift(agentDirectory: string): string[] {
+  const drift: string[] = [];
+  const themePath = path.join(piThemeDirectory(agentDirectory), `${DEFAULT_THEME_NAME}.json`);
+  const settings = readPiSettings(agentDirectory);
+  const merged = mergePiSettings(settings, agentDirectory, { themePath, themeName: DEFAULT_THEME_NAME });
+  if (serializePiSettings(merged) !== serializePiSettings(settings)) {
+    drift.push('Pi user settings are out of date; run doompi init');
+  }
+  if (!piExtensionAliasIsCurrent(agentDirectory)) drift.push('Pi user dispatcher is out of date; run doompi init');
+  const expectedTheme = `${JSON.stringify(DEFAULT_THEME, null, 2)}\n`;
+  if (!fs.existsSync(themePath) || fs.readFileSync(themePath, 'utf8') !== expectedTheme) {
+    drift.push('Pi user theme is out of date; run doompi init');
+  }
+  return drift;
+}
+
 /** Differences between what a sync would produce and what is on disk. */
 export function collectDrift(
   repoRoot: string,
@@ -254,17 +276,8 @@ export function collectDrift(
   if (settingsMode === 'persisted') {
     const agentDirectory = piAgentDirectory(environment);
     const themePath = path.join(piThemeDirectory(agentDirectory), `${DEFAULT_THEME_NAME}.json`);
-    const settings = readPiSettings(agentDirectory);
-    const merged = mergePiSettings(settings, agentDirectory, { themePath, themeName: DEFAULT_THEME_NAME });
-    if (serializePiSettings(merged) !== serializePiSettings(settings)) {
-      drift.push('Pi user settings are out of date; run doompi init');
-    }
+    drift.push(...piIntegrationDrift(agentDirectory));
     if (projectRegistersDoom(repoRoot)) drift.push(DUPLICATE_REGISTRATION_DRIFT);
-    if (!piExtensionAliasIsCurrent(agentDirectory)) drift.push('Pi user dispatcher is out of date; run doompi init');
-    const expectedTheme = `${JSON.stringify(DEFAULT_THEME, null, 2)}\n`;
-    if (!fs.existsSync(themePath) || fs.readFileSync(themePath, 'utf8') !== expectedTheme) {
-      drift.push('Pi user theme is out of date; run doompi init');
-    }
     if (state.baseline.themePath !== themePath || state.baseline.themeName !== DEFAULT_THEME_NAME) {
       drift.push('synced theme location is out of date');
     }
@@ -431,20 +444,16 @@ export class SyncCommand {
     const selection = toSelection(parsed.options);
     const agentDirectory = piAgentDirectory(environment, homeDirectory);
     if (this.settingsMode === 'persisted' && !check) {
-      const themePath = path.join(piThemeDirectory(agentDirectory), `${DEFAULT_THEME_NAME}.json`);
-      const settings = readPiSettings(agentDirectory);
-      const expectedSettings = mergePiSettings(settings, agentDirectory, {
-        themePath,
-        themeName: DEFAULT_THEME_NAME,
-      });
-      const expectedTheme = `${JSON.stringify(DEFAULT_THEME, null, 2)}\n`;
-      const ready =
-        piExtensionAliasIsCurrent(agentDirectory) &&
-        serializePiSettings(expectedSettings) === serializePiSettings(settings) &&
-        fs.existsSync(themePath) &&
-        fs.readFileSync(themePath, 'utf8') === expectedTheme;
-      if (!ready) {
-        throw new Error('DoomPi Pi integration is not initialized. Run doompi init before doompi sync.');
+      if (piExtensionDispatcherIsUpgradeable(agentDirectory)) {
+        const previousVersion = piExtensionDispatcherVersion(agentDirectory);
+        writePiExtensionAlias(agentDirectory);
+        output.write(
+          `repair:   upgraded Pi user dispatcher from protocol ${String(previousVersion)} to ${String(PI_DISPATCHER_VERSION)}\n`,
+        );
+      }
+      const drift = piIntegrationDrift(agentDirectory);
+      if (drift.length > 0) {
+        throw new Error(`DoomPi Pi integration is not ready:\n${drift.map((entry) => `  ${entry}`).join('\n')}`);
       }
     }
     if (check) {

--- a/packages/core/doompi/src/extensions/entries/modeCatalog.ts
+++ b/packages/core/doompi/src/extensions/entries/modeCatalog.ts
@@ -24,6 +24,7 @@ import {
   type TransitionSource,
 } from '@agimon-ai/doompi-extension-contracts/transition';
 import type { Context } from '@deepseek-ai/cordis';
+import { type ContextPublisher, createContextPublisher } from '../../services/contextCatalog.ts';
 import { projectMinorModes } from '../../services/minorModeProjection.ts';
 import { createMinorModeCatalogHost } from '../../services/modeCatalog.ts';
 import { registerMinorModeCommand } from './minorModeCommand.ts';
@@ -70,12 +71,31 @@ export async function modeCatalogExtension(pi: ExtensionAPI): Promise<void> {
   // catalog binding the session-scoped inject below sets and clears.
   const activeCatalog: CatalogBinding = { current: undefined };
   registerMinorModeCommand(pi, () => activeCatalog.current);
+  // The composition is only complete once every extension has registered, so
+  // the inventory is read on the same deferred tick the catalog republishes on.
+  const contextBinding: { publisher?: ContextPublisher } = {};
   pi.on('session_start', () => {
-    setTimeout(() => activeCatalog.republish?.(), BOOT_PUBLISH_DELAY_MS);
+    setTimeout(() => {
+      activeCatalog.republish?.();
+      void contextBinding.publisher?.publish();
+    }, BOOT_PUBLISH_DELAY_MS);
+  });
+  // MCP status is pull-only and servers connect long after startup, so the
+  // boot read above cannot see them. A turn is the moment the composition is
+  // actually sent, which makes it both the freshest and the most meaningful
+  // time to price. Identical compositions are skipped, so a quiet session
+  // journals nothing extra.
+  pi.on('turn_start', () => {
+    void contextBinding.publisher?.publish();
   });
   const connection = await connectDoomCordisHost(pi, PACKAGE_SOURCE);
   const fiber = connection.root.plugin((cordis: Context) => {
-    modeCatalogPlugin(cordis, pi, activeCatalog);
+    contextBinding.publisher = createContextPublisher(pi, cordis);
+    modeCatalogPlugin(cordis, pi, activeCatalog, () => void contextBinding.publisher?.publish());
+    return () => {
+      contextBinding.publisher?.dispose();
+      contextBinding.publisher = undefined;
+    };
   });
   try {
     await fiber;
@@ -102,6 +122,7 @@ function modeCatalogPlugin(
   cordis: Context,
   pi: Pick<ExtensionAPI, 'appendEntry'>,
   activeCatalog: CatalogBinding,
+  onCatalogChanged: () => void,
 ): void {
   cordis.inject([DOOM_HELP_SERVICE], (helpContext) => {
     const contribution = requireDoomHelpService(helpContext).register({
@@ -174,6 +195,8 @@ function modeCatalogPlugin(
       if (serialized === published) return;
       published = serialized;
       pi.appendEntry(DOOM_MINOR_MODE_ENTRY_TYPE, projection);
+      // A mode changing is the usual reason the toolbox changed too.
+      onCatalogChanged();
     };
     const unsubscribe = catalog.subscribe(() => {
       settle ??= setTimeout(publish, PROJECTION_SETTLE_MS);

--- a/packages/core/doompi/src/services/contextCatalog.ts
+++ b/packages/core/doompi/src/services/contextCatalog.ts
@@ -1,0 +1,125 @@
+import { resolvePluginEntries } from '@agimon-ai/doompi-config/domains';
+import { getHarnessState, harnessRoot } from '@agimon-ai/doompi-config/harnessStore';
+import type { PackageAttribution } from '@agimon-ai/doompi-config/types';
+import { readDoomMcpStatus } from '@agimon-ai/doompi-extension-contracts/mcp-status';
+import { readDoomSkillSourcesService } from '@agimon-ai/doompi-extension-contracts/skills';
+import { buildSkillCatalog, counter, type SkillEntry } from '@agimon-ai/doompi-skill/catalog';
+import { extensionName, extensionPackageName, extensionToolSource } from '@agimon-ai/doompi-ui/extensionName';
+import { buildToolSources } from '@agimon-ai/doompi-ui/toolInventory';
+import type { Context } from '@deepseek-ai/cordis';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { DOOM_CONTEXT_ENTRY_TYPE, projectContext } from './contextProjection.ts';
+
+/**
+ * Publishes what the session is composed of, and what it costs.
+ *
+ * Read at publish time rather than accumulated, because the answer changes for
+ * reasons this module does not see: a reconnected MCP server, a domain switch,
+ * a plan-mode tool swap. Reading the live inventory is cheap next to being
+ * wrong about it.
+ */
+export interface ContextPublisher {
+  /** Never rejects: callers fire this and forget it. */
+  publish: () => Promise<void>;
+  dispose: () => void;
+}
+
+/** Skills sit under owners, which is one level deeper than a flat list. */
+function flattenSkills(groups: Awaited<ReturnType<typeof buildSkillCatalog>>['groups']): SkillEntry[] {
+  return groups.flatMap((group) => group.owners.flatMap((owner) => owner.skills));
+}
+
+/**
+ * Package and plugin names to the mode that admitted them.
+ *
+ * Two halves meet here. Layer packages come from the harness, recorded when the
+ * composition resolved. Domain plugins are re-resolved, because only the plugin
+ * entry knows the domain that carried it.
+ */
+function attributionFor(repoRoot: string, domains: readonly string[], pluginDirectories: readonly string[]) {
+  const harness = getHarnessState();
+  const attribution: Record<string, PackageAttribution> = { ...harness.packageAttribution };
+  try {
+    for (const entry of resolvePluginEntries(repoRoot, [...domains], [...pluginDirectories])) {
+      if (entry.name && entry.domain) attribution[entry.name] = { kind: 'domain', mode: entry.domain };
+    }
+  } catch {
+    // A domain that no longer resolves must not cost the reader the tool list.
+    // Anything unmatched simply lands under core.
+  }
+  return attribution;
+}
+
+export function createContextPublisher(pi: ExtensionAPI, cordis: Context): ContextPublisher {
+  let published: string | undefined;
+  let revision = 0;
+  let disposed = false;
+
+  const build = async (): Promise<void> => {
+    if (disposed) return;
+    const harness = getHarnessState();
+    const mcpServers = readDoomMcpStatus(cordis)?.getSnapshot().servers;
+    const sources = buildToolSources({
+      tools: pi.getAllTools(),
+      activeTools: pi.getActiveTools(),
+      ...(mcpServers ? { mcpServers } : {}),
+      resolveExtensionName: extensionName,
+      resolveExtensionPackageName: extensionPackageName,
+      resolveExtensionToolSource: (toolName) => extensionToolSource(pi, toolName),
+    });
+
+    const repoRoot = harnessRoot(harness);
+    let skills: SkillEntry[] = [];
+    try {
+      const catalog = await buildSkillCatalog({
+        repoRoot,
+        activeSkillDirectories: harness.skillDirectories,
+        extensionSources: readDoomSkillSourcesService(cordis)?.list() ?? [],
+      });
+      skills = flattenSkills(catalog.groups);
+    } catch {
+      // Tools are the larger cost and are already in hand; a skill walk that
+      // fails should not take the whole figure down with it.
+    }
+
+    const projection = projectContext({
+      revision: revision + 1,
+      majorMode: harness.majorMode,
+      minorModes: [],
+      sources,
+      skills,
+      attribution: attributionFor(repoRoot, harness.domains, harness.pluginDirectories),
+      countTokens: await counter(),
+    });
+
+    // Revision is compared out, so a republish that changed nothing is silent
+    // rather than a new journal entry saying the same thing.
+    const serialized = JSON.stringify({ ...projection, revision: 0 });
+    if (serialized === published || disposed) return;
+    published = serialized;
+    revision += 1;
+    pi.appendEntry(DOOM_CONTEXT_ENTRY_TYPE, { ...projection, revision });
+  };
+
+  /**
+   * Reporting the composition is a convenience, so it fails quietly.
+   *
+   * Callers publish without awaiting, and an escaping rejection would surface
+   * as an unhandled error in a live session. A panel that cannot say what the
+   * toolbox costs is a far smaller problem than that.
+   */
+  const publish = async (): Promise<void> => {
+    try {
+      await build();
+    } catch {
+      // Left unreported on purpose: the next composition change tries again.
+    }
+  };
+
+  return {
+    publish,
+    dispose: () => {
+      disposed = true;
+    },
+  };
+}

--- a/packages/core/doompi/src/services/contextProjection.ts
+++ b/packages/core/doompi/src/services/contextProjection.ts
@@ -1,0 +1,186 @@
+import type { PackageAttribution } from '@agimon-ai/doompi-config/types';
+import type { SkillEntry } from '@agimon-ai/doompi-skill/catalog';
+import { type CountTokens, type ToolSource, tokensForTool } from '@agimon-ai/doompi-ui/toolInventory';
+
+/**
+ * What the session is carrying, and what carrying it costs.
+ *
+ * Grouped by the mode that admitted each package rather than by where the tool
+ * came from, because a mode is the thing a reader can switch off. The mechanism
+ * (extension, MCP server, plugin) orders rows inside a group instead, so the
+ * expensive thing is still easy to find.
+ *
+ * Schemas never travel. Only names, kinds, owners and integer counts do, which
+ * keeps the payload small enough to republish whenever the composition changes.
+ */
+export const CONTEXT_PROJECTION_VERSION = 1;
+
+/** Journal entry the cockpit reads; mirrored by CONTEXT_ENTRY_TYPE in doompi-web. */
+export const DOOM_CONTEXT_ENTRY_TYPE = 'doom-context';
+
+/** The tokenizer these counts came from, so a reader can judge them. */
+export const CONTEXT_PROJECTION_ESTIMATOR = 'gpt-tokenizer';
+
+export type ContextGroupKind = 'major' | 'minor' | 'domain' | 'core';
+export type ContextItemSource = 'extension' | 'mcp' | 'plugin' | 'core';
+
+/** Everything the runtime could not attribute lands here rather than vanishing. */
+const CORE_GROUP = 'core';
+/** Pi's own tools have no package; the runtime itself is the owner. */
+const CORE_OWNER = 'pi';
+const MCP_KEY_PREFIX = 'mcp:';
+
+const KIND_ORDER: Record<ContextGroupKind, number> = { major: 0, minor: 1, domain: 2, core: 3 };
+const SOURCE_ORDER: Record<ContextItemSource, number> = { extension: 0, mcp: 1, plugin: 2, core: 3 };
+
+export interface ContextItemProjection {
+  readonly name: string;
+  readonly itemKind: 'tool' | 'skill';
+  readonly source: ContextItemSource;
+  /** The package, server, or plugin that registered it. */
+  readonly owner: string;
+  readonly tokens: number;
+  readonly active: boolean;
+}
+
+export interface ContextGroupProjection {
+  readonly id: string;
+  readonly label: string;
+  readonly kind: ContextGroupKind;
+  readonly items: readonly ContextItemProjection[];
+  /** What the group costs now: active items only. */
+  readonly tokens: number;
+  /** What its gated items would add if switched on. */
+  readonly inactiveTokens: number;
+}
+
+export interface ContextProjection {
+  readonly version: typeof CONTEXT_PROJECTION_VERSION;
+  readonly revision: number;
+  readonly groups: readonly ContextGroupProjection[];
+  readonly totalTokens: number;
+  readonly inactiveTokens: number;
+  readonly estimator: typeof CONTEXT_PROJECTION_ESTIMATOR;
+}
+
+export interface ContextProjectionInput {
+  readonly revision: number;
+  readonly majorMode: string;
+  /** Active minor modes, in the order the catalog reports them. */
+  readonly minorModes: readonly { readonly id: string; readonly label: string }[];
+  readonly sources: readonly ToolSource[];
+  readonly skills: readonly SkillEntry[];
+  /**
+   * Owner identifier to the mode that admitted it.
+   *
+   * Keys are package names for extensions and layer packages, and plugin or
+   * server names for anything a domain carries. The caller owns this join
+   * because only it knows how a given deployment resolved its plugins.
+   */
+  readonly attribution: Readonly<Record<string, PackageAttribution>>;
+  readonly countTokens: CountTokens;
+}
+
+interface Bucket {
+  kind: ContextGroupKind;
+  label: string;
+  items: ContextItemProjection[];
+}
+
+function skillSource(group: SkillEntry['group']): ContextItemSource {
+  if (group === 'plugins') return 'plugin';
+  if (group === 'extensions') return 'extension';
+  return 'core';
+}
+
+function byRow(left: ContextItemProjection, right: ContextItemProjection): number {
+  return SOURCE_ORDER[left.source] - SOURCE_ORDER[right.source] || left.name.localeCompare(right.name);
+}
+
+export function projectContext(input: ContextProjectionInput): ContextProjection {
+  const buckets = new Map<string, Bucket>();
+
+  // Declared before anything is placed, so a mode with nothing attributed to it
+  // still appears. An empty group is a fact worth showing: it says the mode is
+  // on and cheap, not that the runtime forgot about it.
+  const declare = (id: string, label: string, kind: ContextGroupKind): void => {
+    if (!buckets.has(id)) buckets.set(id, { kind, label, items: [] });
+  };
+  if (input.majorMode) declare(input.majorMode, input.majorMode, 'major');
+  for (const mode of input.minorModes) declare(mode.id, mode.label, 'minor');
+
+  const place = (owner: string, item: ContextItemProjection): void => {
+    const attributed = input.attribution[owner];
+    const id = attributed?.mode ?? CORE_GROUP;
+    declare(id, id, attributed ? (attributed.kind === 'domain' ? 'domain' : 'major') : 'core');
+    buckets.get(id)?.items.push(item);
+  };
+
+  for (const source of input.sources) {
+    // An extension is owned by its package, an MCP tool by the server that
+    // advertised it. `label` is display text like `scaffold · mcp`, so the
+    // identifier comes from the key instead: an owner is joined on, not read.
+    const owner =
+      source.kind === 'extension'
+        ? (source.packageName ?? source.key)
+        : source.kind === 'mcp'
+          ? source.key.slice(MCP_KEY_PREFIX.length)
+          : CORE_OWNER;
+    for (const tool of source.tools) {
+      const cost = tokensForTool(tool, input.countTokens);
+      const item: ContextItemProjection = {
+        name: tool.name,
+        itemKind: 'tool',
+        source: source.kind === 'core' ? 'core' : source.kind,
+        owner,
+        tokens: cost.totalTokens,
+        active: tool.active,
+      };
+      if (source.kind === 'core') {
+        declare(CORE_GROUP, CORE_GROUP, 'core');
+        buckets.get(CORE_GROUP)?.items.push(item);
+      } else {
+        place(owner, item);
+      }
+    }
+  }
+
+  for (const skill of input.skills) {
+    place(skill.owner, {
+      name: skill.name,
+      itemKind: 'skill',
+      source: skillSource(skill.group),
+      owner: skill.owner,
+      tokens: skill.promptTokens ?? 0,
+      // A skill is always offered to the model; there is no inactive state for
+      // it the way there is for a tool Pi has filtered out.
+      active: true,
+    });
+  }
+
+  const groups: ContextGroupProjection[] = [...buckets.entries()]
+    .map(([id, bucket]) => {
+      const items = [...bucket.items].sort(byRow);
+      // Only what is actually sent counts. Pi builds the prompt from its
+      // active tools, so a gated one costs nothing until it is switched on,
+      // and folding it into the total would overstate the bill by a third.
+      return {
+        id,
+        label: bucket.label,
+        kind: bucket.kind,
+        items,
+        tokens: items.reduce((total, item) => total + (item.active ? item.tokens : 0), 0),
+        inactiveTokens: items.reduce((total, item) => total + (item.active ? 0 : item.tokens), 0),
+      };
+    })
+    .sort((left, right) => KIND_ORDER[left.kind] - KIND_ORDER[right.kind] || left.label.localeCompare(right.label));
+
+  return {
+    version: CONTEXT_PROJECTION_VERSION,
+    revision: input.revision,
+    groups,
+    totalTokens: groups.reduce((total, group) => total + group.tokens, 0),
+    inactiveTokens: groups.reduce((total, group) => total + group.inactiveTokens, 0),
+    estimator: CONTEXT_PROJECTION_ESTIMATOR,
+  };
+}

--- a/packages/core/doompi/src/services/extensionAssembler.ts
+++ b/packages/core/doompi/src/services/extensionAssembler.ts
@@ -3,6 +3,7 @@ import {
   type LayerResolvers,
   type MajorModesConfig,
 } from '@agimon-ai/doompi-config/majorModes';
+import type { PackageAttribution } from '@agimon-ai/doompi-config/types';
 import {
   consumerPackageEntries,
   consumerPackageEntry,
@@ -91,6 +92,31 @@ export interface ExtensionComposition {
   readonly fingerprint: string;
 }
 
+/**
+ * Which layer of which major mode admitted each package.
+ *
+ * The composition already holds this join while it resolves package names to
+ * entry paths, then drops it, so a session cannot afterwards say why a tool is
+ * present. Reducing it here keeps the selection type private and costs one pass
+ * over an array the caller already has.
+ *
+ * Only `package` entries appear. A bare `extension` selector is a path rather
+ * than a package name, so it has nothing a registered tool could be joined on.
+ */
+export function packageAttribution(composition: ExtensionComposition): Record<string, PackageAttribution> {
+  const attribution: Record<string, PackageAttribution> = {};
+  const mode = composition.majorMode?.name;
+  if (mode === undefined) return attribution;
+  for (const selection of composition.selections) {
+    if (selection.entryKind !== 'package') continue;
+    if (selection.outcome !== 'resolved') continue;
+    // First layer wins, matching activation order: the earlier layer is the one
+    // whose copy of a duplicated package actually loaded.
+    if (attribution[selection.selector] !== undefined) continue;
+    attribution[selection.selector] = { kind: 'major', mode, layer: selection.layer };
+  }
+  return attribution;
+}
 export const COMPOSITION_FINGERPRINT_VERSION = 4;
 export const STANDARD_PI_EXTENSION_CONTRACT_VERSION = 2;
 

--- a/packages/core/doompi/src/services/extensionAssembler.ts
+++ b/packages/core/doompi/src/services/extensionAssembler.ts
@@ -4,6 +4,7 @@ import {
   type MajorModesConfig,
 } from '@agimon-ai/doompi-config/majorModes';
 import type { PackageAttribution } from '@agimon-ai/doompi-config/types';
+import { extensionPackageName } from '@agimon-ai/doompi-ui/extensionName';
 import {
   consumerPackageEntries,
   consumerPackageEntry,
@@ -102,6 +103,11 @@ export interface ExtensionComposition {
  *
  * Only `package` entries appear. A bare `extension` selector is a path rather
  * than a package name, so it has nothing a registered tool could be joined on.
+ *
+ * Keyed by manifest name first, because that is what a registered tool resolves
+ * to. The selector is kept as an alias: a layer may name a package as
+ * `@agimon-ai/doompi-team` when published or `./layers/team/doompi-team` in a
+ * checkout, and both have to find the same layer.
  */
 export function packageAttribution(composition: ExtensionComposition): Record<string, PackageAttribution> {
   const attribution: Record<string, PackageAttribution> = {};
@@ -112,8 +118,10 @@ export function packageAttribution(composition: ExtensionComposition): Record<st
     if (selection.outcome !== 'resolved') continue;
     // First layer wins, matching activation order: the earlier layer is the one
     // whose copy of a duplicated package actually loaded.
-    if (attribution[selection.selector] !== undefined) continue;
-    attribution[selection.selector] = { kind: 'major', mode, layer: selection.layer };
+    const value: PackageAttribution = { kind: 'major', mode, layer: selection.layer };
+    const manifest = selection.path === undefined ? undefined : extensionPackageName(selection.path);
+    if (manifest !== undefined && attribution[manifest] === undefined) attribution[manifest] = value;
+    if (attribution[selection.selector] === undefined) attribution[selection.selector] = value;
   }
   return attribution;
 }

--- a/packages/core/doompi/tests/commands/syncCommand.test.ts
+++ b/packages/core/doompi/tests/commands/syncCommand.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { loadMajorModesConfig } from '@agimon-ai/doompi-config/majorModes';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { piExtensionAliasPath, writePiExtensionAlias } from '../../src/adapters/piExtensionAlias';
+import { PI_DISPATCHER_VERSION } from '../../src/adapters/piExtensionDispatcher';
 import { DUPLICATE_REGISTRATION_DRIFT } from '../../src/adapters/projectPiSettings';
 import { resolveSyncLocation, syncGenerationDirectory } from '../../src/adapters/syncLocation';
 import {
@@ -566,6 +567,45 @@ describe('doompi sync', { timeout: 30_000 }, () => {
     expect(fs.existsSync(piExtensionAliasPath(path.join(root, '.pi')))).toBe(false);
   });
 
+  it('self-heals a stale but upgradeable Pi dispatcher and reports the repair', async () => {
+    const root = makeRepository();
+    const dispatcherPath = piExtensionAliasPath(agentDirectory(root));
+    fs.writeFileSync(
+      path.join(dispatcherPath, 'package.json'),
+      `${JSON.stringify({ name: '@agimon-ai/doompi', doompiDispatcher: 1 })}\n`,
+    );
+
+    const { output, text } = capture();
+    const code = await new SyncCommand().execute(['sync'], environmentFor(root), root, output);
+
+    expect(code).toBe(0);
+    expect(text()).toContain('repair:   upgraded Pi user dispatcher from protocol 1 to 2');
+    const manifest = JSON.parse(fs.readFileSync(path.join(dispatcherPath, 'package.json'), 'utf8')) as {
+      doompiDispatcher?: unknown;
+    };
+    expect(manifest.doompiDispatcher).toBe(PI_DISPATCHER_VERSION);
+  });
+
+  it('refuses to repair an unmanaged dispatcher path and names the real condition', async () => {
+    const root = makeRepository();
+    const dispatcherPath = piExtensionAliasPath(agentDirectory(root));
+    fs.rmSync(dispatcherPath, { recursive: true, force: true });
+    fs.mkdirSync(dispatcherPath, { recursive: true });
+
+    await expect(new SyncCommand().execute(['sync'], environmentFor(root), root, capture().output)).rejects.toThrow(
+      'Pi user dispatcher is out of date; run doompi init',
+    );
+    expect(fs.existsSync(path.join(dispatcherPath, 'package.json'))).toBe(false);
+  });
+
+  it('names stale user settings instead of claiming the integration is uninitialized', async () => {
+    const root = makeRepository();
+    fs.writeFileSync(path.join(agentDirectory(root), 'settings.json'), '{"extensions":[]}\n');
+
+    await expect(new SyncCommand().execute(['sync'], environmentFor(root), root, capture().output)).rejects.toThrow(
+      'Pi user settings are out of date; run doompi init',
+    );
+  });
   it('drops a project registration key that empties out and leaves the root marker in place', async () => {
     const root = makeRepository();
     const projectSettingsPath = path.join(root, '.pi', 'settings.json');

--- a/packages/core/doompi/tests/fixtures/packageCompatibility.json
+++ b/packages/core/doompi/tests/fixtures/packageCompatibility.json
@@ -797,6 +797,7 @@
     "exports": {
       ".": "tir",
       "./extensions/pi": "tir",
+      "./hub-api": "tir",
       "./metrics": "tir",
       "./metricsSource": "tir",
       "./tui/metricsOverlay": "tir",
@@ -812,6 +813,11 @@
         "types": "./dist/extensions/pi.d.mts",
         "import": "./dist/extensions/pi.mjs",
         "require": "./dist/extensions/pi.cjs"
+      },
+      "./hub-api": {
+        "types": "./dist/hubApi.d.mts",
+        "import": "./dist/hubApi.mjs",
+        "require": "./dist/hubApi.cjs"
       },
       "./metrics": {
         "types": "./dist/metrics.d.mts",
@@ -838,7 +844,7 @@
       "extensions": ["./dist/extensions/pi.mjs"]
     },
     "assets": [],
-    "files": ["dist"],
+    "files": ["dist", "src/web", "src/exports/webClient.ts", "src/types/webMetrics.ts", "src/types/issueGrouping.ts"],
     "os": [],
     "cpu": []
   },

--- a/packages/core/doompi/tests/services/compatibilityContext.test.ts
+++ b/packages/core/doompi/tests/services/compatibilityContext.test.ts
@@ -88,6 +88,7 @@ describe('buildCompatibilityContext', () => {
       {
         name: 'shared',
         directory: path.join(root, 'plugins', 'shared'),
+        domain: 'default',
         source: { type: 'local', path: path.join(root, 'plugins', 'shared') },
       },
     ]);

--- a/packages/core/doompi/tests/services/contextCatalog.test.ts
+++ b/packages/core/doompi/tests/services/contextCatalog.test.ts
@@ -1,0 +1,86 @@
+import type { Context } from '@deepseek-ai/cordis';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { describe, expect, it } from 'vitest';
+import { createContextPublisher } from '../../src/services/contextCatalog.ts';
+
+/** Neither the MCP status nor the skill-source service is provided here. */
+const cordis = { get: () => undefined } as unknown as Context;
+
+function harness(tools: { name: string; description?: string }[]) {
+  const appended: { type: string; data: unknown }[] = [];
+  const pi = {
+    getAllTools: () => tools.map((tool) => ({ ...tool, sourceInfo: { path: '/x/pi.mjs', source: 'builtin' } })),
+    getActiveTools: () => tools.map((tool) => tool.name),
+    appendEntry: (type: string, data: unknown) => appended.push({ type, data }),
+  } as unknown as ExtensionAPI;
+  return { pi, appended };
+}
+
+describe('createContextPublisher', () => {
+  it('journals the composition under the entry type the cockpit reads', async () => {
+    const { pi, appended } = harness([{ name: 'read', description: 'Reads a file' }]);
+
+    await createContextPublisher(pi, cordis).publish();
+
+    expect(appended).toHaveLength(1);
+    expect(appended[0]?.type).toBe('doom-context');
+    const projection = appended[0]?.data as { groups: unknown[]; totalTokens: number; estimator: string };
+    expect(projection.estimator).toBe('gpt-tokenizer');
+    expect(projection.groups.length).toBeGreaterThan(0);
+    expect(projection.totalTokens).toBeGreaterThan(0);
+  });
+
+  it('prices a Pi builtin into the core group', async () => {
+    const { pi, appended } = harness([{ name: 'read', description: 'Reads a file' }]);
+
+    await createContextPublisher(pi, cordis).publish();
+
+    const projection = appended[0]?.data as {
+      groups: { kind: string; items: { name: string; tokens: number }[] }[];
+    };
+    const core = projection.groups.find((group) => group.kind === 'core');
+    expect(core?.items.map((item) => item.name)).toContain('read');
+    expect(core?.items.find((item) => item.name === 'read')?.tokens).toBeGreaterThan(0);
+  });
+
+  // Republishing happens whenever a mode flips, which is far more often than
+  // the toolbox actually changes. An identical payload must stay off the journal.
+  it('says nothing when the composition has not changed', async () => {
+    const { pi, appended } = harness([{ name: 'read' }]);
+    const publisher = createContextPublisher(pi, cordis);
+
+    await publisher.publish();
+    await publisher.publish();
+    await publisher.publish();
+
+    expect(appended).toHaveLength(1);
+  });
+
+  it('publishes again once the toolbox really changes', async () => {
+    const tools = [{ name: 'read' }];
+    const appended: { type: string; data: unknown }[] = [];
+    const pi = {
+      getAllTools: () => tools.map((tool) => ({ ...tool, sourceInfo: { path: '/x/pi.mjs', source: 'builtin' } })),
+      getActiveTools: () => tools.map((tool) => tool.name),
+      appendEntry: (type: string, data: unknown) => appended.push({ type, data }),
+    } as unknown as ExtensionAPI;
+    const publisher = createContextPublisher(pi, cordis);
+
+    await publisher.publish();
+    tools.push({ name: 'bash' });
+    await publisher.publish();
+
+    expect(appended).toHaveLength(2);
+    expect(appended[1]?.data).toMatchObject({ revision: 2 });
+  });
+
+  it('goes quiet after disposal', async () => {
+    const { pi, appended } = harness([{ name: 'read' }]);
+    const publisher = createContextPublisher(pi, cordis);
+
+    publisher.dispose();
+    await publisher.publish();
+
+    expect(appended).toHaveLength(0);
+  });
+});

--- a/packages/core/doompi/tests/services/contextProjection.test.ts
+++ b/packages/core/doompi/tests/services/contextProjection.test.ts
@@ -1,0 +1,227 @@
+import type { PackageAttribution } from '@agimon-ai/doompi-config/types';
+import type { SkillEntry } from '@agimon-ai/doompi-skill/catalog';
+import type { ToolSource } from '@agimon-ai/doompi-ui/toolInventory';
+import { describe, expect, it } from 'vitest';
+import { projectContext } from '../../src/services/contextProjection.ts';
+
+// One token per character, so every figure below is checkable by hand.
+const countTokens = (text: string): number => text.length;
+
+const TEAM: PackageAttribution = { kind: 'major', mode: 'copilot', layer: 'team' };
+const DEV: PackageAttribution = { kind: 'domain', mode: 'development' };
+
+function source(overrides: Partial<ToolSource> & Pick<ToolSource, 'key' | 'kind'>): ToolSource {
+  return { label: overrides.key, tools: [], ...overrides };
+}
+
+function tool(name: string, active = true) {
+  return { name, description: 'd', active };
+}
+
+function skill(overrides: Partial<SkillEntry> & Pick<SkillEntry, 'name' | 'owner' | 'group'>): SkillEntry {
+  return {
+    description: 'd',
+    filePath: '/x/SKILL.md',
+    baseDir: '/x',
+    modelInvocable: true,
+    ...overrides,
+  };
+}
+
+function project(input: Partial<Parameters<typeof projectContext>[0]> = {}) {
+  return projectContext({
+    revision: 1,
+    majorMode: 'copilot',
+    minorModes: [],
+    sources: [],
+    skills: [],
+    attribution: {},
+    countTokens,
+    ...input,
+  });
+}
+
+describe('projectContext', () => {
+  it('files a layer package under the major mode that admitted it', () => {
+    const result = project({
+      sources: [
+        source({
+          key: '/x/pi.mjs',
+          kind: 'extension',
+          packageName: '@agimon-ai/doompi-team',
+          tools: [tool('subagent')],
+        }),
+      ],
+      attribution: { '@agimon-ai/doompi-team': TEAM },
+    });
+
+    expect(result.groups.map((group) => [group.kind, group.id])).toEqual([['major', 'copilot']]);
+    expect(result.groups[0]?.items.map((item) => item.name)).toEqual(['subagent']);
+  });
+
+  it('files a domain plugin skill under its domain', () => {
+    const result = project({
+      skills: [skill({ name: 'doompi-review', owner: 'testing', group: 'plugins', promptTokens: 40 })],
+      attribution: { testing: { kind: 'domain', mode: 'testing' } },
+    });
+    const domain = result.groups.find((group) => group.kind === 'domain');
+
+    expect(domain?.id).toBe('testing');
+    expect(domain?.items[0]).toMatchObject({ name: 'doompi-review', itemKind: 'skill', source: 'plugin', tokens: 40 });
+  });
+
+  // The failure this guards is silent: an unattributed tool that vanished would
+  // still be costing context while the total claimed otherwise.
+  it('keeps an unattributed tool visible under core', () => {
+    const result = project({
+      sources: [
+        source({ key: '/y/pi.mjs', kind: 'extension', packageName: '@scope/unknown', tools: [tool('mystery')] }),
+      ],
+    });
+    const core = result.groups.find((group) => group.kind === 'core');
+
+    expect(core?.items.map((item) => item.name)).toEqual(['mystery']);
+    expect(result.totalTokens).toBeGreaterThan(0);
+  });
+
+  it('puts Pi builtins under core without needing attribution', () => {
+    const result = project({ sources: [source({ key: 'core', kind: 'core', tools: [tool('read')] })] });
+
+    expect(result.groups.find((group) => group.kind === 'core')?.items[0]).toMatchObject({
+      name: 'read',
+      source: 'core',
+    });
+  });
+
+  it('orders rows extension, then mcp, then plugin', () => {
+    const result = project({
+      sources: [
+        source({ key: 'mcp:scaffold', kind: 'mcp', label: 'scaffold', tools: [tool('scaffold_list')] }),
+        source({
+          key: '/x/pi.mjs',
+          kind: 'extension',
+          packageName: '@agimon-ai/doompi-team',
+          tools: [tool('subagent')],
+        }),
+      ],
+      skills: [skill({ name: 'writing', owner: 'blog', group: 'plugins' })],
+      attribution: {
+        '@agimon-ai/doompi-team': { kind: 'domain', mode: 'development' },
+        scaffold: { kind: 'domain', mode: 'development' },
+        blog: { kind: 'domain', mode: 'development' },
+      },
+    });
+
+    expect(result.groups.find((group) => group.id === 'development')?.items.map((item) => item.source)).toEqual([
+      'extension',
+      'mcp',
+      'plugin',
+    ]);
+  });
+
+  it('subtotals each group and totals the composition', () => {
+    const result = project({
+      sources: [
+        source({
+          key: '/x/pi.mjs',
+          kind: 'extension',
+          packageName: '@agimon-ai/doompi-team',
+          tools: [tool('subagent')],
+        }),
+      ],
+      skills: [skill({ name: 'review', owner: 'testing', group: 'plugins', promptTokens: 40 })],
+      attribution: { '@agimon-ai/doompi-team': TEAM, testing: { kind: 'domain', mode: 'testing' } },
+    });
+    const major = result.groups.find((group) => group.id === 'copilot');
+
+    expect(major?.tokens).toBe(major?.items.reduce((sum, item) => sum + item.tokens, 0));
+    expect(result.totalTokens).toBe(result.groups.reduce((sum, group) => sum + group.tokens, 0));
+  });
+
+  // An active mode that costs nothing is a useful fact; a missing row reads as
+  // a bug in the surface rather than as an answer.
+  it('shows an active mode that brought nothing', () => {
+    const result = project({ minorModes: [{ id: 'plan', label: 'plan' }] });
+
+    expect(result.groups.map((group) => group.id)).toEqual(['copilot', 'plan']);
+    expect(result.groups.every((group) => group.items.length === 0)).toBe(true);
+    expect(result.totalTokens).toBe(0);
+  });
+
+  it('orders groups major, minor, domain, then core', () => {
+    const result = project({
+      minorModes: [{ id: 'plan', label: 'plan' }],
+      sources: [
+        source({ key: 'core', kind: 'core', tools: [tool('read')] }),
+        source({ key: '/d/pi.mjs', kind: 'extension', packageName: '@scope/dev', tools: [tool('scaffold')] }),
+      ],
+      attribution: { '@scope/dev': DEV },
+    });
+
+    expect(result.groups.map((group) => group.kind)).toEqual(['major', 'minor', 'domain', 'core']);
+  });
+
+  // Pi builds the prompt from its active tools, so a gated one is not sent and
+  // costs nothing yet. Counting it would overstate the bill; hiding it would
+  // lose the answer to "what would turning this on cost me".
+  it('keeps a gated tool out of the total but still prices it', () => {
+    const result = project({
+      sources: [source({ key: 'core', kind: 'core', tools: [tool('write', false)] })],
+    });
+    const core = result.groups.find((group) => group.kind === 'core');
+
+    expect(core?.items[0]).toMatchObject({ name: 'write', active: false });
+    expect(core?.items[0]?.tokens).toBeGreaterThan(0);
+    expect(core?.tokens).toBe(0);
+    expect(core?.inactiveTokens).toBe(core?.items[0]?.tokens);
+    expect(result.totalTokens).toBe(0);
+    expect(result.inactiveTokens).toBeGreaterThan(0);
+  });
+
+  it('separates what is being paid for from what is merely loaded', () => {
+    const result = project({
+      sources: [source({ key: 'core', kind: 'core', tools: [tool('read'), tool('narrate', false)] })],
+    });
+    const core = result.groups.find((group) => group.kind === 'core');
+    const read = core?.items.find((item) => item.name === 'read');
+
+    expect(core?.tokens).toBe(read?.tokens);
+    expect(result.totalTokens).toBe(read?.tokens);
+    expect(result.inactiveTokens).toBe(core?.items.find((item) => item.name === 'narrate')?.tokens);
+  });
+
+  it('stamps the version, revision, and estimator it was built with', () => {
+    expect(project({ revision: 7 })).toMatchObject({ version: 1, revision: 7, estimator: 'gpt-tokenizer' });
+  });
+});
+
+describe('MCP attribution', () => {
+  // `label` is display text like `scaffold · mcp`. Joining or grouping on it
+  // would invent an owner that matches nothing and reads as a stray suffix.
+  it('owns an MCP tool by its server name, not its display label', () => {
+    const result = project({
+      sources: [source({ key: 'mcp:scaffold', kind: 'mcp', label: 'scaffold · mcp', tools: [tool('scaffold_list')] })],
+      attribution: { scaffold: { kind: 'domain', mode: 'development' } },
+    });
+    const domain = result.groups.find((group) => group.id === 'development');
+
+    expect(domain?.items[0]).toMatchObject({ name: 'scaffold_list', source: 'mcp', owner: 'scaffold' });
+  });
+
+  it('keeps an unattributed MCP server out of the extension buckets', () => {
+    const result = project({
+      sources: [source({ key: 'mcp:lonely', kind: 'mcp', label: 'lonely · mcp', tools: [tool('lonely_call')] })],
+    });
+    const core = result.groups.find((group) => group.kind === 'core');
+
+    expect(core?.items[0]).toMatchObject({ source: 'mcp', owner: 'lonely' });
+  });
+
+  it('names Pi itself as the owner of its builtins', () => {
+    const result = project({
+      sources: [source({ key: 'core', kind: 'core', label: 'pi · core', tools: [tool('read')] })],
+    });
+
+    expect(result.groups.find((group) => group.kind === 'core')?.items[0]).toMatchObject({ owner: 'pi' });
+  });
+});

--- a/packages/core/doompi/tests/services/extensionAssembler.test.ts
+++ b/packages/core/doompi/tests/services/extensionAssembler.test.ts
@@ -8,6 +8,7 @@ import {
   assembleExtensions,
   type ExtensionContext,
   type ExtensionLayerResolvers,
+  packageAttribution,
   resolveExtensionComposition,
 } from '../../src/services/extensionAssembler.ts';
 
@@ -626,5 +627,61 @@ describe('standard extension composition', () => {
     expect(child).toEqual(composition.childActivation);
     expect(parent).not.toBe(composition.parentActivation);
     expect(child).not.toBe(composition.childActivation);
+  });
+});
+
+describe('packageAttribution', () => {
+  it('names the layer of the major mode that admitted each package', () => {
+    const config = loadMajorModesConfig(REPOSITORY_ROOT);
+    const composition = resolveExtensionComposition(
+      context(config, { majorMode: 'copilot', layers: resolveLayers(config, 'copilot'), resolvers: resolver() }),
+    );
+
+    expect(packageAttribution(composition)['@agimon-ai/doompi-team']).toEqual({
+      kind: 'major',
+      mode: 'copilot',
+      layer: 'team',
+    });
+    expect(packageAttribution(composition)['@agimon-ai/doompi-task']).toEqual({
+      kind: 'major',
+      mode: 'copilot',
+      layer: 'task',
+    });
+  });
+
+  // The join this feeds is against a package manifest name, and `extensionName`
+  // deliberately strips the scope for display. If attribution ever strips it
+  // too, every scoped package silently loses its mode and the surface that
+  // reads this quietly reports nothing.
+  it('keeps the npm scope, because the join key is the manifest name', () => {
+    const config = loadMajorModesConfig(REPOSITORY_ROOT);
+    const composition = resolveExtensionComposition(
+      context(config, { majorMode: 'copilot', layers: resolveLayers(config, 'copilot'), resolvers: resolver() }),
+    );
+    const attribution = packageAttribution(composition);
+
+    expect(Object.keys(attribution)).toContain('@agimon-ai/doompi-team');
+    expect(Object.keys(attribution)).not.toContain('doompi-team');
+    expect(Object.keys(attribution).every((name) => !name.startsWith('/'))).toBe(true);
+  });
+
+  it('attributes a layer that a mode does not select to nothing', () => {
+    const config = loadMajorModesConfig(REPOSITORY_ROOT);
+    const composition = resolveExtensionComposition(
+      context(config, { majorMode: 'minimal', layers: resolveLayers(config, 'minimal'), resolvers: resolver() }),
+    );
+    const attribution = packageAttribution(composition);
+
+    expect(attribution['@agimon-ai/doompi-team']?.mode).toBe('minimal');
+    expect(attribution['@agimon-ai/vibe-lint']).toBeUndefined();
+  });
+
+  it('reports nothing when the composition names no major mode', () => {
+    const config = loadMajorModesConfig(REPOSITORY_ROOT);
+    const composition = resolveExtensionComposition(
+      context(config, { majorMode: '', layers: [], resolvers: resolver() }),
+    );
+
+    expect(packageAttribution(composition)).toEqual({});
   });
 });

--- a/packages/core/doompi/tests/services/extensionAssembler.test.ts
+++ b/packages/core/doompi/tests/services/extensionAssembler.test.ts
@@ -14,6 +14,8 @@ import {
 
 const CONFIG_PATH = '/repo/.doom/modes.yaml';
 const REPOSITORY_ROOT = path.resolve(__dirname, '..', 'fixtures', 'repository');
+/** The real checkout, whose modes.yaml names layer packages by local path. */
+const WORKSPACE_ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..');
 const CONFIGURED_COPILOT_FEATURE_PACKAGES = [
   '@agimon-ai/doompi-team',
   '@agimon-ai/doompi-user-feedback',
@@ -683,5 +685,34 @@ describe('packageAttribution', () => {
     );
 
     expect(packageAttribution(composition)).toEqual({});
+  });
+});
+
+describe('packageAttribution across config styles', () => {
+  // The checked-in .doom/modes.yaml names layer packages by local path, e.g.
+  // './layers/team/doompi-team', while a published install names the same
+  // package '@agimon-ai/doompi-team'. Tools only ever resolve to the manifest
+  // name, so attribution keyed on the selector alone silently matches nothing
+  // in a source checkout and every tool falls into the core group.
+  it('keys a local-path package by its manifest name', () => {
+    const entry = path.join(WORKSPACE_ROOT, 'layers', 'team', 'doompi-team', 'package.json');
+    expect(fs.existsSync(entry), entry).toBe(true);
+    const selector = './layers/team/doompi-team';
+    const config = modes({ team: layer({ packages: [{ name: selector }] }) }, ['team']);
+    const composition = resolveExtensionComposition(
+      context(config, {
+        majorMode: 'test',
+        layers: ['team'],
+        resolvers: resolver({
+          localPackageEntries: () => [path.join(path.dirname(entry), 'src', 'index.ts')],
+          localPackageName: () => selector,
+        }),
+      }),
+    );
+    const attribution = packageAttribution(composition);
+
+    expect(attribution['@agimon-ai/doompi-team']).toEqual({ kind: 'major', mode: 'test', layer: 'team' });
+    // The selector stays as an alias so a published config still resolves.
+    expect(attribution[selector]).toEqual({ kind: 'major', mode: 'test', layer: 'team' });
   });
 });

--- a/packages/core/doompi/tests/services/piExtensionAlias.test.ts
+++ b/packages/core/doompi/tests/services/piExtensionAlias.test.ts
@@ -10,7 +10,11 @@ import {
   piExtensionAliasPath,
   writePiExtensionAlias,
 } from '../../src/adapters/piExtensionAlias';
-import { PI_DISPATCHER_VERSION } from '../../src/adapters/piExtensionDispatcher.ts';
+import {
+  PI_DISPATCHER_VERSION,
+  piExtensionDispatcherIsUpgradeable,
+  piExtensionDispatcherVersion,
+} from '../../src/adapters/piExtensionDispatcher.ts';
 import {
   publishSyncRegistration,
   SYNC_REGISTRATION_VERSION,
@@ -184,6 +188,40 @@ describe('Pi extension dispatcher package', () => {
     };
     expect(manifest.doompiDispatcher).toBe(PI_DISPATCHER_VERSION);
     expect(piExtensionAliasIsCurrent(root)).toBe(true);
+  });
+
+  it('reports a stale managed dispatcher as not current but upgradeable', () => {
+    const root = temporaryRoot();
+    const dispatcherPath = piExtensionAliasPath(root);
+    fs.mkdirSync(dispatcherPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(dispatcherPath, 'package.json'),
+      `${JSON.stringify({ name: '@agimon-ai/doompi', doompiDispatcher: 1 })}\n`,
+    );
+    fs.writeFileSync(path.join(dispatcherPath, 'dispatcher.mjs'), 'stale\n');
+
+    expect(piExtensionAliasIsCurrent(root)).toBe(false);
+    expect(piExtensionDispatcherIsUpgradeable(root)).toBe(true);
+    expect(piExtensionDispatcherVersion(root)).toBe(1);
+  });
+
+  it('reports a current dispatcher as not upgradeable', () => {
+    const root = temporaryRoot();
+    const packageRoot = fakePackage(path.join(root, 'install', 'doompi'));
+    writePiExtensionAlias(root, packageRoot);
+
+    expect(piExtensionAliasIsCurrent(root)).toBe(true);
+    expect(piExtensionDispatcherIsUpgradeable(root)).toBe(false);
+    expect(piExtensionDispatcherVersion(root)).toBe(PI_DISPATCHER_VERSION);
+  });
+
+  it('reports an unmanaged dispatcher path as not upgradeable', () => {
+    const root = temporaryRoot();
+    const dispatcherPath = piExtensionAliasPath(root);
+    fs.mkdirSync(dispatcherPath, { recursive: true });
+
+    expect(piExtensionDispatcherIsUpgradeable(root)).toBe(false);
+    expect(piExtensionDispatcherVersion(root)).toBeUndefined();
   });
   it('does not replace an unmanaged path', () => {
     const root = temporaryRoot();

--- a/packages/default/doompi-edit/src/web/EditToolMessage.tsx
+++ b/packages/default/doompi-edit/src/web/EditToolMessage.tsx
@@ -5,6 +5,7 @@ import {
   MessageItemHeader,
   MessageItemStatus,
   SyntaxLine,
+  ToolPathLink,
   toolTone,
   useSyntaxLines,
 } from '@agimon-ai/doompi-web-components';
@@ -55,9 +56,20 @@ function DiffRows({ rows, gutter, path }: { rows: readonly DiffRow[]; gutter: nu
  * edit whose details never arrived shows nothing, and a failed one shows the
  * tool's message in red.
  */
-export function EditToolMessage({ args, result, output, running, isError }: ToolMessageRenderProps) {
+export function EditToolMessage({
+  args,
+  result,
+  output,
+  running,
+  isError,
+  fileTabFor,
+  openTransientTab,
+}: ToolMessageRenderProps) {
   const call = editCallView(args);
   const view = result === null || isError ? undefined : editResultView(result);
+  // The file this edit lands in, opened from the header rather than found
+  // again in a file list; plain text when nothing installed can show it.
+  const tab = fileTabFor(call.path);
   return (
     <MessageItem
       tone={toolTone({ running, isError })}
@@ -67,7 +79,7 @@ export function EditToolMessage({ args, result, output, running, isError }: Tool
         <>
           <MessageItemHeader title="edit">
             <span data-testid="tool-call-edit" className="flex min-w-0 flex-1 items-center gap-2">
-              <span className="truncate text-doom-text">{call.path}</span>
+              <ToolPathLink path={call.path} {...(tab === undefined ? {} : { onOpen: () => openTransientTab(tab) })} />
               <span className="shrink-0 text-doom-faint">· {call.ranges}</span>
             </span>
           </MessageItemHeader>

--- a/packages/default/doompi-edit/src/web/EditToolMessage.tsx
+++ b/packages/default/doompi-edit/src/web/EditToolMessage.tsx
@@ -4,7 +4,9 @@ import {
   MessageItemBody,
   MessageItemHeader,
   MessageItemStatus,
+  SyntaxLine,
   toolTone,
+  useSyntaxLines,
 } from '@agimon-ai/doompi-web-components';
 import type { ToolMessageRenderProps } from '@agimon-ai/doompi-web-contracts';
 import { type DiffRow, editCallView, editResultView, resultTextLines } from './editToolView.ts';
@@ -19,6 +21,33 @@ const ROW_TONE: Readonly<Record<DiffRow['marker'], string>> = {
   '-': 'bg-doom-tint-red text-doom-red',
   ' ': 'text-doom-dim',
 };
+
+/**
+ * The banded rows, and the grammar over them.
+ *
+ * Its own component because the colours come from a hook, and the body that
+ * renders these rows is chosen inside a render prop. The rows are parsed as
+ * one document: a diff is not a file, so a replaced line is seen twice and a
+ * split string can colour oddly, which costs a token here and there and never
+ * costs the reader the text. The `+` and `-` wash stays underneath, so what
+ * changed is still legible when the grammar has coloured the foreground.
+ */
+function DiffRows({ rows, gutter, path }: { rows: readonly DiffRow[]; gutter: number; path: string }) {
+  const spans = useSyntaxLines(rows.map((row) => row.content).join('\n'), { path });
+  return (
+    <>
+      {rows.map((row, index) => (
+        <span key={`${String(index)}-${row.lineNumber}`} className={`flex gap-2 ${ROW_TONE[row.marker]}`}>
+          <span className="shrink-0 text-right text-doom-faint" style={{ width: `${String(gutter)}ch` }}>
+            {row.lineNumber}
+          </span>
+          <span className="w-2 shrink-0">{row.marker === ' ' ? '' : row.marker}</span>
+          <SyntaxLine spans={spans?.[index]} text={row.content} className="min-w-0 whitespace-pre-wrap break-words" />
+        </span>
+      ))}
+    </>
+  );
+}
 
 /**
  * The edit tool's timeline item: `path · N ranges` in the header; the display
@@ -62,18 +91,7 @@ export function EditToolMessage({ args, result, output, running, isError }: Tool
               const { shown, hidden } = collapseLines(view.rows, COLLAPSED_ROWS, expanded);
               return (
                 <MessageItemBody data-testid="tool-result-edit" className="flex flex-col font-mono">
-                  {shown.map((row, index) => (
-                    <span key={`${String(index)}-${row.lineNumber}`} className={`flex gap-2 ${ROW_TONE[row.marker]}`}>
-                      <span
-                        className="shrink-0 text-right text-doom-faint"
-                        style={{ width: `${String(view.gutter)}ch` }}
-                      >
-                        {row.lineNumber}
-                      </span>
-                      <span className="w-2 shrink-0">{row.marker === ' ' ? '' : row.marker}</span>
-                      <span className="min-w-0 whitespace-pre-wrap break-words">{row.content}</span>
-                    </span>
-                  ))}
+                  <DiffRows rows={shown} gutter={view.gutter} path={call.path} />
                   {hidden > 0 ? (
                     <MessageItemStatus expands className="pt-1">
                       {hidden} more rows

--- a/packages/default/doompi-file-edit/src/adapters/TimelineStore/TimelineStore.ts
+++ b/packages/default/doompi-file-edit/src/adapters/TimelineStore/TimelineStore.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs/promises';
+import fs, { type FileHandle } from 'node:fs/promises';
 import {
   type AnyTimelineEvent,
   confirmedChanges,
@@ -9,8 +9,16 @@ import {
 import type { FileEditEntry, FileEditVersion, TimelineEvent } from '../../types/domain';
 import type { ITimelineStore } from '../../types/timelineStore';
 
-const LOCK_RETRY_MS = 10;
-const LOCK_RETRIES = 100;
+const LOCK_RETRY_MS = 25;
+const LOCK_RETRIES = 400;
+/**
+ * How long a lock file may sit untouched before a waiter treats it as abandoned.
+ *
+ * An append writes one line, so a holder that has been there for half a minute
+ * is a process that died without unlinking. Without this, that one file would
+ * block every later append to the same timeline permanently.
+ */
+const LOCK_STALE_MS = 30_000;
 
 function hasCode(error: unknown, code: string): boolean {
   return error instanceof Error && 'code' in error && error.code === code;
@@ -65,24 +73,48 @@ export class TimelineStore implements ITimelineStore {
 
   private async withLock<T>(operation: () => Promise<T>): Promise<T> {
     const lockPath = `${this.requirePath()}.lock`;
+    const lock = await this.acquire(lockPath);
+    try {
+      return await operation();
+    } finally {
+      await lock.close();
+      await this.release(lockPath);
+    }
+  }
+
+  /** Waits for the lock file, breaking one an earlier process left behind. */
+  private async acquire(lockPath: string): Promise<FileHandle> {
     for (let attempt = 0; attempt < LOCK_RETRIES; attempt += 1) {
       try {
-        const lock = await fs.open(lockPath, 'wx');
-        try {
-          return await operation();
-        } finally {
-          await lock.close();
-          try {
-            await fs.unlink(lockPath);
-          } catch (error) {
-            if (!hasCode(error, 'ENOENT')) console.warn(`Could not remove timeline lock: ${String(error)}`);
-          }
-        }
+        return await fs.open(lockPath, 'wx');
       } catch (error) {
         if (!hasCode(error, 'EEXIST')) throw error;
+        if (await this.breakStale(lockPath)) continue;
         await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_MS));
       }
     }
     throw new Error(`Timed out acquiring timeline lock ${lockPath}`);
+  }
+
+  /** Whether the lock is now free to take, having removed it when its holder is gone. */
+  private async breakStale(lockPath: string): Promise<boolean> {
+    try {
+      const stats = await fs.stat(lockPath);
+      if (Date.now() - stats.mtimeMs < LOCK_STALE_MS) return false;
+      await fs.unlink(lockPath);
+      return true;
+    } catch (error) {
+      // Already gone, or another waiter broke it first: either way, try again.
+      if (hasCode(error, 'ENOENT')) return true;
+      throw error;
+    }
+  }
+
+  private async release(lockPath: string): Promise<void> {
+    try {
+      await fs.unlink(lockPath);
+    } catch (error) {
+      if (!hasCode(error, 'ENOENT')) console.warn(`Could not remove timeline lock: ${String(error)}`);
+    }
   }
 }

--- a/packages/default/doompi-file-edit/src/adapters/fileEditsApi.ts
+++ b/packages/default/doompi-file-edit/src/adapters/fileEditsApi.ts
@@ -10,6 +10,7 @@ import {
   API_BASE_PATH,
   type FileEditsCumulativeView,
   type FileEditsDetailView,
+  type FileEditsPreviewView,
   type FileEditsSaveRequest,
   type FileEditsSaveView,
   type FileEditsVersionView,
@@ -31,10 +32,12 @@ import { TimelineStore } from './TimelineStore/TimelineStore.ts';
  * makes the session id and working directory available without the page
  * supplying either: a page names a file, never a session's private paths.
  *
- * The detail route answers everything a reader needs to open a file, because
- * splitting it would make the page stitch three responses together for one
- * click. The save route is the only mutation, and it refuses unless the reader
- * proves they were looking at the content that is still on disk.
+ * The detail route answers everything a reader needs to open a changed file,
+ * because splitting it would make the page stitch three responses together for
+ * one click. The save route is the only mutation, and it refuses unless the
+ * reader proves they were looking at the content that is still on disk. The
+ * preview route is the read-only way in to a file the session never changed,
+ * bounded by the working directory instead of by the timeline.
  */
 
 /** Past this, the working view reports the file rather than carrying it. */
@@ -89,6 +92,27 @@ async function readWorking(filePath: string): Promise<FileEditsWorkingView> {
   }
   const content = raw.toString('utf8');
   return { content, hash: hashOf(content), unavailable: false };
+}
+
+function isInside(root: string, candidate: string): boolean {
+  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+/**
+ * The same containment check after symlinks are followed. A path that does not
+ * exist yet resolves to nothing, and there is nothing to hand out, so it
+ * passes and the read below reports it missing.
+ */
+async function isRealPathInside(root: string, candidate: string): Promise<boolean> {
+  let realRoot: string;
+  let real: string;
+  try {
+    realRoot = await fs.realpath(root);
+    real = await fs.realpath(candidate);
+  } catch {
+    return true;
+  }
+  return isInside(realRoot, real);
 }
 
 /**
@@ -198,6 +222,36 @@ export function createFileEditsApi(options: FileEditsApiOptions = {}): Hono {
       versions: await Promise.all(versions.map((version) => toVersionView(version, snapshots))),
       cumulative: await toCumulativeView(versions, working, snapshots),
       working,
+    };
+    return context.json(body);
+  });
+
+  /**
+   * The file a request names, read only, for a file the timeline knows nothing
+   * about: a path the agent read but never changed is still a path the reader
+   * clicked, and refusing it would leave the link dead.
+   *
+   * The working directory is the boundary here, since the timeline is not.
+   * Containment is checked lexically and again on the real path, so a symlink
+   * inside the tree cannot hand out something beyond it, and a host that gave
+   * these routes no working directory has no boundary to enforce and so serves
+   * nothing.
+   */
+  app.get('/preview', async (context) => {
+    const requested = context.req.query(PATH_QUERY_PARAM);
+    if (requested === undefined || requested === '' || requested.includes('\0')) {
+      return context.json({ error: 'A preview names a path.' }, 400);
+    }
+    if (cwd === '') return context.json({ error: 'This session has no working directory to read from.' }, 403);
+    const root = path.resolve(cwd);
+    const filePath = path.resolve(root, requested);
+    if (!isInside(root, filePath) || !(await isRealPathInside(root, filePath))) {
+      return context.json({ error: 'The path leaves the session directory.' }, 403);
+    }
+    const body: FileEditsPreviewView = {
+      path: filePath,
+      relPath: path.relative(root, filePath),
+      working: await readWorking(filePath),
     };
     return context.json(body);
   });

--- a/packages/default/doompi-file-edit/src/types/fileEditsApi.ts
+++ b/packages/default/doompi-file-edit/src/types/fileEditsApi.ts
@@ -7,9 +7,10 @@ import type { FileEditOrigin, FileEditTool } from './domain.ts';
  * bundle may read: the cockpit plugin builds its URLs from these and the
  * routes answer them, so neither half can drift from the other.
  *
- * Two routes only. Opening a file wants its whole history at once, so `detail`
- * answers in one round trip rather than making the page stitch three reads
- * together; `content` takes the manual save back.
+ * Three routes. Opening a changed file wants its whole history at once, so
+ * `detail` answers in one round trip rather than making the page stitch three
+ * reads together; `content` takes the manual save back; `preview` reads a file
+ * the session never changed, which has no history to answer with.
  */
 
 /** Where a host mounts this package's API; the segment after /api/plugin/. */
@@ -31,6 +32,11 @@ export function contentPath(): string {
   return '/content';
 }
 
+/** One unchanged file, read only, relative to the API's own mount. */
+export function previewPath(): string {
+  return '/preview';
+}
+
 /**
  * The absolute URL a page fetches, through the hub. The whole query is built
  * here, session parameter included, so a caller never appends a second '?'.
@@ -44,6 +50,12 @@ export function detailUrl(sessionId: string, filePath: string): string {
 export function contentUrl(sessionId: string): string {
   const search = new URLSearchParams({ [SESSION_QUERY_PARAM]: sessionId });
   return `/api/plugin/${API_BASE_PATH}${contentPath()}?${search.toString()}`;
+}
+
+/** The absolute URL a page reads an unchanged file through. */
+export function previewUrl(sessionId: string, filePath: string): string {
+  const search = new URLSearchParams({ [SESSION_QUERY_PARAM]: sessionId, [PATH_QUERY_PARAM]: filePath });
+  return `/api/plugin/${API_BASE_PATH}${previewPath()}?${search.toString()}`;
 }
 
 /** The absolute URL a page deletes a file through; the path rides the query, not a body. */
@@ -115,6 +127,17 @@ export interface FileEditsDetailView {
   relPath: string;
   versions: FileEditsVersionView[];
   cumulative: FileEditsCumulativeView;
+  working: FileEditsWorkingView;
+}
+
+/**
+ * What the preview route answers with: the file as it stands, and nothing
+ * about how it got there. A file this session never touched has no history and
+ * no baseline, so there is no diff to send and no save to take back.
+ */
+export interface FileEditsPreviewView {
+  path: string;
+  relPath: string;
   working: FileEditsWorkingView;
 }
 

--- a/packages/default/doompi-file-edit/src/web/FilePreviewPanel.tsx
+++ b/packages/default/doompi-file-edit/src/web/FilePreviewPanel.tsx
@@ -1,0 +1,150 @@
+import { Breadcrumb, Button, CodeEditor, Markdown, MediaPreview } from '@agimon-ai/doompi-web-components';
+import type { TransientTab, WebPluginSlotProps } from '@agimon-ai/doompi-web-contracts';
+import { useEffect, useState } from 'react';
+import type { FileEditsPreviewView } from '../types/fileEditsApi.ts';
+import { fetchFilePreview, sessionFileUrl } from './filesApi.ts';
+import { fileTabId, previewModeOf } from './fileView.ts';
+
+/**
+ * A file the session never changed, opened read-only.
+ *
+ * The tab a changed file opens is built around its history: a diff, a version
+ * list, an editor, a delete. None of that exists for a file the session only
+ * read, and offering an edit view over a file this package holds no baseline
+ * for would put a save behind a reader who cannot see what they are about to
+ * overwrite. So this is one view, the file as it stands, and nothing else.
+ *
+ * Its content comes from the preview route, which is bounded by the session's
+ * working directory rather than by the timeline.
+ */
+
+interface FilePreviewPanelProps extends WebPluginSlotProps {
+  filePath: string;
+}
+
+/** What one fetch settled on, tagged with the file it was about. */
+interface Loaded {
+  path: string;
+  preview?: FileEditsPreviewView;
+  error?: string;
+}
+
+export function FilePreviewPanel({ filePath, sessionId, closeTransientTab }: FilePreviewPanelProps) {
+  // The answer carries the path it answered for, so switching files is a state
+  // that does not match rather than a reset the effect has to perform.
+  const [loaded, setLoaded] = useState<Loaded | undefined>(undefined);
+
+  useEffect(() => {
+    if (sessionId === null) return;
+    let cancelled = false;
+    void fetchFilePreview(sessionId, filePath).then((result) => {
+      if (cancelled) return;
+      setLoaded(result.ok ? { path: filePath, preview: result.preview } : { path: filePath, error: result.error });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, filePath]);
+
+  const current = loaded?.path === filePath ? loaded : undefined;
+  const preview = current?.preview;
+  const error = current?.error;
+  // Before the answer arrives the path is all there is to name the file by,
+  // and the route's own relative path replaces it once it does.
+  const relPath = preview?.relPath ?? filePath;
+  const working = preview?.working;
+  const content = working?.content ?? '';
+  const previewMode = previewModeOf(relPath, working?.unavailable === true);
+  const mediaSrc = sessionId === null ? '' : sessionFileUrl(sessionId, relPath);
+
+  return (
+    <div data-testid="files-preview-panel" className="flex min-h-0 flex-1 flex-col">
+      <header className="flex shrink-0 items-center gap-2 border-b border-doom-border px-4 py-2">
+        <Breadcrumb path={relPath} data-testid="files-preview-breadcrumb" className="min-w-0 flex-1" />
+        <span className="shrink-0 text-[9px] text-doom-faint">unchanged</span>
+        <Button
+          variant="ghost"
+          size="xs"
+          data-testid="files-preview-close"
+          onClick={() => closeTransientTab(filePreviewTabId(filePath))}
+          className="shrink-0 text-[9px]"
+        >
+          close
+        </Button>
+      </header>
+
+      {error === undefined ? null : (
+        <p data-testid="files-preview-error" className="px-4 py-3 text-[11px] text-doom-red">
+          {error}
+        </p>
+      )}
+      {preview === undefined && error === undefined ? (
+        <p data-testid="files-preview-loading" className="px-4 py-3 text-[11px] text-doom-faint">
+          reading this file…
+        </p>
+      ) : null}
+
+      {preview === undefined ? null : (
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <div
+            data-testid="files-preview"
+            data-mode={previewMode}
+            className="flex h-full flex-col gap-2 p-4 text-[12px] text-doom-text"
+          >
+            {previewMode === 'unavailable' ? (
+              <p data-testid="files-preview-unavailable" className="text-[11px] text-doom-faint">
+                {working?.reason ?? 'this file cannot be shown'}
+              </p>
+            ) : null}
+            {previewMode === 'media' || previewMode === 'unavailable' ? (
+              <MediaPreview src={mediaSrc} path={relPath} data-testid="files-preview-media" />
+            ) : previewMode === 'markdown' ? (
+              <Markdown text={content} />
+            ) : previewMode === 'html' ? (
+              <iframe
+                data-testid="files-preview-html"
+                title={relPath}
+                sandbox=""
+                srcDoc={content}
+                className="h-[36rem] w-full rounded border border-doom-border bg-doom-deep"
+              />
+            ) : previewMode === 'code' ? (
+              <CodeEditor
+                data-testid="files-preview-code"
+                value={content}
+                path={relPath}
+                readOnly
+                className="min-h-[24rem] flex-1 rounded border border-doom-border"
+              />
+            ) : (
+              <pre
+                data-testid="files-preview-text"
+                className="whitespace-pre-wrap break-words font-mono text-[11px] leading-[1.5] text-doom-text"
+              >
+                {content}
+              </pre>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The id of the read-only tab, kept apart from the changed-file tab's own id:
+ * the same file can be read now and changed later, and the two tabs are not
+ * the same view of it.
+ */
+export function filePreviewTabId(filePath: string): string {
+  return `${fileTabId(filePath)}-preview`;
+}
+
+/** The transient tab an unchanged file opens in; the same file reopens rather than duplicating. */
+export function filePreviewTab(filePath: string): TransientTab {
+  return {
+    id: filePreviewTabId(filePath),
+    label: filePath.split('/').at(-1) ?? filePath,
+    panel: (props) => <FilePreviewPanel {...props} filePath={filePath} />,
+  };
+}

--- a/packages/default/doompi-file-edit/src/web/fileLinks.ts
+++ b/packages/default/doompi-file-edit/src/web/fileLinks.ts
@@ -1,6 +1,7 @@
 import type { FileLinkSource, TransientTab } from '@agimon-ai/doompi-web-contracts';
 import type { FilesItemView } from '../types/webFiles.ts';
 import { fileTab } from './FilePanel.tsx';
+import { filePreviewTab } from './FilePreviewPanel.tsx';
 import { files } from './filesStore.ts';
 
 /**
@@ -41,5 +42,17 @@ export const fileLinks: FileLinkSource = {
   resolve: (sessionId, path): TransientTab | undefined => {
     const item = match(sessionId, path);
     return item === undefined ? undefined : fileTab(item.path, item.relPath);
+  },
+  // A tool argument is a path on purpose, so nothing here has to be guessed.
+  // A file the session changed opens on its history; one it only read opens
+  // read-only, and the route behind that tab is what decides whether a path
+  // outside the working directory may be shown at all.
+  openPath: (sessionId, path): TransientTab | undefined => {
+    const item = match(sessionId, path);
+    if (item !== undefined) return fileTab(item.path, item.relPath);
+    // A call with no path argument at all hands this an empty string, and
+    // there is no file to open behind it.
+    const candidate = path.trim();
+    return candidate === '' ? undefined : filePreviewTab(candidate);
   },
 };

--- a/packages/default/doompi-file-edit/src/web/filesApi.ts
+++ b/packages/default/doompi-file-edit/src/web/filesApi.ts
@@ -3,7 +3,9 @@ import {
   deleteUrl,
   detailUrl,
   type FileEditsDetailView,
+  type FileEditsPreviewView,
   type FileEditsSaveView,
+  previewUrl,
 } from '../types/fileEditsApi.ts';
 import { sealedTransport } from '@agimon-ai/doompi-web-security/browser';
 
@@ -69,6 +71,22 @@ export async function fetchFileDetail(sessionId: string, filePath: string): Prom
   if (!response.ok) return { ok: false, error: errorOf(body, `The session answered ${response.status}.`) };
   if (!isRecord(body)) return { ok: false, error: 'The session answered with no detail.' };
   return { ok: true, detail: body as unknown as FileEditsDetailView };
+}
+
+export type FetchPreviewResult = { ok: true; preview: FileEditsPreviewView } | { ok: false; error: string };
+
+/** One file the session never changed, read only; the route bounds it to the working directory. */
+export async function fetchFilePreview(sessionId: string, filePath: string): Promise<FetchPreviewResult> {
+  let response: Response;
+  try {
+    response = await sealedTransport.fetch(previewUrl(sessionId, filePath));
+  } catch {
+    return { ok: false, error: UNREACHABLE };
+  }
+  const body = await readBody(response);
+  if (!response.ok) return { ok: false, error: errorOf(body, `The session answered ${response.status}.`) };
+  if (!isRecord(body)) return { ok: false, error: 'The session answered with no file.' };
+  return { ok: true, preview: body as unknown as FileEditsPreviewView };
 }
 
 export type SaveResult =

--- a/packages/default/doompi-file-edit/tests/timeline.test.ts
+++ b/packages/default/doompi-file-edit/tests/timeline.test.ts
@@ -185,6 +185,34 @@ describe('TimelineStore', () => {
     expect(await store.list()).toHaveLength(12);
   });
 
+  it('breaks a lock an earlier process died holding, instead of failing forever', async () => {
+    // A killed writer never unlinks its lock. Before this, the orphan file made
+    // every later append to that timeline throw for the life of the machine.
+    const lockPath = path.join(directory, 'timeline.jsonl.lock');
+    fs.writeFileSync(lockPath, '');
+    const stale = new Date(Date.now() - 60_000);
+    fs.utimesSync(lockPath, stale, stale);
+    await store.append(event({ path: '/a.ts', tool: 'edit', at: 10 }));
+    expect((await store.list()).map((entry) => entry.path)).toEqual(['/a.ts']);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('waits on a lock a live writer still holds, and appends once it is released', async () => {
+    const lockPath = path.join(directory, 'timeline.jsonl.lock');
+    fs.writeFileSync(lockPath, '');
+    let done = false;
+    const append = store.append(event({ path: '/a.ts', tool: 'edit', at: 10 })).then(() => {
+      done = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    // The lock was written just now, so it is a holder that may still be working.
+    expect(done).toBe(false);
+    expect(fs.existsSync(lockPath)).toBe(true);
+    fs.unlinkSync(lockPath);
+    await append;
+    expect((await store.list()).map((entry) => entry.path)).toEqual(['/a.ts']);
+  });
+
   it('refuses to work before it has been told which file it owns', async () => {
     const uninitialized = new TimelineStore();
     await expect(uninitialized.list()).rejects.toThrow('not initialized');

--- a/packages/default/doompi-file-edit/tests/unit/fileEditsApi.test.ts
+++ b/packages/default/doompi-file-edit/tests/unit/fileEditsApi.test.ts
@@ -5,8 +5,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { NodeSnapshotStoreAdapter } from '../../src/adapters/node/snapshotStore.ts';
 import { TimelineStore } from '../../src/adapters/TimelineStore/TimelineStore.ts';
 import { createFileEditsApi } from '../../src/adapters/fileEditsApi.ts';
-import type { FileEditsDetailView, FileEditsErrorView } from '../../src/types/fileEditsApi.ts';
-import { contentUrl, deleteUrl, detailUrl } from '../../src/types/fileEditsApi.ts';
+import type { FileEditsDetailView, FileEditsErrorView, FileEditsPreviewView } from '../../src/types/fileEditsApi.ts';
+import { contentUrl, deleteUrl, detailUrl, previewUrl } from '../../src/types/fileEditsApi.ts';
 
 let cwd: string;
 let timeline: TimelineStore;
@@ -109,6 +109,49 @@ describe('the file-edits session API', () => {
   it('refuses a path that climbs out of the session, because the timeline never held it', async () => {
     const response = await app.fetch(new Request(mounted(detailUrl('s1', '../../etc/passwd'))));
     expect(response.status).toBe(404);
+  });
+
+  it('previews a file the session never changed, read only', async () => {
+    const filePath = path.join(cwd, 'untouched.ts');
+    fs.writeFileSync(filePath, 'export const x = 1;\n');
+    const response = await app.fetch(new Request(mounted(previewUrl('s1', filePath))));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as FileEditsPreviewView;
+    expect(body.relPath).toBe('untouched.ts');
+    expect(body.working.content).toBe('export const x = 1;\n');
+    expect(body.working.unavailable).toBe(false);
+  });
+
+  it('refuses a preview that climbs out of the working directory', async () => {
+    const escaping = await app.fetch(new Request(mounted(previewUrl('s1', path.join(cwd, '..', 'passwd')))));
+    expect(escaping.status).toBe(403);
+    const relative = await app.fetch(new Request(mounted(previewUrl('s1', '../../etc/passwd'))));
+    expect(relative.status).toBe(403);
+  });
+
+  it('refuses a preview through a symlink that points outside', async () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'doom-file-edit-outside-'));
+    try {
+      fs.writeFileSync(path.join(outside, 'secret.env'), 'TOKEN=1');
+      fs.symlinkSync(path.join(outside, 'secret.env'), path.join(cwd, 'linked.env'));
+      const response = await app.fetch(new Request(mounted(previewUrl('s1', path.join(cwd, 'linked.env')))));
+      expect(response.status).toBe(403);
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a preview of a file that is not there rather than refusing', async () => {
+    const response = await app.fetch(new Request(mounted(previewUrl('s1', path.join(cwd, 'absent.ts')))));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as FileEditsPreviewView;
+    expect(body.working.unavailable).toBe(true);
+  });
+
+  it('serves no preview at all when the host gave it no working directory', async () => {
+    const unbounded = createFileEditsApi({ sessionId: 's1', timeline, snapshots });
+    const response = await unbounded.fetch(new Request(mounted(previewUrl('s1', '/etc/passwd'))));
+    expect(response.status).toBe(403);
   });
 
   it('writes a manual save and answers the new hash', async () => {

--- a/packages/default/doompi-file-edit/tests/web/fileLinks.test.ts
+++ b/packages/default/doompi-file-edit/tests/web/fileLinks.test.ts
@@ -53,6 +53,23 @@ describe('fileLinks', () => {
     expect(fileLinks.resolve(null, 'src/app.ts')).toBeUndefined();
   });
 
+  it('opens a changed file on its history when the caller is sure it is a path', () => {
+    const tab = fileLinks.openPath?.(SESSION, 'src/app.ts');
+    expect(tab?.id).toBe(fileLinks.resolve(SESSION, 'src/app.ts')?.id);
+  });
+
+  it('opens a file the session never changed read-only, which resolve refuses', () => {
+    expect(fileLinks.resolve(SESSION, 'src/other.ts')).toBeUndefined();
+    const tab = fileLinks.openPath?.(SESSION, '/repo/src/other.ts');
+    expect(tab?.label).toBe('other.ts');
+    expect(tab?.id.endsWith('-preview')).toBe(true);
+  });
+
+  it('has nothing to open for a call with no path', () => {
+    expect(fileLinks.openPath?.(SESSION, '')).toBeUndefined();
+    expect(fileLinks.openPath?.(SESSION, '   ')).toBeUndefined();
+  });
+
   it('fingerprints the paths, so a swap at equal length still re-resolves', () => {
     const before = fileLinks.fingerprint(SESSION);
     filesChannel.apply(SESSION, filesChannel.parse({ items: [item('src/app.ts'), item('docs/CHANGES.md')] })!);

--- a/packages/default/doompi-log/package.json
+++ b/packages/default/doompi-log/package.json
@@ -27,7 +27,10 @@
     "directory": "packages/default/doompi-log"
   },
   "files": [
-    "dist"
+    "dist",
+    "src/web",
+    "src/exports/webClient.ts",
+    "src/types/webMetrics.ts"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -68,13 +71,16 @@
   "scripts": {
     "build": "tsdown",
     "test": "vitest --run",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p src/web/tsconfig.json",
     "lint": "oxlint . && oxfmt . --check",
     "fixcode": "oxlint . --fix && oxfmt ."
   },
   "dependencies": {
     "@agimon-ai/doompi-extension-contracts": "workspace:*",
     "@agimon-ai/doompi-telemetry": "workspace:*",
+    "@agimon-ai/doompi-web-components": "workspace:*",
+    "@agimon-ai/doompi-web-contracts": "workspace:*",
+    "@agimon-ai/doompi-web-security": "workspace:*",
     "@agimon-ai/log-sink-mcp": "0.29.19",
     "@deepseek-ai/cordis": "4.0.1"
   },
@@ -82,8 +88,12 @@
     "@agimon-ai/doompi-ui": "workspace:*",
     "@earendil-works/pi-coding-agent": "0.84.4",
     "@earendil-works/pi-tui": "0.84.4",
+    "@tanstack/react-store": "0.11.1",
+    "@tanstack/store": "0.11.1",
     "@types/node": "26.4.0",
+    "@types/react": "19.2.18",
     "@vitest/coverage-v8": "4.1.11",
+    "react": "19.2.8",
     "tsdown": "0.22.14",
     "typescript": "7.0.2",
     "vitest": "4.1.11"
@@ -102,6 +112,10 @@
   },
   "engines": {
     "node": ">=22.19.0"
+  },
+  "doompiWeb": {
+    "pluginId": "log",
+    "client": "./src/exports/webClient.ts"
   },
   "pi": {
     "extensions": [

--- a/packages/default/doompi-log/package.json
+++ b/packages/default/doompi-log/package.json
@@ -30,7 +30,8 @@
     "dist",
     "src/web",
     "src/exports/webClient.ts",
-    "src/types/webMetrics.ts"
+    "src/types/webMetrics.ts",
+    "src/types/issueGrouping.ts"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -62,6 +63,11 @@
       "import": "./dist/tui/metricsOverlay.mjs",
       "require": "./dist/tui/metricsOverlay.cjs"
     },
+    "./hub-api": {
+      "types": "./dist/hubApi.d.mts",
+      "import": "./dist/hubApi.mjs",
+      "require": "./dist/hubApi.cjs"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -82,7 +88,8 @@
     "@agimon-ai/doompi-web-contracts": "workspace:*",
     "@agimon-ai/doompi-web-security": "workspace:*",
     "@agimon-ai/log-sink-mcp": "0.29.19",
-    "@deepseek-ai/cordis": "4.0.1"
+    "@deepseek-ai/cordis": "4.0.1",
+    "hono": "4.13.5"
   },
   "devDependencies": {
     "@agimon-ai/doompi-ui": "workspace:*",
@@ -112,6 +119,13 @@
   },
   "engines": {
     "node": ">=22.19.0"
+  },
+  "doompiApi": {
+    "basePath": "log",
+    "hub": {
+      "entry": "./src/exports/hubApi.ts",
+      "dist": "./dist/hubApi.mjs"
+    }
   },
   "doompiWeb": {
     "pluginId": "log",

--- a/packages/default/doompi-log/src/adapters/hubApi.ts
+++ b/packages/default/doompi-log/src/adapters/hubApi.ts
@@ -1,0 +1,251 @@
+import type { DoomApi, DoomApiContext, DoomApiHandler } from '@agimon-ai/doompi-extension-contracts/package-api';
+import type { LogMetricGroupRow, LogMetricsReport, ToolMetricRow } from '@agimon-ai/log-sink-mcp';
+import { Hono } from 'hono';
+import { createIssuesSource } from './node/issuesSource.ts';
+import { createMetricsSource } from './node/metricsSource.ts';
+import type { IssuesSource } from '../types/issuesSource.ts';
+import type { MetricsFilter, MetricsSource } from '../types/metricsSource.ts';
+import {
+  isMetricsDimension,
+  isMetricsPeriod,
+  LOG_API_BASE_PATH,
+  ISSUE_SAMPLE_LIMIT,
+  METRICS_GROUP_LIMIT,
+  METRICS_QUERY_PARAMS,
+  METRICS_TOOL_LIMIT,
+  type MetricsBucket,
+  type MetricsDimension,
+  type MetricsGroup,
+  type MetricsPeriod,
+  type MetricsReport,
+  type MetricsTool,
+  type MetricsUnavailable,
+  type IssuesView,
+} from '../types/webMetrics.ts';
+
+/**
+ * The cockpit's half of this package's metrics access.
+ *
+ * Hub-scoped rather than session-scoped: the questions this answers, where the
+ * tokens went and which agents failed, are about the machine over time, and a
+ * session server can only see itself. The sink is already machine-wide, so the
+ * hub is the only place the two agree.
+ *
+ * The query path is not reimplemented here. `createMetricsSource` already owns
+ * the sink's two transports and its fallback order, and the TUI overlay reads
+ * through the same source, so both surfaces answer from one implementation.
+ */
+
+const DEFAULT_DIMENSION: MetricsDimension = 'model';
+const DEFAULT_PERIOD: MetricsPeriod = 'week';
+
+/** The sink groups sessions under a different name than the page's dimension. */
+const SINK_GROUP_BY = {
+  session: 'session',
+  agent: 'agent',
+  model: 'model',
+  provider: 'provider',
+} as const;
+
+function toBucket(bucket: LogMetricsReport['timeline'][number]): MetricsBucket {
+  return {
+    label: bucket.label,
+    totalTokens: bucket.totalTokens,
+    inputTokens: bucket.inputTokens,
+    outputTokens: bucket.outputTokens,
+  };
+}
+
+function toGroup(row: LogMetricGroupRow): MetricsGroup {
+  return {
+    key: row.key,
+    totalTokens: row.totalTokens,
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    issueCount: row.issueCount,
+    failed: row.failed,
+  };
+}
+
+/**
+ * The turn's p90 rather than a sum: the sink attributes a whole turn's tokens
+ * to every tool that ran in it, so adding them across calls would multiply the
+ * same tokens by however many tools shared the turn.
+ */
+function toTool(row: ToolMetricRow): MetricsTool {
+  return {
+    name: row.toolName,
+    calls: row.invocationCount,
+    p90TotalTokens: row.toolCallTurn.p90TotalTokens,
+  };
+}
+
+/** Which filter field carries a focus value, per dimension. */
+const FOCUS_FIELD: Record<MetricsDimension, keyof MetricsFilter> = {
+  session: 'sessionId',
+  agent: 'agentName',
+  model: 'model',
+  provider: 'provider',
+};
+
+/**
+ * The focus the sink actually applied, read from its own echo.
+ *
+ * A daemon that predates a filter ignores it and answers with everything. If
+ * the page trusted the request instead of this echo, it would label the whole
+ * machine's numbers as one model's.
+ */
+function appliedFocus(report: LogMetricsReport, dimension: MetricsDimension): string | undefined {
+  // The daemon is a separate process on its own release cadence, so its
+  // response is parsed defensively rather than trusted to carry every field.
+  const filters = report.filters as LogMetricsReport['filters'] | undefined;
+  if (filters === undefined) return undefined;
+  if (dimension === 'session') return filters.sessionId;
+  if (dimension === 'agent') return filters.agentName;
+  const applied = dimension === 'model' ? filters.model : filters.provider;
+  if (applied === undefined) return undefined;
+  return Array.isArray(applied) ? applied[0] : applied;
+}
+
+/**
+ * The sink's own type says Date, but both transports parse JSON, so what
+ * arrives is an ISO string. Trusting the declared type here throws on every
+ * real response, which no test using a hand-built Date would ever catch.
+ */
+function generatedAtIso(value: LogMetricsReport['generatedAt']): string {
+  if (value instanceof Date) return value.toISOString();
+  const parsed = new Date(value as unknown as string);
+  return Number.isNaN(parsed.getTime()) ? new Date(0).toISOString() : parsed.toISOString();
+}
+
+function toReport(report: LogMetricsReport, source: MetricsSource, dimension: MetricsDimension): MetricsReport {
+  const focus = appliedFocus(report, dimension);
+  return {
+    generatedAt: generatedAtIso(report.generatedAt),
+    dimension: report.groupBy as MetricsDimension,
+    period: report.period as MetricsPeriod,
+    bucketUnit: String(report.bucket),
+    transport: source.lastTransport(),
+    ...(focus === undefined ? {} : { focus }),
+    totals: {
+      totalTokens: report.totals.totalTokens,
+      inputTokens: report.totals.inputTokens,
+      outputTokens: report.totals.outputTokens,
+      cachedTokens: report.totals.cachedInputTokens,
+      reasoningTokens: report.totals.reasoningOutputTokens,
+      groupCount: report.totals.groupCount,
+      failedGroups: report.totals.failedGroups,
+      issueCount: report.totals.issueCount,
+    },
+    timeline: report.timeline.map(toBucket),
+    groups: report.groups.map(toGroup),
+    tools: report.tools.rows.map(toTool),
+  };
+}
+
+/**
+ * A report the sink answered but with nothing in it reads as "no data", not as
+ * an empty chart. The distinction the reader needs is whether telemetry is not
+ * being recorded or simply has not been recorded yet.
+ */
+function isEmpty(report: MetricsReport): boolean {
+  return report.totals.totalTokens === 0 && report.groups.length === 0 && report.tools.length === 0;
+}
+
+export interface HubApiOptions {
+  /** Injected by tests; production resolves the machine's sink. */
+  source?: MetricsSource;
+  issues?: IssuesSource;
+}
+
+export function createLogHubApi(options: HubApiOptions = {}): Hono {
+  const app = new Hono();
+  // One source for the life of the hub: it caches the resolved sink endpoint,
+  // and rebuilding it per request would re-probe the daemon every time.
+  const source = options.source ?? createMetricsSource();
+  const issues = options.issues ?? createIssuesSource();
+
+  app.get('/metrics', async (context) => {
+    const requestedDimension = context.req.query(METRICS_QUERY_PARAMS.dimension) ?? DEFAULT_DIMENSION;
+    const requestedPeriod = context.req.query(METRICS_QUERY_PARAMS.period) ?? DEFAULT_PERIOD;
+    if (!isMetricsDimension(requestedDimension)) {
+      return context.json({ error: `Unknown dimension '${requestedDimension}'.` }, 400);
+    }
+    if (!isMetricsPeriod(requestedPeriod)) {
+      return context.json({ error: `Unknown period '${requestedPeriod}'.` }, 400);
+    }
+
+    const focus = context.req.query(METRICS_QUERY_PARAMS.focus);
+    const filter: MetricsFilter | undefined =
+      focus === undefined || focus === '' ? undefined : { [FOCUS_FIELD[requestedDimension]]: focus };
+
+    let report: LogMetricsReport;
+    try {
+      report = await source.query({
+        groupBy: SINK_GROUP_BY[requestedDimension],
+        period: requestedPeriod,
+        limit: METRICS_GROUP_LIMIT,
+        toolLimit: METRICS_TOOL_LIMIT,
+        ...(filter === undefined ? {} : { filter }),
+      });
+    } catch (error) {
+      // Both transports declined. That is the ordinary state on a machine
+      // where the sink has never run, so it is reported as absence rather
+      // than raised as a fault the page has to render as a crash.
+      const unavailable: MetricsUnavailable = {
+        unavailable: 'no-sink',
+        detail: error instanceof Error ? error.message : 'The log sink did not answer.',
+      };
+      return context.json(unavailable);
+    }
+
+    const body = toReport(report, source, requestedDimension);
+    if (isEmpty(body)) {
+      const unavailable: MetricsUnavailable = {
+        unavailable: 'no-data',
+        detail: 'The log sink is running but has recorded no usage for this period.',
+      };
+      return context.json(unavailable);
+    }
+    return context.json(body);
+  });
+
+  /**
+   * The detail behind the count the report carries. Separate from /metrics
+   * because it costs a subprocess: the running daemon has no issues route, so
+   * folding it into every report would make the whole page as slow as its
+   * slowest transport.
+   */
+  app.get('/issues', async (context) => {
+    const focus = context.req.query(METRICS_QUERY_PARAMS.focus);
+    try {
+      const report = await issues.query({
+        limit: ISSUE_SAMPLE_LIMIT,
+        ...(focus === undefined || focus === '' ? {} : { sessionId: focus }),
+      });
+      return context.json(report satisfies IssuesView);
+    } catch (error) {
+      const unavailable: MetricsUnavailable = {
+        unavailable: 'no-sink',
+        detail: error instanceof Error ? error.message : 'The log sink did not answer.',
+      };
+      return context.json(unavailable);
+    }
+  });
+
+  return app;
+}
+
+/** The named export a host imports from this package's built hub entry. */
+export const api: DoomApi = {
+  basePath: LOG_API_BASE_PATH,
+  start(_context: DoomApiContext): DoomApiHandler {
+    const app = createLogHubApi();
+    return {
+      fetch: (request) => app.fetch(request),
+      // The source holds no handle of its own: the HTTP transport is a fetch
+      // per query and the CLI transport is a subprocess bounded by its timeout.
+      close: () => undefined,
+    };
+  },
+};

--- a/packages/default/doompi-log/src/adapters/node/issuesSource.ts
+++ b/packages/default/doompi-log/src/adapters/node/issuesSource.ts
@@ -1,0 +1,138 @@
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { resolveLogSinkInstance } from '@agimon-ai/log-sink-mcp';
+import type { AgentIssueSample, IssuesQueryParams, IssuesReport, IssuesSource } from '../../types/issuesSource.ts';
+
+/**
+ * Agent-issue analysis over the sink's CLI.
+ *
+ * One transport, not two, because the daemon serves only /api/metrics and
+ * /api/logs: there is no issues route to prefer. Every call is a subprocess,
+ * which is why the page asks for this only when a reader opens the section
+ * rather than alongside each report.
+ */
+
+const PACKAGE_NAME = '@agimon-ai/log-sink-mcp';
+const CLI_TIMEOUT_MS = 60000;
+/** The analysis scans the whole window, so its output is larger than a metrics report. */
+const MAX_CLI_BUFFER = 32 * 1024 * 1024;
+
+export interface IssuesSourceOptions {
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  packageName?: string;
+  serviceName?: string;
+  /** Overrides the subprocess in tests. */
+  cliRunner?: (params: IssuesQueryParams) => Promise<unknown>;
+}
+
+function cliEntryPoint(): string {
+  const require = createRequire(import.meta.url);
+  const packageJson = require.resolve(`${PACKAGE_NAME}/package.json`);
+  return path.join(path.dirname(packageJson), 'dist', 'cli.mjs');
+}
+
+function runCli(params: IssuesQueryParams, dbPath: string | undefined): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      [
+        cliEntryPoint(),
+        'logs',
+        'agent-issues',
+        '--limit',
+        String(params.limit),
+        ...(params.sessionId === undefined ? [] : ['--session-id', params.sessionId]),
+        ...(dbPath === undefined ? [] : ['--db-path', dbPath]),
+      ],
+      { timeout: CLI_TIMEOUT_MS, maxBuffer: MAX_CLI_BUFFER },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(stderr.trim() || error.message));
+          return;
+        }
+        try {
+          resolve(JSON.parse(stdout) as unknown);
+        } catch {
+          reject(new Error('The log sink returned output this version cannot read.'));
+        }
+      },
+    );
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function counts(value: unknown): Record<string, number> {
+  if (!isRecord(value)) return {};
+  const entries = Object.entries(value).flatMap(([key, count]) =>
+    typeof count === 'number' ? [[key, count] as [string, number]] : [],
+  );
+  return Object.fromEntries(entries);
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function nullableText(value: unknown): string | null {
+  return typeof value === 'string' && value !== '' ? value : null;
+}
+
+function toSample(value: unknown): AgentIssueSample[] {
+  if (!isRecord(value)) return [];
+  return [
+    {
+      fingerprint: text(value.fingerprint),
+      occurrenceCount: typeof value.occurrenceCount === 'number' ? value.occurrenceCount : 1,
+      category: text(value.category),
+      timestamp: text(value.timestamp),
+      level: text(value.level),
+      message: text(value.message),
+      // The sink leaves detail null when the message already is the detail.
+      detail: nullableText(value.detail) ?? text(value.message),
+      tool: nullableText(value.tool),
+      errorType: nullableText(value.errorType),
+      agentName: nullableText(value.agentName),
+      model: nullableText(value.model),
+      statusCode: nullableText(value.statusCode),
+    },
+  ];
+}
+
+/**
+ * The CLI's report is a foreign process's JSON, so every field is narrowed
+ * here rather than cast. A sink one version ahead may add fields, and a sink
+ * one version behind may omit them; neither should throw.
+ */
+function toReport(raw: unknown): IssuesReport {
+  if (!isRecord(raw)) throw new Error('The log sink returned output this version cannot read.');
+  const samples = Array.isArray(raw.issues) ? raw.issues.flatMap(toSample) : [];
+  return {
+    totalIssues: typeof raw.totalIssues === 'number' ? raw.totalIssues : 0,
+    uniqueIncidents: typeof raw.uniqueIncidents === 'number' ? raw.uniqueIncidents : 0,
+    byCategory: counts(raw.byCategory),
+    byTool: counts(raw.byTool),
+    byErrorType: counts(raw.byErrorType),
+    samples,
+  };
+}
+
+export function createIssuesSource(options: IssuesSourceOptions = {}): IssuesSource {
+  const instance = resolveLogSinkInstance({
+    env: options.env,
+    cwd: options.cwd,
+    packageName: options.packageName,
+    serviceName: options.serviceName,
+  });
+  const cliRunner = options.cliRunner ?? ((params: IssuesQueryParams) => runCli(params, instance?.dbPath));
+
+  return {
+    async query(params) {
+      return toReport(await cliRunner(params));
+    },
+  };
+}

--- a/packages/default/doompi-log/src/adapters/node/metricsSource.ts
+++ b/packages/default/doompi-log/src/adapters/node/metricsSource.ts
@@ -31,7 +31,11 @@ const HTTP_TIMEOUT_MS = 5000;
 const CLI_TIMEOUT_MS = 30000;
 /** A day of dev telemetry is already ~140k records; keep the payload bounded. */
 const MAX_CLI_BUFFER = 32 * 1024 * 1024;
-const TOOL_LIMIT = '1';
+/**
+ * The overlay ranks one tool, but a page pairing tool calls against failure
+ * counts needs a denominator for every tool that failed, so callers ask.
+ */
+const DEFAULT_TOOL_LIMIT = 1;
 /** The panel ranks consumers, so ask for the biggest rather than the most recent. */
 const TOKEN_SORT = 'total-tokens';
 
@@ -61,14 +65,43 @@ function cliEntryPoint(): string {
   return path.join(path.dirname(packageJson), 'dist', 'cli.mjs');
 }
 
+/**
+ * The sink names these the same way on the wire and on the command line, apart
+ * from the case convention, so the two transports stay in step.
+ */
+const FILTER_QUERY_KEYS = {
+  sessionId: 'sessionId',
+  agentName: 'agentName',
+  model: 'model',
+  provider: 'provider',
+} as const;
+
+const FILTER_CLI_FLAGS = {
+  sessionId: '--session-id',
+  agentName: '--agent-name',
+  model: '--model',
+  provider: '--provider',
+} as const;
+
+function filterEntries(params: MetricsQueryParams): [keyof typeof FILTER_QUERY_KEYS, string][] {
+  const filter = params.filter;
+  if (filter === undefined) return [];
+  return (Object.keys(FILTER_QUERY_KEYS) as (keyof typeof FILTER_QUERY_KEYS)[]).flatMap((key) => {
+    const value = filter[key];
+    return value === undefined || value === '' ? [] : [[key, value] as [keyof typeof FILTER_QUERY_KEYS, string]];
+  });
+}
+
 function searchParams(params: MetricsQueryParams): string {
-  return new URLSearchParams({
+  const search = new URLSearchParams({
     groupBy: params.groupBy,
     period: params.period,
     sort: TOKEN_SORT,
     limit: String(params.limit),
-    toolLimit: TOOL_LIMIT,
-  }).toString();
+    toolLimit: String(params.toolLimit ?? DEFAULT_TOOL_LIMIT),
+  });
+  for (const [key, value] of filterEntries(params)) search.set(FILTER_QUERY_KEYS[key], value);
+  return search.toString();
 }
 
 async function queryHttp(
@@ -109,7 +142,8 @@ function runCli(params: MetricsQueryParams, dbPath: string | undefined): Promise
         '--limit',
         String(params.limit),
         '--tool-limit',
-        TOOL_LIMIT,
+        String(params.toolLimit ?? DEFAULT_TOOL_LIMIT),
+        ...filterEntries(params).flatMap(([key, value]) => [FILTER_CLI_FLAGS[key], value]),
         ...(dbPath === undefined ? [] : ['--db-path', dbPath]),
       ],
       { timeout: CLI_TIMEOUT_MS, maxBuffer: MAX_CLI_BUFFER },

--- a/packages/default/doompi-log/src/exports/hubApi.ts
+++ b/packages/default/doompi-log/src/exports/hubApi.ts
@@ -1,0 +1,2 @@
+export type { HubApiOptions } from '../adapters/hubApi.ts';
+export { api, createLogHubApi } from '../adapters/hubApi.ts';

--- a/packages/default/doompi-log/src/exports/webClient.ts
+++ b/packages/default/doompi-log/src/exports/webClient.ts
@@ -1,0 +1,1 @@
+export { webPlugin } from '../web/index.ts';

--- a/packages/default/doompi-log/src/types/issueGrouping.ts
+++ b/packages/default/doompi-log/src/types/issueGrouping.ts
@@ -1,0 +1,86 @@
+import type { IssueSample } from './webMetrics.ts';
+
+/**
+ * Turning a list of incidents into a ranked list of problems.
+ *
+ * Pure, and in types/ so both halves may use it: the page ranks, and a test
+ * can assert the ranking without a render or a subprocess.
+ *
+ * Two things the sink's own output needs fixing for. It can emit the same
+ * fingerprint more than once, so occurrences have to be re-summed or the same
+ * problem appears three times at a third of its real weight. And its ordering
+ * is by recency, which buries a problem that happened twenty times under one
+ * that happened once a minute ago.
+ */
+
+export interface IssueGroup {
+  /** Stable identity for a row, unique after merging. */
+  key: string;
+  /** How many times this exact problem happened. */
+  occurrences: number;
+  category: string;
+  /** The actionable line: the spawn that failed, the path that was missing. */
+  detail: string;
+  tool: string | null;
+  errorType: string | null;
+  agentName: string | null;
+  model: string | null;
+  statusCode: string | null;
+  /** Most recent occurrence across the merged incidents. */
+  lastSeen: string;
+  /** Every incident folded into this row, for the expanded view. */
+  members: IssueSample[];
+}
+
+/**
+ * A key that separates problems a reader would act on separately.
+ *
+ * The sink's fingerprint is the primary key, but it can be empty, and several
+ * distinct bash failures share 'tool_failure|pi|bash||pi.tool_result' because
+ * the record name is all they carry. Folding the detail in keeps two different
+ * failures apart while still merging repeats of the same one.
+ */
+export function groupingKey(sample: IssueSample): string {
+  const base = sample.fingerprint === '' ? `${sample.category}|${sample.message}` : sample.fingerprint;
+  return `${base}|${sample.detail}`;
+}
+
+/** Incidents merged by problem and ranked by how often each happened. */
+export function groupIssues(samples: readonly IssueSample[]): IssueGroup[] {
+  const groups = new Map<string, IssueGroup>();
+
+  for (const sample of samples) {
+    const key = groupingKey(sample);
+    const existing = groups.get(key);
+    if (existing === undefined) {
+      groups.set(key, {
+        key,
+        occurrences: sample.occurrenceCount,
+        category: sample.category,
+        detail: sample.detail,
+        tool: sample.tool,
+        errorType: sample.errorType,
+        agentName: sample.agentName,
+        model: sample.model,
+        statusCode: sample.statusCode,
+        lastSeen: sample.timestamp,
+        members: [sample],
+      });
+      continue;
+    }
+    existing.occurrences += sample.occurrenceCount;
+    existing.members.push(sample);
+    if (sample.timestamp > existing.lastSeen) existing.lastSeen = sample.timestamp;
+    // A merged row keeps whichever identifying field any member supplied, so
+    // one incident missing an agent name does not blank it for the group.
+    existing.tool ??= sample.tool;
+    existing.errorType ??= sample.errorType;
+    existing.agentName ??= sample.agentName;
+    existing.model ??= sample.model;
+    existing.statusCode ??= sample.statusCode;
+  }
+
+  return [...groups.values()].sort(
+    (left, right) => right.occurrences - left.occurrences || left.detail.localeCompare(right.detail),
+  );
+}

--- a/packages/default/doompi-log/src/types/issuesSource.ts
+++ b/packages/default/doompi-log/src/types/issuesSource.ts
@@ -1,0 +1,58 @@
+/**
+ * The sink's agent-issue analysis, which is a different report from its
+ * metrics one and reached a different way.
+ *
+ * The running daemon exposes only /api/metrics and /api/logs over HTTP, so
+ * there is no fast path for this: the CLI subcommand is the only transport.
+ * That is why the page fetches it on demand rather than with every report.
+ */
+
+export interface IssuesQueryParams {
+  /** Narrows to one hashed session, matching the metrics session dimension. */
+  sessionId?: string;
+  /** How many incidents to return; the counts are unaffected. */
+  limit: number;
+}
+
+/**
+ * One recurring problem, as the sink fingerprints it.
+ *
+ * The sink already collapses occurrences into incidents, so `occurrenceCount`
+ * is how many times this exact problem happened. That number is the reason
+ * this report exists: a page that only totals tokens tells nobody what to fix,
+ * and "this same failure happened twenty times" does.
+ *
+ * `detail` is the actionable line. `message` is often a record name such as
+ * 'pi.tool_result', while detail carries the spawn that failed or the path
+ * that was missing.
+ */
+export interface AgentIssueSample {
+  /** The sink's grouping key. Not unique in its output, so callers re-merge. */
+  fingerprint: string;
+  occurrenceCount: number;
+  category: string;
+  timestamp: string;
+  level: string;
+  message: string;
+  detail: string;
+  tool: string | null;
+  errorType: string | null;
+  agentName: string | null;
+  model: string | null;
+  statusCode: string | null;
+}
+
+export interface IssuesReport {
+  totalIssues: number;
+  /** Distinct incidents after the sink groups by fingerprint. */
+  uniqueIncidents: number;
+  byCategory: Record<string, number>;
+  /** Failures per tool, which the metrics report's tool rows do not carry. */
+  byTool: Record<string, number>;
+  byErrorType: Record<string, number>;
+  samples: AgentIssueSample[];
+}
+
+export interface IssuesSource {
+  query(params: IssuesQueryParams): Promise<IssuesReport>;
+}

--- a/packages/default/doompi-log/src/types/metricsSource.ts
+++ b/packages/default/doompi-log/src/types/metricsSource.ts
@@ -1,9 +1,28 @@
 import type { LogMetricsGroupBy, LogMetricsPeriod, LogMetricsReport } from '@agimon-ai/log-sink-mcp';
 
+/**
+ * Narrowing one query to a single group, for a reader who clicked a row.
+ *
+ * Every field is optional and callers that pass none behave exactly as before,
+ * which is what keeps the TUI overlay unaffected. The sink echoes the filters
+ * it actually applied back on the report, so a caller can tell an honoured
+ * filter from one an older daemon ignored rather than presenting unfiltered
+ * numbers as filtered ones.
+ */
+export interface MetricsFilter {
+  sessionId?: string;
+  agentName?: string;
+  model?: string;
+  provider?: string;
+}
+
 export interface MetricsQueryParams {
   groupBy: LogMetricsGroupBy;
   period: LogMetricsPeriod;
   limit: number;
+  /** How many tool rows to rank; defaults to the overlay's one. */
+  toolLimit?: number;
+  filter?: MetricsFilter;
 }
 
 export type MetricsQuery = (params: MetricsQueryParams) => Promise<LogMetricsReport>;

--- a/packages/default/doompi-log/src/types/webMetrics.ts
+++ b/packages/default/doompi-log/src/types/webMetrics.ts
@@ -1,0 +1,126 @@
+/**
+ * The metrics API, shared by this package's hub-scoped route and its cockpit
+ * plugin. The two halves run in different processes, so the wire vocabulary is
+ * declared here: `src/web` may reach `src/types` and nothing else on the node
+ * side.
+ *
+ * The shapes are deliberately narrower than log-sink-mcp's own report. The
+ * sink's LogMetricsReport carries filters, span counts, and distribution
+ * detail the page never draws, and re-exporting it would tie the browser
+ * bundle to a node package's types. What crosses the wire is what a chart
+ * reads.
+ */
+
+/** The segment this package's API is mounted under, below /api/plugin. */
+export const LOG_API_BASE_PATH = 'log';
+
+/**
+ * The dimensions the page offers.
+ *
+ * log-sink-mcp also groups by 'workflow-run', 'workflow-name', 'job' and
+ * 'step'. Those are omitted on purpose: no DoomPi package emits the matching
+ * attributes today, so offering them would draw an empty chart and read as a
+ * bug rather than as a gap.
+ */
+export const METRICS_DIMENSIONS = ['session', 'agent', 'model', 'provider'] as const;
+export type MetricsDimension = (typeof METRICS_DIMENSIONS)[number];
+
+export const METRICS_PERIODS = ['day', 'week', 'month', 'all'] as const;
+export type MetricsPeriod = (typeof METRICS_PERIODS)[number];
+
+export const METRICS_QUERY_PARAMS = {
+  dimension: 'dimension',
+  period: 'period',
+} as const;
+
+/** How many groups and tools one response carries; the page ranks, it does not page. */
+export const METRICS_GROUP_LIMIT = 20;
+
+/** One point on the cost and token timeline. */
+export interface MetricsBucket {
+  /** Bucket start as an ISO instant, so the browser owns the formatting. */
+  startedAt: string;
+  totalTokens: number;
+  cost: number;
+}
+
+/** One row of the selected dimension. */
+export interface MetricsGroup {
+  /**
+   * The group's identity as the sink reports it. For the session dimension
+   * this is an opaque hash, never a session the cockpit can open, because
+   * doompi-telemetry hashes identifier-shaped attributes before export.
+   */
+  key: string;
+  totalTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number;
+  failed: boolean;
+}
+
+/**
+ * One tool's activity.
+ *
+ * `calls` and `failed` are exact. `totalTokens` is not a per-tool share: the
+ * sink attributes a turn's total to every tool that ran in that turn, so the
+ * figure ranks tools and does not measure them. The page must say so wherever
+ * it draws this field.
+ */
+export interface MetricsTool {
+  name: string;
+  calls: number;
+  failed: number;
+  totalTokens: number;
+}
+
+/** Which transport answered, so the page can say where its numbers came from. */
+export type MetricsTransport = 'http' | 'cli';
+
+export interface MetricsReport {
+  generatedAt: string;
+  dimension: MetricsDimension;
+  period: MetricsPeriod;
+  transport: MetricsTransport;
+  totals: {
+    totalTokens: number;
+    inputTokens: number;
+    outputTokens: number;
+    cost: number;
+    toolCalls: number;
+    failedToolCalls: number;
+  };
+  timeline: MetricsBucket[];
+  groups: MetricsGroup[];
+  tools: MetricsTool[];
+}
+
+/**
+ * Why the page has nothing to draw.
+ *
+ * The sink is a separate daemon that may be missing, older than the query, or
+ * simply empty, and those are three different things to tell a reader. They
+ * are not errors: metricsSource already treats a rejecting daemon as
+ * unavailable rather than fatal.
+ */
+export type MetricsUnavailableReason = 'no-sink' | 'sink-outdated' | 'no-data';
+
+export interface MetricsUnavailable {
+  unavailable: MetricsUnavailableReason;
+  detail: string;
+}
+
+export type MetricsResponse = MetricsReport | MetricsUnavailable;
+
+export function isMetricsUnavailable(response: MetricsResponse): response is MetricsUnavailable {
+  return 'unavailable' in response;
+}
+
+/** The absolute URL the page reads one report from. */
+export function metricsUrl(dimension: MetricsDimension, period: MetricsPeriod): string {
+  const search = new URLSearchParams({
+    [METRICS_QUERY_PARAMS.dimension]: dimension,
+    [METRICS_QUERY_PARAMS.period]: period,
+  });
+  return `/api/plugin/${LOG_API_BASE_PATH}/metrics?${search.toString()}`;
+}

--- a/packages/default/doompi-log/src/types/webMetrics.ts
+++ b/packages/default/doompi-log/src/types/webMetrics.ts
@@ -4,11 +4,14 @@
  * declared here: `src/web` may reach `src/types` and nothing else on the node
  * side.
  *
- * The shapes are deliberately narrower than log-sink-mcp's own report. The
- * sink's LogMetricsReport carries filters, span counts, and distribution
- * detail the page never draws, and re-exporting it would tie the browser
- * bundle to a node package's types. What crosses the wire is what a chart
- * reads.
+ * The shapes are narrower than log-sink-mcp's own report, which carries filter
+ * echoes, span counts and token distributions the page never draws.
+ * Re-exporting the sink's types would also tie the browser bundle to a node
+ * package. What crosses the wire is what a chart reads.
+ *
+ * Two things the sink does not have, so this contract does not pretend to:
+ * money, and per-tool failures. The sink records tokens only, and its tool rows
+ * carry an invocation count with no error field.
  */
 
 /** The segment this package's API is mounted under, below /api/plugin. */
@@ -31,17 +34,25 @@ export type MetricsPeriod = (typeof METRICS_PERIODS)[number];
 export const METRICS_QUERY_PARAMS = {
   dimension: 'dimension',
   period: 'period',
+  /** Narrows the whole report to one value of the current dimension. */
+  focus: 'focus',
 } as const;
 
 /** How many groups and tools one response carries; the page ranks, it does not page. */
 export const METRICS_GROUP_LIMIT = 20;
 
-/** One point on the cost and token timeline. */
+/** One point on the token timeline. */
 export interface MetricsBucket {
-  /** Bucket start as an ISO instant, so the browser owns the formatting. */
-  startedAt: string;
+  /**
+   * The sink's own local-time label ('YYYY-MM-DD', or 'YYYY-MM-DD HH:00' for an
+   * hour bucket). Carried rather than derived: bucket boundaries are aligned to
+   * local time, so slicing the ISO instant renders the wrong day east of
+   * Greenwich.
+   */
+  label: string;
   totalTokens: number;
-  cost: number;
+  inputTokens: number;
+  outputTokens: number;
 }
 
 /** One row of the selected dimension. */
@@ -55,41 +66,72 @@ export interface MetricsGroup {
   totalTokens: number;
   inputTokens: number;
   outputTokens: number;
-  cost: number;
+  /** Problems the sink detected for this group; 0 when it saw none. */
+  issueCount: number;
   failed: boolean;
 }
 
 /**
  * One tool's activity.
  *
- * `calls` and `failed` are exact. `totalTokens` is not a per-tool share: the
- * sink attributes a turn's total to every tool that ran in that turn, so the
- * figure ranks tools and does not measure them. The page must say so wherever
- * it draws this field.
+ * `calls` is exact. `p90TotalTokens` is not this tool's consumption: the sink
+ * attributes the whole turn's tokens to every tool that ran in that turn, so
+ * the figure ranks tools and does not measure them. The page must say so
+ * wherever it draws this field.
+ *
+ * There is no failure count here because the sink's tool rows do not carry
+ * one. Per-tool failures live in its separate agent-issues report, which the
+ * running daemon does not expose over HTTP.
  */
 export interface MetricsTool {
   name: string;
   calls: number;
-  failed: number;
-  totalTokens: number;
+  p90TotalTokens: number;
 }
 
 /** Which transport answered, so the page can say where its numbers came from. */
 export type MetricsTransport = 'http' | 'cli';
 
+export interface MetricsTotals {
+  /**
+   * The providers' own reported total. It is not inputTokens + outputTokens:
+   * on a cached agent workload it is dominated by cache traffic, and those two
+   * fields are a fraction of a percent of it. The page must never present the
+   * three as a breakdown.
+   */
+  totalTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  /** Cache reads, usually the largest real component of totalTokens. */
+  cachedTokens: number;
+  reasoningTokens: number;
+  groupCount: number;
+  /** Groups the sink flagged as having failed, out of groupCount. */
+  failedGroups: number;
+  issueCount: number;
+}
+
 export interface MetricsReport {
   generatedAt: string;
   dimension: MetricsDimension;
   period: MetricsPeriod;
-  transport: MetricsTransport;
-  totals: {
-    totalTokens: number;
-    inputTokens: number;
-    outputTokens: number;
-    cost: number;
-    toolCalls: number;
-    failedToolCalls: number;
-  };
+  /**
+   * The width of one timeline bucket, chosen by the sink from the period. A
+   * long period over a short history collapses to a single bucket, so the page
+   * says which unit it is drawing rather than implying a series it does not
+   * have.
+   */
+  bucketUnit: string;
+  /**
+   * The dimension value this report is narrowed to, echoed back from the sink
+   * rather than from the request. A daemon older than the filter ignores it
+   * and returns everything, so trusting the request would label unfiltered
+   * numbers as filtered; absence here means the drill-down did not happen.
+   */
+  focus?: string;
+  /** Undefined when the source could not say which transport answered. */
+  transport?: MetricsTransport;
+  totals: MetricsTotals;
   timeline: MetricsBucket[];
   groups: MetricsGroup[];
   tools: MetricsTool[];
@@ -98,12 +140,16 @@ export interface MetricsReport {
 /**
  * Why the page has nothing to draw.
  *
- * The sink is a separate daemon that may be missing, older than the query, or
- * simply empty, and those are three different things to tell a reader. They
- * are not errors: metricsSource already treats a rejecting daemon as
- * unavailable rather than fatal.
+ * The sink is a separate daemon that may be missing or simply empty, and those
+ * are different things to tell a reader. Neither is an error: the metrics
+ * source already treats a rejecting daemon as unavailable rather than fatal.
+ *
+ * 'no-api' is the third case and belongs to the cockpit rather than the sink.
+ * A hub serving a bundle without package APIs mounted answers this route with
+ * the SPA shell, and a 200 of HTML must read as a feature that is not
+ * installed, not as a corrupt response.
  */
-export type MetricsUnavailableReason = 'no-sink' | 'sink-outdated' | 'no-data';
+export type MetricsUnavailableReason = 'no-sink' | 'no-data' | 'no-api';
 
 export interface MetricsUnavailable {
   unavailable: MetricsUnavailableReason;
@@ -116,11 +162,84 @@ export function isMetricsUnavailable(response: MetricsResponse): response is Met
   return 'unavailable' in response;
 }
 
-/** The absolute URL the page reads one report from. */
-export function metricsUrl(dimension: MetricsDimension, period: MetricsPeriod): string {
+export function isMetricsDimension(value: string): value is MetricsDimension {
+  return (METRICS_DIMENSIONS as readonly string[]).includes(value);
+}
+
+export function isMetricsPeriod(value: string): value is MetricsPeriod {
+  return (METRICS_PERIODS as readonly string[]).includes(value);
+}
+
+/** One tool's failure count, paired with its call count from the metrics report. */
+export interface IssueToolRow {
+  name: string;
+  failures: number;
+}
+
+/**
+ * One recurring problem, as the sink fingerprints it.
+ *
+ * `occurrenceCount` is how many times it happened, which is the number a
+ * reader acts on. `detail` is the actionable line; `message` is often only a
+ * record name such as 'pi.tool_result'.
+ */
+export interface IssueSample {
+  fingerprint: string;
+  occurrenceCount: number;
+  category: string;
+  timestamp: string;
+  level: string;
+  message: string;
+  detail: string;
+  tool: string | null;
+  errorType: string | null;
+  agentName: string | null;
+  model: string | null;
+  statusCode: string | null;
+}
+
+/**
+ * The detail behind the issue count.
+ *
+ * Fetched separately from the report because the running sink exposes no
+ * issues route over HTTP, so this costs a subprocess. The page asks for it
+ * when a reader opens the section, not with every refresh.
+ */
+export interface IssuesView {
+  totalIssues: number;
+  uniqueIncidents: number;
+  byCategory: Record<string, number>;
+  byTool: Record<string, number>;
+  byErrorType: Record<string, number>;
+  samples: IssueSample[];
+}
+
+export type IssuesResponse = IssuesView | MetricsUnavailable;
+
+export function isIssuesUnavailable(response: IssuesResponse): response is MetricsUnavailable {
+  return 'unavailable' in response;
+}
+
+/** How many incidents the issues section ranks. */
+export const ISSUE_SAMPLE_LIMIT = 50;
+
+/** How many tool rows the report ranks, so a failing tool has a denominator. */
+export const METRICS_TOOL_LIMIT = 15;
+
+/** The absolute URL the page reads the issue detail from. */
+export function issuesUrl(focus?: string): string {
+  const search = new URLSearchParams();
+  if (focus !== undefined && focus !== '') search.set(METRICS_QUERY_PARAMS.focus, focus);
+  const query = search.toString();
+  return `/api/plugin/${LOG_API_BASE_PATH}/issues${query === '' ? '' : `?${query}`}`;
+}
+
+/** The absolute URL the page reads one report from; `focus` narrows it to one group. */
+export function metricsUrl(dimension: MetricsDimension, period: MetricsPeriod, focus?: string): string {
   const search = new URLSearchParams({
     [METRICS_QUERY_PARAMS.dimension]: dimension,
     [METRICS_QUERY_PARAMS.period]: period,
   });
+  if (focus !== undefined && focus !== '') search.set(METRICS_QUERY_PARAMS.focus, focus);
   return `/api/plugin/${LOG_API_BASE_PATH}/metrics?${search.toString()}`;
 }

--- a/packages/default/doompi-log/src/web/IssuesDetail.tsx
+++ b/packages/default/doompi-log/src/web/IssuesDetail.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import { groupIssues, type IssueGroup } from '../types/issueGrouping.ts';
+import type { IssuesView, MetricsTool } from '../types/webMetrics.ts';
+import { barFraction } from './charts/chartScale.ts';
+
+/**
+ * What is actually going wrong, ranked by how often.
+ *
+ * A count of 69 issues tells nobody what to change. The same 69 collapsed into
+ * "this spawn failed 20 times, this hook failed 3" is a work list, so the
+ * ranked bar is the primary view here and the totals are context beside it.
+ *
+ * Each bar expands to the incidents behind it, because the row states the
+ * problem and the reader still needs the session, model, and timestamps to go
+ * and look at one.
+ */
+
+function countRows(counts: Record<string, number>): [string, number][] {
+  return Object.entries(counts).sort(([, left], [, right]) => right - left);
+}
+
+/** A short, human label for a problem; the detail can be a whole command line. */
+function titleOf(group: IssueGroup): string {
+  if (group.errorType !== null) return group.errorType;
+  if (group.tool !== null) return `${group.tool} failed`;
+  return group.category;
+}
+
+interface IssueRowProps {
+  group: IssueGroup;
+  max: number;
+  tools: readonly MetricsTool[];
+}
+
+function IssueRow({ group, max, tools }: IssueRowProps) {
+  const [open, setOpen] = useState(false);
+  const width = `${(barFraction(group.occurrences, max) * 100).toFixed(2)}%`;
+  const calls = tools.find((tool) => tool.name === group.tool)?.calls;
+
+  return (
+    <li className="flex flex-col">
+      <div className="relative">
+        <span aria-hidden="true" className="absolute inset-y-0 left-0 rounded-[2px] bg-doom-red/20" style={{ width }} />
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          aria-expanded={open}
+          data-testid={`metrics-issue-${group.key}`}
+          className="relative flex w-full items-center gap-2 rounded-[2px] px-1 py-[3px] text-left text-[10px] hover:bg-doom-tint focus-visible:outline focus-visible:outline-1 focus-visible:outline-doom-blue"
+        >
+          <span className="w-8 shrink-0 text-right font-bold text-doom-red">{group.occurrences}</span>
+          <span className="w-24 shrink-0 truncate text-doom-hi">{titleOf(group)}</span>
+          <span className="min-w-0 flex-1 truncate text-doom-dim">{group.detail}</span>
+          {calls === undefined ? null : <span className="shrink-0 text-doom-faint">of {calls} calls</span>}
+        </button>
+      </div>
+
+      {open ? (
+        <div className="flex flex-col gap-1 px-2 py-2 text-[10px]" data-testid={`metrics-issue-body-${group.key}`}>
+          <div className="flex flex-wrap gap-x-3 gap-y-1 text-[9px] text-doom-faint">
+            <span>category {group.category}</span>
+            {group.tool === null ? null : <span>tool {group.tool}</span>}
+            {group.errorType === null ? null : <span>error {group.errorType}</span>}
+            {group.statusCode === null ? null : <span>status {group.statusCode}</span>}
+            {group.agentName === null ? null : <span>agent {group.agentName}</span>}
+            {group.model === null ? null : <span>model {group.model}</span>}
+            <span>last seen {group.lastSeen}</span>
+          </div>
+          <span className="break-words text-doom-dim">{group.detail}</span>
+          <ul className="flex flex-col gap-[1px] text-[9px] text-doom-faint">
+            {group.members.map((member, index) => (
+              <li key={`${member.timestamp}-${String(index)}`} className="flex flex-wrap gap-x-2">
+                <span>{member.timestamp}</span>
+                <span>{member.level}</span>
+                <span>
+                  {member.occurrenceCount}
+                  {'\u00d7'}
+                </span>
+                <span className="min-w-0 truncate">{member.message}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+export interface IssuesDetailProps {
+  view: IssuesView;
+  /** Tool call counts from the report, used as the denominator. */
+  tools: readonly MetricsTool[];
+}
+
+export function IssuesDetail({ view, tools }: IssuesDetailProps) {
+  const groups = groupIssues(view.samples);
+  const max = groups[0]?.occurrences ?? 0;
+  const callsByTool = new Map(tools.map((tool) => [tool.name, tool.calls]));
+
+  return (
+    <div className="flex flex-col gap-3">
+      <span className="text-[10px] text-doom-dim">
+        <span className="text-doom-hi">{view.totalIssues}</span> occurrences of{' '}
+        <span className="text-doom-hi">{groups.length}</span> distinct problems, worst first
+      </span>
+
+      {groups.length === 0 ? null : (
+        <ul className="flex flex-col gap-[2px]" data-testid="metrics-issue-groups">
+          {groups.map((group) => (
+            <IssueRow key={group.key} group={group} max={max} tools={tools} />
+          ))}
+        </ul>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <span className="text-[9px] font-bold text-doom-faint">failures by tool</span>
+        <table className="w-full text-[10px]" data-testid="metrics-issues-tools">
+          <tbody>
+            {countRows(view.byTool).map(([name, failures]) => {
+              const calls = callsByTool.get(name);
+              return (
+                <tr key={name} className="border-b border-doom-border/40">
+                  <td className="min-w-0 truncate py-1 text-doom-dim">{name}</td>
+                  <td className="w-16 py-1 text-right text-doom-red">{failures}</td>
+                  <td className="w-28 py-1 text-right text-doom-faint">
+                    {/* Only tools the report also ranked have a denominator;
+                        the two reports scan on their own limits. */}
+                    {calls === undefined ? 'of unknown calls' : `of ${String(calls)} calls`}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-[10px] text-doom-dim">
+        <span className="text-[9px] font-bold text-doom-faint">by category</span>
+        {countRows(view.byCategory).map(([name, count]) => (
+          <span key={name}>
+            {name} <span className="text-doom-hi">{count}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/default/doompi-log/src/web/IssuesSection.tsx
+++ b/packages/default/doompi-log/src/web/IssuesSection.tsx
@@ -1,0 +1,83 @@
+import { Button, Spinner } from '@agimon-ai/doompi-web-components';
+import { useState } from 'react';
+import { isIssuesUnavailable, type IssuesView, type MetricsTool } from '../types/webMetrics.ts';
+import { IssuesDetail } from './IssuesDetail.tsx';
+import { fetchIssues } from './metricsApi.ts';
+
+/**
+ * The detail behind the issue count.
+ *
+ * Collapsed until asked for, because the hub answers this from a subprocess:
+ * the running log sink serves no issues route over HTTP. Opening it is the
+ * reader agreeing to that cost, which is better than making every refresh of
+ * the whole page wait on the slowest transport.
+ *
+ * Only the going-and-getting lives here; IssuesDetail owns what the numbers
+ * look like once they arrive.
+ */
+
+interface IssuesSectionProps {
+  /** Tool call counts from the report, used as the denominator. */
+  tools: readonly MetricsTool[];
+  /** The dimension value the page is narrowed to, forwarded as a session filter. */
+  focus?: string;
+}
+
+export function IssuesSection({ tools, focus }: IssuesSectionProps) {
+  const [view, setView] = useState<IssuesView | undefined>(undefined);
+  const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const load = (): void => {
+    setOpen(true);
+    setLoading(true);
+    setMessage('');
+    void fetchIssues(focus).then((result) => {
+      setLoading(false);
+      if ('error' in result) {
+        if (result.error !== '') setMessage(result.error);
+        return;
+      }
+      if (isIssuesUnavailable(result.issues)) {
+        setMessage(result.issues.detail);
+        return;
+      }
+      setView(result.issues);
+    });
+  };
+
+  return (
+    <section className="flex flex-col gap-1" data-testid="metrics-issues">
+      <div className="flex items-center gap-2">
+        <span className="text-[9px] font-bold text-doom-faint">issues</span>
+        {open ? null : (
+          <Button variant="ghost" size="xs" className="text-[9px]" onClick={load} data-testid="metrics-issues-open">
+            show detail
+          </Button>
+        )}
+        {open && !loading ? (
+          <Button variant="ghost" size="xs" className="text-[9px]" onClick={load} data-testid="metrics-issues-reload">
+            reload
+          </Button>
+        ) : null}
+        {loading ? <Spinner /> : null}
+      </div>
+      {/* Reading this scans the whole window in a subprocess, so the reader is
+          told why it is behind a click rather than left wondering. */}
+      {open ? null : (
+        <span className="text-[9px] text-doom-faint/70">
+          the log sink has no issues endpoint, so this is read separately and takes a moment
+        </span>
+      )}
+
+      {message === '' ? null : (
+        <span className="text-[10px] text-doom-yellow" data-testid="metrics-issues-message">
+          {message}
+        </span>
+      )}
+
+      {view === undefined ? null : <IssuesDetail view={view} tools={tools} />}
+    </section>
+  );
+}

--- a/packages/default/doompi-log/src/web/MetricsNotice.tsx
+++ b/packages/default/doompi-log/src/web/MetricsNotice.tsx
@@ -1,0 +1,59 @@
+import { Button, EmptyState } from '@agimon-ai/doompi-web-components';
+import type { MetricsDimension, MetricsUnavailable, MetricsUnavailableReason } from '../types/webMetrics.ts';
+import { DIMENSION_LABELS } from './MetricsReportView.tsx';
+
+/**
+ * Everything the page says instead of, or above, a report.
+ *
+ * Kept pure and apart from the panel because these are the states that decide
+ * whether a reader trusts the numbers, and they are the ones a fetching
+ * component makes awkward to assert. The panel decides which state it is in;
+ * this decides how each one reads.
+ */
+
+const EMPTY_TITLES: Record<MetricsUnavailableReason, string> = {
+  'no-sink': 'no log sink',
+  'no-data': 'nothing recorded yet',
+  'no-api': 'metrics not installed',
+};
+
+export function EmptyForReason({ response }: { response: MetricsUnavailable }) {
+  return (
+    <EmptyState title={EMPTY_TITLES[response.unavailable]} description={response.detail} data-testid="metrics-empty" />
+  );
+}
+
+export interface FocusNoticeProps {
+  /** What the reader asked to narrow to; empty means they asked for nothing. */
+  requested: string;
+  /** What the sink echoed back as applied; absent means it ignored the filter. */
+  applied: string | undefined;
+  dimension: MetricsDimension;
+  onClear: () => void;
+}
+
+export function FocusNotice({ requested, applied, dimension, onClear }: FocusNoticeProps) {
+  if (requested === '') return null;
+  if (applied === undefined) {
+    // The sink answered without echoing the filter, so these are the machine's
+    // whole numbers. Saying "showing model X" over them would be a lie, so the
+    // drill-down is reported as refused instead.
+    return (
+      <span className="text-[10px] text-doom-yellow" data-testid="metrics-focus-refused">
+        this log sink does not support narrowing by {DIMENSION_LABELS[dimension]}, so the numbers below are still
+        everything
+        <Button variant="ghost" size="xs" className="ml-2 text-[9px]" onClick={onClear}>
+          clear
+        </Button>
+      </span>
+    );
+  }
+  return (
+    <span className="text-[10px] text-doom-dim" data-testid="metrics-focus">
+      narrowed to <span className="text-doom-hi">{applied}</span>
+      <Button variant="ghost" size="xs" className="ml-2 text-[9px]" onClick={onClear}>
+        clear
+      </Button>
+    </span>
+  );
+}

--- a/packages/default/doompi-log/src/web/MetricsPanel.tsx
+++ b/packages/default/doompi-log/src/web/MetricsPanel.tsx
@@ -1,0 +1,20 @@
+import { EmptyState } from '@agimon-ai/doompi-web-components';
+import type { SettingsPanelProps } from '@agimon-ai/doompi-web-contracts';
+
+/**
+ * The metrics settings page.
+ *
+ * Placeholder body: the route, the menu entry and the host transport are in
+ * place, and the report this draws arrives with the hub API. Kept as its own
+ * component from the start so the page that replaces this body does not also
+ * have to change how it is mounted.
+ */
+export function MetricsPanel(_props: SettingsPanelProps) {
+  return (
+    <EmptyState
+      title="no metrics yet"
+      description="This page will chart tool failures, tokens by dimension, and cost over time from the local log sink."
+      data-testid="metrics-placeholder"
+    />
+  );
+}

--- a/packages/default/doompi-log/src/web/MetricsPanel.tsx
+++ b/packages/default/doompi-log/src/web/MetricsPanel.tsx
@@ -1,20 +1,126 @@
-import { EmptyState } from '@agimon-ai/doompi-web-components';
+import {
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Spinner,
+} from '@agimon-ai/doompi-web-components';
 import type { SettingsPanelProps } from '@agimon-ai/doompi-web-contracts';
+import { useEffect, useState } from 'react';
+import {
+  isMetricsUnavailable,
+  METRICS_DIMENSIONS,
+  METRICS_PERIODS,
+  type MetricsDimension,
+  type MetricsPeriod,
+  type MetricsReport,
+  type MetricsResponse,
+} from '../types/webMetrics.ts';
+import { EmptyForReason, FocusNotice } from './MetricsNotice.tsx';
+import { DIMENSION_LABELS } from './MetricsReportView.tsx';
+import { MetricsReportView } from './MetricsReportView.tsx';
+import { fetchMetrics } from './metricsApi.ts';
 
 /**
  * The metrics settings page.
  *
- * Placeholder body: the route, the menu entry and the host transport are in
- * place, and the report this draws arrives with the hub API. Kept as its own
- * component from the start so the page that replaces this body does not also
- * have to change how it is mounted.
+ * Reports rather than writes, which is why it is drawn instead of declared as
+ * fields. The numbers come from the machine's log sink, so every one of them
+ * can be absent for a reason the reader needs told apart: no sink installed,
+ * a sink with nothing recorded yet, or a hub that did not answer.
+ *
+ * Tables here, charts next. The data path is worth proving before the drawing
+ * code is layered on it.
  */
+
 export function MetricsPanel(_props: SettingsPanelProps) {
+  const [dimension, setDimension] = useState<MetricsDimension>('model');
+  const [period, setPeriod] = useState<MetricsPeriod>('week');
+  const [focus, setFocus] = useState('');
+  const [response, setResponse] = useState<MetricsResponse | undefined>(undefined);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    void fetchMetrics(dimension, period, focus, controller.signal).then((result) => {
+      if (controller.signal.aborted) return;
+      if ('error' in result) {
+        // An empty message is an aborted request, which the next effect replaces.
+        if (result.error !== '') setError(result.error);
+      } else {
+        setError('');
+        setResponse(result.report);
+      }
+      setLoading(false);
+    });
+    return () => controller.abort();
+  }, [dimension, period, focus]);
+
+  const report: MetricsReport | undefined =
+    response === undefined || isMetricsUnavailable(response) ? undefined : response;
+
   return (
-    <EmptyState
-      title="no metrics yet"
-      description="This page will chart tool failures, tokens by dimension, and cost over time from the local log sink."
-      data-testid="metrics-placeholder"
-    />
+    <div className="flex flex-col gap-3" data-testid="metrics-panel">
+      <div className="flex min-w-0 flex-wrap items-center gap-2">
+        <Select
+          value={dimension}
+          onValueChange={(next) => {
+            setFocus('');
+            setDimension(next as MetricsDimension);
+          }}
+        >
+          <SelectTrigger data-testid="metrics-dimension" className="w-[140px] text-[10px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {METRICS_DIMENSIONS.map((candidate) => (
+              <SelectItem key={candidate} value={candidate}>
+                {DIMENSION_LABELS[candidate]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={period} onValueChange={(next) => setPeriod(next as MetricsPeriod)}>
+          <SelectTrigger data-testid="metrics-period" className="w-[110px] text-[10px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {METRICS_PERIODS.map((candidate) => (
+              <SelectItem key={candidate} value={candidate}>
+                {candidate}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {loading ? <Spinner /> : null}
+        <Button
+          variant="ghost"
+          size="xs"
+          className="ml-auto text-[9px]"
+          onClick={() => setPeriod((current) => current)}
+          disabled={loading}
+        >
+          refresh
+        </Button>
+      </div>
+
+      {error === '' ? null : (
+        <span className="text-[10px] text-doom-red" data-testid="metrics-error">
+          {error}
+        </span>
+      )}
+
+      {response !== undefined && isMetricsUnavailable(response) ? <EmptyForReason response={response} /> : null}
+
+      {report === undefined ? null : (
+        <FocusNotice requested={focus} applied={report.focus} dimension={dimension} onClear={() => setFocus('')} />
+      )}
+
+      {report === undefined ? null : <MetricsReportView report={report} onFocus={setFocus} />}
+    </div>
   );
 }

--- a/packages/default/doompi-log/src/web/MetricsReportView.tsx
+++ b/packages/default/doompi-log/src/web/MetricsReportView.tsx
@@ -1,0 +1,123 @@
+import { Badge } from '@agimon-ai/doompi-web-components';
+import type { MetricsDimension, MetricsReport } from '../types/webMetrics.ts';
+import { IssuesSection } from './IssuesSection.tsx';
+import { GroupBars } from './charts/GroupBars.tsx';
+import { TimelineChart } from './charts/TimelineChart.tsx';
+import { formatTokens } from './charts/chartScale.ts';
+
+/**
+ * One report, drawn.
+ *
+ * Separated from the panel so the loaded shape is a pure function of a report:
+ * the panel owns the selects, the fetch and the empty states, and this owns
+ * what a report looks like. That split is what lets the degenerate shapes, a
+ * single bucket or an all-zero series, be rendered and asserted directly.
+ */
+
+export const DIMENSION_LABELS: Record<MetricsDimension, string> = {
+  session: 'session',
+  agent: 'agent',
+  model: 'model',
+  provider: 'provider',
+};
+
+/**
+ * The session dimension shows an opaque hash. doompi-telemetry hashes
+ * identifier-shaped attributes before export, by design, so there is no
+ * session here the cockpit could open even if the row were clickable.
+ */
+export const DIMENSION_NOTES: Partial<Record<MetricsDimension, string>> = {
+  session: 'session ids are hashed before export, so these identify a session without naming one',
+};
+
+export interface MetricsReportViewProps {
+  report: MetricsReport;
+  onFocus: (key: string) => void;
+}
+
+export function MetricsReportView({ report, onFocus }: MetricsReportViewProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <div className="flex flex-wrap items-center gap-3 text-[10px] text-doom-dim">
+          <span>
+            <span className="text-doom-hi">{formatTokens(report.totals.totalTokens)}</span> total
+          </span>
+          <span>
+            <span className="text-doom-hi">{formatTokens(report.totals.cachedTokens)}</span> cache reads
+          </span>
+          <span>
+            <span className="text-doom-hi">{formatTokens(report.totals.outputTokens)}</span> out
+          </span>
+          <span>
+            <span className="text-doom-hi">{formatTokens(report.totals.inputTokens)}</span> in
+          </span>
+          {report.totals.reasoningTokens === 0 ? null : (
+            <span>
+              <span className="text-doom-hi">{formatTokens(report.totals.reasoningTokens)}</span> reasoning
+            </span>
+          )}
+          {report.totals.issueCount === 0 ? null : <Badge tone="red">{report.totals.issueCount} issues</Badge>}
+          {report.totals.failedGroups === 0 ? null : (
+            <span className="text-doom-faint">
+              {report.totals.failedGroups} of {report.totals.groupCount} {DIMENSION_LABELS[report.dimension]}s failed
+            </span>
+          )}
+        </div>
+        {/*
+            The total is the providers' own figure, and on a cached workload
+            the named parts are a fraction of a percent of it. Listing them
+            beside it without this line reads as a breakdown that does not
+            add up, which is worse than not showing them.
+          */}
+        <span className="text-[9px] text-doom-faint/70">
+          total is what the providers reported and is dominated by cache traffic; the parts beside it are counted
+          separately and do not sum to it
+        </span>
+      </div>
+
+      <section className="flex flex-col gap-1">
+        <span className="text-[9px] font-bold text-doom-faint">tokens over time</span>
+        <TimelineChart buckets={report.timeline} bucketUnit={report.bucketUnit} />
+      </section>
+
+      <section className="flex flex-col gap-1">
+        <span className="text-[9px] font-bold text-doom-faint">tokens by {DIMENSION_LABELS[report.dimension]}</span>
+        {DIMENSION_NOTES[report.dimension] === undefined ? null : (
+          <span className="text-[9px] text-doom-faint/70">{DIMENSION_NOTES[report.dimension]}</span>
+        )}
+        <GroupBars groups={report.groups} focus={report.focus} onFocus={onFocus} />
+      </section>
+
+      <section className="flex flex-col gap-1">
+        <span className="text-[9px] font-bold text-doom-faint">tool calls</span>
+        {/*
+            The token column is a ranking hint, not a measurement. The sink
+            attributes a turn's whole total to every tool that ran in that
+            turn, so saying otherwise here would be a lie the chart repeats.
+          */}
+        <span className="text-[9px] text-doom-faint/70">
+          call counts are exact; the token column ranks tools by the turns they ran in, and is not each tool&apos;s own
+          consumption
+        </span>
+        <table className="w-full text-[10px]" data-testid="metrics-tools">
+          <tbody>
+            {report.tools.map((tool) => (
+              <tr key={tool.name} className="border-b border-doom-border/40">
+                <td className="min-w-0 truncate py-1 text-doom-dim">{tool.name}</td>
+                <td className="w-20 py-1 text-right text-doom-hi">{tool.calls}</td>
+                <td className="w-20 py-1 text-right text-doom-faint">{formatTokens(tool.p90TotalTokens)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <IssuesSection tools={report.tools} focus={report.dimension === 'session' ? report.focus : undefined} />
+
+      <span className="text-[9px] text-doom-faint/70" data-testid="metrics-provenance">
+        read over {report.transport ?? 'an unreported transport'} · generated {report.generatedAt}
+      </span>
+    </div>
+  );
+}

--- a/packages/default/doompi-log/src/web/charts/GroupBars.tsx
+++ b/packages/default/doompi-log/src/web/charts/GroupBars.tsx
@@ -1,0 +1,73 @@
+import type { MetricsGroup } from '../../types/webMetrics.ts';
+import { barFraction, formatTokens, seriesMax } from './chartScale.ts';
+
+/**
+ * Tokens per group, as horizontal bars.
+ *
+ * Horizontal rather than vertical because the labels are model names and
+ * session hashes, which do not fit under a column. Each row is a button when
+ * the caller supplies a handler: clicking one narrows the whole page to that
+ * group, which is the drill-down.
+ *
+ * A row is not a link to a session even when the dimension is 'session'. The
+ * identifier is a hash, so there is no session for it to open.
+ */
+
+interface GroupBarsProps {
+  groups: readonly MetricsGroup[];
+  /** The group the page is currently narrowed to, if any. */
+  focus?: string;
+  onFocus?: (key: string) => void;
+}
+
+export function GroupBars({ groups, focus, onFocus }: GroupBarsProps) {
+  const max = seriesMax(groups.map((group) => group.totalTokens));
+
+  return (
+    <ul className="flex flex-col gap-[3px]" data-testid="metrics-group-bars">
+      {groups.map((group) => {
+        const width = `${(barFraction(group.totalTokens, max) * 100).toFixed(2)}%`;
+        const selected = focus === group.key;
+        const row = (
+          <>
+            <span className="min-w-0 flex-1 truncate text-left text-doom-dim">{group.key}</span>
+            <span className="w-14 shrink-0 text-right text-doom-hi">{formatTokens(group.totalTokens)}</span>
+            <span className="w-10 shrink-0 text-right">
+              {group.issueCount === 0 ? (
+                <span className="text-doom-faint/50">ok</span>
+              ) : (
+                <span className="text-doom-red">{group.issueCount}</span>
+              )}
+            </span>
+          </>
+        );
+
+        return (
+          <li key={group.key} className="relative">
+            {/* The bar is behind the text rather than beside it, so a long
+                model name keeps its full width instead of competing with the
+                track for horizontal space. */}
+            <span
+              aria-hidden="true"
+              className={`absolute inset-y-0 left-0 rounded-[2px] ${selected ? 'bg-doom-blue/30' : 'bg-doom-blue/15'}`}
+              style={{ width }}
+            />
+            {onFocus === undefined ? (
+              <span className="relative flex items-center gap-2 px-1 py-[3px] text-[10px]">{row}</span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => onFocus(selected ? '' : group.key)}
+                aria-pressed={selected}
+                data-testid={`metrics-group-${group.key}`}
+                className="relative flex w-full items-center gap-2 rounded-[2px] px-1 py-[3px] text-[10px] hover:bg-doom-tint focus-visible:outline focus-visible:outline-1 focus-visible:outline-doom-blue"
+              >
+                {row}
+              </button>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/default/doompi-log/src/web/charts/TimelineChart.tsx
+++ b/packages/default/doompi-log/src/web/charts/TimelineChart.tsx
@@ -1,0 +1,76 @@
+import type { MetricsBucket } from '../../types/webMetrics.ts';
+import { barFraction, formatTokens, seriesMax } from './chartScale.ts';
+
+/**
+ * Tokens per bucket, as columns.
+ *
+ * Drawn as SVG rather than with a charting library because the cockpit bundle
+ * has none and the plugin import allowlist admits none. That constraint is a
+ * good fit here: this is a bar per bucket, and a dependency would cost more
+ * than it saves.
+ *
+ * Columns use currentColor and theme classes rather than literal colours, so
+ * the chart follows whichever theme the cockpit renders with.
+ */
+
+const VIEWBOX_HEIGHT = 100;
+
+/**
+ * Widest a single column may get.
+ *
+ * Dividing the width by the bucket count alone turns a one-bucket period into
+ * a slab spanning the whole panel at full height, which reads as a rendering
+ * fault rather than as "one bucket". Capping it keeps a short series looking
+ * like bars on an axis.
+ */
+const MAX_COLUMN_PERCENT = 9;
+
+interface TimelineChartProps {
+  buckets: readonly MetricsBucket[];
+  /** The sink's bucket width, named so a flat chart explains itself; absent on an older hub. */
+  bucketUnit?: string;
+}
+
+export function TimelineChart({ buckets, bucketUnit }: TimelineChartProps) {
+  // An older hub does not send the unit; say nothing rather than 'undefined'.
+  const unit = bucketUnit === undefined || bucketUnit === '' ? '' : `${bucketUnit} `;
+  const max = seriesMax(buckets.map((bucket) => bucket.totalTokens));
+  const columnWidth = Math.min(MAX_COLUMN_PERCENT, 100 / Math.max(1, buckets.length));
+
+  return (
+    <div className="flex flex-col gap-1" data-testid="metrics-timeline-chart">
+      <svg
+        viewBox={`0 0 100 ${VIEWBOX_HEIGHT}`}
+        preserveAspectRatio="none"
+        className="h-24 w-full text-doom-blue"
+        role="img"
+        aria-label={`tokens per bucket, peak ${formatTokens(max)}`}
+      >
+        {buckets.map((bucket, index) => {
+          const height = barFraction(bucket.totalTokens, max) * VIEWBOX_HEIGHT;
+          return (
+            <rect
+              key={bucket.label}
+              x={index * columnWidth + columnWidth * 0.15}
+              y={VIEWBOX_HEIGHT - height}
+              width={columnWidth * 0.7}
+              height={height}
+              fill="currentColor"
+            >
+              <title>{`${bucket.label}: ${formatTokens(bucket.totalTokens)} tokens`}</title>
+            </rect>
+          );
+        })}
+      </svg>
+      <div className="flex flex-wrap justify-between gap-x-3 text-[9px] text-doom-faint">
+        <span>{buckets[0]?.label ?? ''}</span>
+        {buckets.length > 1 ? <span>peak {formatTokens(max)}</span> : null}
+        <span>
+          {buckets.length === 1
+            ? `one ${unit}bucket, ${formatTokens(max)}; pick a shorter period for finer buckets`
+            : `${String(buckets.length)} ${unit}buckets`}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/default/doompi-log/src/web/charts/chartScale.ts
+++ b/packages/default/doompi-log/src/web/charts/chartScale.ts
@@ -1,0 +1,47 @@
+/**
+ * The arithmetic behind the charts, kept out of the components so it can be
+ * tested as plain functions rather than through a render.
+ *
+ * There is no charting library in the cockpit bundle and the plugin import
+ * allowlist would not admit one, so these are the primitives the SVG is drawn
+ * from. They are deliberately small: a bar length and a tick set, nothing that
+ * pretends to be a plotting engine.
+ */
+
+/** Bar length as a fraction of the track, guarding the all-zero series. */
+export function barFraction(value: number, max: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  if (!Number.isFinite(max) || max <= 0) return 0;
+  return Math.min(1, value / max);
+}
+
+/** The largest value in a series, or 0 for an empty one. */
+export function seriesMax(values: readonly number[]): number {
+  return values.reduce((highest, value) => (value > highest ? value : highest), 0);
+}
+
+/**
+ * Compact token counts. Charts label axes and bars in a few characters, and a
+ * raw nine-digit total makes every row the same illegible width.
+ */
+export function formatTokens(value: number): string {
+  // A field the hub did not send is unknown, not zero. Rendering it as '0'
+  // states a fact nobody measured, which is how a version skew between the
+  // page bundle and the hub API turns into a confident wrong number.
+  if (!Number.isFinite(value)) return '\u2014';
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+  return String(Math.round(value));
+}
+
+/**
+ * Evenly spaced x positions for a series, in the 0..1 range.
+ *
+ * A single point sits at the left edge rather than dividing by zero, which is
+ * what a one-bucket timeline is: the sink answered, there is just one day.
+ */
+export function evenPositions(count: number): number[] {
+  if (count <= 0) return [];
+  if (count === 1) return [0];
+  return Array.from({ length: count }, (_, index) => index / (count - 1));
+}

--- a/packages/default/doompi-log/src/web/index.ts
+++ b/packages/default/doompi-log/src/web/index.ts
@@ -1,0 +1,23 @@
+import { defineWebPlugin } from '@agimon-ai/doompi-web-contracts';
+import { MetricsPanel } from './MetricsPanel.tsx';
+
+/**
+ * This package's cockpit presence: one settings page.
+ *
+ * The page is drawn rather than declared as fields because it has nothing to
+ * write. What a reader cannot otherwise reach is where the tokens and the cost
+ * went, and that answer is a shape, not a value in a config file. The TUI
+ * already answers it behind SPC h l; this is the same question asked from the
+ * browser.
+ */
+export const webPlugin = defineWebPlugin({
+  id: 'log',
+  settingsPanels: [
+    {
+      id: 'metrics',
+      label: 'metrics',
+      detail: 'where this machine spent its tokens and its money',
+      component: MetricsPanel,
+    },
+  ],
+});

--- a/packages/default/doompi-log/src/web/metricsApi.ts
+++ b/packages/default/doompi-log/src/web/metricsApi.ts
@@ -1,0 +1,114 @@
+import { sealedTransport } from '@agimon-ai/doompi-web-security/browser';
+import {
+  isMetricsUnavailable,
+  issuesUrl,
+  metricsUrl,
+  type MetricsDimension,
+  type MetricsPeriod,
+  type MetricsResponse,
+  type IssuesResponse,
+} from '../types/webMetrics.ts';
+
+/**
+ * The page's half of this package's metrics API. The only place the cockpit
+ * talks HTTP to the hub for metrics, so if the transport ever changes, it
+ * changes here alone.
+ *
+ * The transport is the shared sealed one rather than bare fetch: a plugin
+ * calling fetch directly sends plaintext to the tunnel's relay.
+ */
+
+const UNREACHABLE = 'The cockpit hub is unreachable.';
+
+/**
+ * A hub with no package APIs mounted serves the SPA shell for this route, so
+ * the answer is a 200 of HTML rather than an error status. Reported as an
+ * uninstalled feature, which is what it is.
+ */
+const NO_API_DETAIL = 'This cockpit is running a bundle without the log package API, so there are no metrics to read.';
+
+const NO_API: MetricsResponse = { unavailable: 'no-api', detail: NO_API_DETAIL };
+
+export type MetricsResult = { report: MetricsResponse } | { error: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Reads one report.
+ *
+ * A missing sink is not an error here: the route answers it as an
+ * `unavailable` body, so the page can name which of the empty states it is in
+ * rather than showing one generic failure.
+ */
+export async function fetchMetrics(
+  dimension: MetricsDimension,
+  period: MetricsPeriod,
+  focus?: string,
+  signal?: AbortSignal,
+): Promise<MetricsResult> {
+  let response: Response;
+  try {
+    response = await sealedTransport.fetch(metricsUrl(dimension, period, focus), { signal });
+  } catch (error) {
+    // An aborted request is the caller replacing it, not a failure to report.
+    if (error instanceof DOMException && error.name === 'AbortError') return { error: '' };
+    return { error: UNREACHABLE };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    // Unparseable and successful means the SPA fallback answered, so the route
+    // is not mounted. Unparseable and failed is a hub that broke mid-response.
+    if (response.ok) return { report: NO_API };
+    return { error: `The hub answered ${String(response.status)}.` };
+  }
+
+  if (!isRecord(body)) return { error: 'The hub returned a response the cockpit could not read.' };
+  if (!response.ok) {
+    const detail = typeof body.error === 'string' ? body.error : `The hub answered ${String(response.status)}.`;
+    return { error: detail };
+  }
+
+  const report = body as unknown as MetricsResponse;
+  if (!isMetricsUnavailable(report) && !Array.isArray(report.groups)) {
+    return { error: 'The hub returned a report the cockpit could not read.' };
+  }
+  return { report };
+}
+
+export type IssuesResult = { issues: IssuesResponse } | { error: string };
+
+/**
+ * Reads the detail behind the issue count.
+ *
+ * Separate call because the hub answers it from a subprocess: folding it into
+ * the report would make every refresh wait on the slowest transport.
+ */
+export async function fetchIssues(focus?: string, signal?: AbortSignal): Promise<IssuesResult> {
+  let response: Response;
+  try {
+    response = await sealedTransport.fetch(issuesUrl(focus), { signal });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') return { error: '' };
+    return { error: UNREACHABLE };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    if (response.ok) return { issues: { unavailable: 'no-api', detail: NO_API_DETAIL } };
+    return { error: `The hub answered ${String(response.status)}.` };
+  }
+
+  if (!isRecord(body)) return { error: 'The hub returned a response the cockpit could not read.' };
+  if (!response.ok) {
+    const detail = typeof body.error === 'string' ? body.error : `The hub answered ${String(response.status)}.`;
+    return { error: detail };
+  }
+  return { issues: body as unknown as IssuesResponse };
+}

--- a/packages/default/doompi-log/src/web/tsconfig.json
+++ b/packages/default/doompi-log/src/web/tsconfig.json
@@ -19,5 +19,5 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]
   },
-  "include": [".", "../types", "../exports/webClient.ts"]
+  "include": [".", "../types", "../exports/webClient.ts", "../../tests/web"]
 }

--- a/packages/default/doompi-log/src/web/tsconfig.json
+++ b/packages/default/doompi-log/src/web/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": [".", "../types", "../exports/webClient.ts"]
+}

--- a/packages/default/doompi-log/tests/chartScale.test.ts
+++ b/packages/default/doompi-log/tests/chartScale.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { barFraction, evenPositions, formatTokens, seriesMax } from '../src/web/charts/chartScale.ts';
+
+/**
+ * The chart arithmetic, tested as functions. The failure that matters here is
+ * a bar drawn off its track or a divide by zero on an empty series, both of
+ * which are arithmetic, not rendering.
+ */
+
+describe('barFraction', () => {
+  it('scales a value against the series peak', () => {
+    expect(barFraction(50, 200)).toBe(0.25);
+    expect(barFraction(200, 200)).toBe(1);
+  });
+
+  it('never exceeds the track', () => {
+    expect(barFraction(500, 200)).toBe(1);
+  });
+
+  it('collapses rather than dividing by zero on an all-zero series', () => {
+    // A period the sink answered with zero tokens is a real state, not a bug,
+    // so it draws no bar instead of NaN.
+    expect(barFraction(0, 0)).toBe(0);
+    expect(barFraction(10, 0)).toBe(0);
+  });
+
+  it('treats a negative or non-finite value as no bar', () => {
+    expect(barFraction(-5, 100)).toBe(0);
+    expect(barFraction(Number.NaN, 100)).toBe(0);
+  });
+});
+
+describe('seriesMax', () => {
+  it('is zero for an empty series', () => {
+    expect(seriesMax([])).toBe(0);
+  });
+
+  it('finds the peak', () => {
+    expect(seriesMax([3, 91, 7])).toBe(91);
+  });
+});
+
+describe('formatTokens', () => {
+  it('compacts thousands and millions', () => {
+    expect(formatTokens(999)).toBe('999');
+    expect(formatTokens(1_500)).toBe('1.5k');
+    expect(formatTokens(2_400_000)).toBe('2.4M');
+  });
+});
+
+describe('evenPositions', () => {
+  it('puts a lone point at the left edge instead of dividing by zero', () => {
+    expect(evenPositions(1)).toEqual([0]);
+  });
+
+  it('spans the full width for a longer series', () => {
+    expect(evenPositions(3)).toEqual([0, 0.5, 1]);
+  });
+
+  it('is empty for no points', () => {
+    expect(evenPositions(0)).toEqual([]);
+  });
+});

--- a/packages/default/doompi-log/tests/hubApi.test.ts
+++ b/packages/default/doompi-log/tests/hubApi.test.ts
@@ -1,0 +1,246 @@
+import type { LogMetricsReport } from '@agimon-ai/log-sink-mcp';
+import { describe, expect, it, vi } from 'vitest';
+import { createLogHubApi } from '../src/adapters/hubApi.ts';
+import type { IssuesSource } from '../src/types/issuesSource.ts';
+import type { IssuesView, MetricsReport, MetricsUnavailable } from '../src/types/webMetrics.ts';
+import type { MetricsSource } from '../src/types/metricsSource.ts';
+
+/**
+ * The hub route is the whole browser-facing surface of this package, so these
+ * exercise it through `fetch` rather than by calling the handler, which is what
+ * the host does.
+ */
+
+function reportWith(overrides: Partial<LogMetricsReport> = {}): LogMetricsReport {
+  return {
+    generatedAt: new Date('2026-01-02T03:04:05.000Z'),
+    groupBy: 'model',
+    period: 'week',
+    bucket: 'day',
+    filters: {},
+    timeline: [{ label: '2026-01-02', totalTokens: 300, inputTokens: 200, outputTokens: 100 }],
+    totals: {
+      totalTokens: 300,
+      inputTokens: 200,
+      outputTokens: 100,
+      cachedInputTokens: 4000,
+      reasoningOutputTokens: 12,
+      groupCount: 2,
+      failedGroups: 1,
+      issueCount: 4,
+    },
+    groups: [{ key: 'sonnet', totalTokens: 300, inputTokens: 200, outputTokens: 100, issueCount: 4, failed: true }],
+    tools: { returnedTools: 1, rows: [{ toolName: 'bash', invocationCount: 7, toolCallTurn: { p90TotalTokens: 90 } }] },
+    ...overrides,
+  } as unknown as LogMetricsReport;
+}
+
+function sourceReturning(report: LogMetricsReport, transport: 'http' | 'cli' = 'http'): MetricsSource {
+  return {
+    query: vi.fn().mockResolvedValue(report),
+    lastTransport: () => transport,
+  } as unknown as MetricsSource;
+}
+
+describe('the log hub API', () => {
+  it('projects the sink report onto the wire shape the page reads', async () => {
+    const source = sourceReturning(reportWith());
+    const app = createLogHubApi({ source });
+
+    const response = await app.fetch(new Request('http://hub/metrics?dimension=model&period=week'));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as MetricsReport;
+
+    expect(body.dimension).toBe('model');
+    expect(body.transport).toBe('http');
+    // cachedTokens is carried because it is usually the bulk of totalTokens,
+    // and a page showing only in and out beside the total implies a breakdown
+    // that does not add up.
+    expect(body.totals).toEqual({
+      totalTokens: 300,
+      inputTokens: 200,
+      outputTokens: 100,
+      cachedTokens: 4000,
+      reasoningTokens: 12,
+      groupCount: 2,
+      failedGroups: 1,
+      issueCount: 4,
+    });
+    expect(body.bucketUnit).toBe('day');
+    expect(body.timeline).toEqual([{ label: '2026-01-02', totalTokens: 300, inputTokens: 200, outputTokens: 100 }]);
+    expect(body.groups[0]).toEqual({
+      key: 'sonnet',
+      totalTokens: 300,
+      inputTokens: 200,
+      outputTokens: 100,
+      issueCount: 4,
+      failed: true,
+    });
+    // Calls are exact; the token figure is the turn p90 the sink attributes,
+    // never a sum, which would multiply shared turns across tools.
+    expect(body.groups).toHaveLength(1);
+    expect(body.tools).toEqual([{ name: 'bash', calls: 7, p90TotalTokens: 90 }]);
+  });
+
+  it('asks the sink for the requested dimension and period', async () => {
+    const source = sourceReturning(reportWith({ groupBy: 'session', period: 'day' }));
+    const app = createLogHubApi({ source });
+
+    await app.fetch(new Request('http://hub/metrics?dimension=session&period=day'));
+
+    expect(source.query).toHaveBeenCalledWith(expect.objectContaining({ groupBy: 'session', period: 'day' }));
+  });
+
+  it('refuses a dimension the sink has no data for rather than querying it', async () => {
+    const source = sourceReturning(reportWith());
+    const app = createLogHubApi({ source });
+
+    // 'workflow-run' is a real sink dimension, but no DoomPi package emits the
+    // attribute, so the page never offers it and the route never forwards it.
+    const response = await app.fetch(new Request('http://hub/metrics?dimension=workflow-run&period=week'));
+
+    expect(response.status).toBe(400);
+    expect(source.query).not.toHaveBeenCalled();
+  });
+
+  it('reports a sink that answered nothing as no-data rather than an empty chart', async () => {
+    const empty = reportWith({
+      timeline: [],
+      groups: [],
+      tools: { returnedTools: 0, rows: [] },
+      totals: {
+        totalTokens: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedInputTokens: 0,
+        reasoningOutputTokens: 0,
+        groupCount: 0,
+        failedGroups: 0,
+        issueCount: 0,
+      },
+    } as unknown as Partial<LogMetricsReport>);
+    const app = createLogHubApi({ source: sourceReturning(empty) });
+
+    const body = (await (await app.fetch(new Request('http://hub/metrics'))).json()) as MetricsUnavailable;
+
+    expect(body.unavailable).toBe('no-data');
+  });
+
+  it('reports both transports declining as absence, not as a fault', async () => {
+    const source = {
+      query: vi.fn().mockRejectedValue(new Error('sink is not running')),
+      lastTransport: () => undefined,
+    } as unknown as MetricsSource;
+    const app = createLogHubApi({ source });
+
+    const response = await app.fetch(new Request('http://hub/metrics'));
+
+    // A machine that has never run the sink is the ordinary case, so the page
+    // gets a state it can name rather than a 500 it has to render as a crash.
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as MetricsUnavailable;
+    expect(body.unavailable).toBe('no-sink');
+    expect(body.detail).toContain('sink is not running');
+  });
+
+  it('forwards a focus as the filter field that dimension uses', async () => {
+    const source = sourceReturning(reportWith({ filters: { model: ['sonnet'] } } as Partial<LogMetricsReport>));
+    const app = createLogHubApi({ source });
+
+    const body = (await (
+      await app.fetch(new Request('http://hub/metrics?dimension=model&period=week&focus=sonnet'))
+    ).json()) as MetricsReport;
+
+    expect(source.query).toHaveBeenCalledWith(expect.objectContaining({ filter: { model: 'sonnet' } }));
+    expect(body.focus).toBe('sonnet');
+  });
+
+  it('maps the focus onto sessionId and agentName for those dimensions', async () => {
+    const source = sourceReturning(reportWith({ groupBy: 'agent' } as Partial<LogMetricsReport>));
+    const app = createLogHubApi({ source });
+
+    await app.fetch(new Request('http://hub/metrics?dimension=agent&focus=reviewer'));
+
+    expect(source.query).toHaveBeenCalledWith(expect.objectContaining({ filter: { agentName: 'reviewer' } }));
+  });
+
+  it('omits the focus when the sink did not echo it back', async () => {
+    // An older daemon ignores an unknown filter and answers with everything.
+    // Reporting the requested value here would label the machine's whole
+    // usage as one model's, so the page is told the narrowing did not happen.
+    const source = sourceReturning(reportWith({ filters: {} } as Partial<LogMetricsReport>));
+    const app = createLogHubApi({ source });
+
+    const body = (await (
+      await app.fetch(new Request('http://hub/metrics?dimension=model&focus=sonnet'))
+    ).json()) as MetricsReport;
+
+    expect(body.focus).toBeUndefined();
+  });
+
+  it('accepts the ISO string both transports actually return for generatedAt', async () => {
+    // LogMetricsReport types generatedAt as Date, but the HTTP and CLI
+    // transports both parse JSON, so a real response carries a string. A
+    // fixture built with `new Date()` hides this; production hits it always.
+    const source = sourceReturning(
+      reportWith({ generatedAt: '2026-01-02T03:04:05.000Z' } as unknown as Partial<LogMetricsReport>),
+    );
+    const app = createLogHubApi({ source });
+
+    const response = await app.fetch(new Request('http://hub/metrics?dimension=model'));
+
+    expect(response.status).toBe(200);
+    expect(((await response.json()) as MetricsReport).generatedAt).toBe('2026-01-02T03:04:05.000Z');
+  });
+
+  it('still accepts a real Date, which the in-process reader returns', async () => {
+    const source = sourceReturning(reportWith({ generatedAt: new Date('2026-05-06T07:08:09.000Z') }));
+    const app = createLogHubApi({ source });
+
+    const body = (await (await app.fetch(new Request('http://hub/metrics'))).json()) as MetricsReport;
+
+    expect(body.generatedAt).toBe('2026-05-06T07:08:09.000Z');
+  });
+
+  it('serves the issue detail the metrics report cannot carry', async () => {
+    const issues = {
+      query: vi.fn().mockResolvedValue({
+        totalIssues: 69,
+        uniqueIncidents: 27,
+        byCategory: { tool_failure: 33 },
+        byTool: { bash: 25 },
+        byErrorType: { ENOENT: 20 },
+        samples: [],
+      }),
+    } as unknown as IssuesSource;
+    const app = createLogHubApi({ source: sourceReturning(reportWith()), issues });
+
+    const body = (await (await app.fetch(new Request('http://hub/issues'))).json()) as IssuesView;
+
+    // byTool is the per-tool failure count; the sink's metrics tool rows have
+    // an invocation count and no error field, so this is the only source of it.
+    expect(body.byTool).toEqual({ bash: 25 });
+    expect(body.totalIssues).toBe(69);
+  });
+
+  it('narrows the issue detail to a focused session', async () => {
+    const issues = { query: vi.fn().mockResolvedValue({ samples: [] }) } as unknown as IssuesSource;
+    const app = createLogHubApi({ source: sourceReturning(reportWith()), issues });
+
+    await app.fetch(new Request('http://hub/issues?focus=id_10851018'));
+
+    expect(issues.query).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'id_10851018' }));
+  });
+
+  it('reports a failing issues subprocess as absence, not as a fault', async () => {
+    const issues = {
+      query: vi.fn().mockRejectedValue(new Error('log-sink-mcp is not installed')),
+    } as unknown as IssuesSource;
+    const app = createLogHubApi({ source: sourceReturning(reportWith()), issues });
+
+    const response = await app.fetch(new Request('http://hub/issues'));
+
+    expect(response.status).toBe(200);
+    expect(((await response.json()) as MetricsUnavailable).unavailable).toBe('no-sink');
+  });
+});

--- a/packages/default/doompi-log/tests/issueGrouping.test.ts
+++ b/packages/default/doompi-log/tests/issueGrouping.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { groupIssues, groupingKey } from '../src/types/issueGrouping.ts';
+import type { IssueSample } from '../src/types/webMetrics.ts';
+
+/**
+ * The ranking is the whole point of the issues view, so it is tested as a
+ * function. Two behaviours matter: the sink repeats fingerprints and those
+ * repeats must merge, and the order must be by how often a problem happened
+ * rather than by when it last did.
+ */
+
+function sample(overrides: Partial<IssueSample> = {}): IssueSample {
+  return {
+    fingerprint: 'fp',
+    occurrenceCount: 1,
+    category: 'log_error',
+    timestamp: '2026-09-02T01:00:00.000Z',
+    level: 'warn',
+    message: 'msg',
+    detail: 'detail',
+    tool: null,
+    errorType: null,
+    agentName: null,
+    model: null,
+    statusCode: null,
+    ...overrides,
+  };
+}
+
+describe('grouping issues', () => {
+  it('merges repeats of one fingerprint and sums their occurrences', () => {
+    // The sink emitted 'tool_failure|pi|bash||pi.tool_result' three times.
+    // Left unmerged, one problem appears three times at a third of its weight.
+    const groups = groupIssues([
+      sample({ fingerprint: 'bash', occurrenceCount: 4, detail: 'pi.tool_result' }),
+      sample({ fingerprint: 'bash', occurrenceCount: 4, detail: 'pi.tool_result' }),
+      sample({ fingerprint: 'bash', occurrenceCount: 2, detail: 'pi.tool_result' }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.occurrences).toBe(10);
+    expect(groups[0]?.members).toHaveLength(3);
+  });
+
+  it('ranks by occurrences, not by recency', () => {
+    const groups = groupIssues([
+      sample({ fingerprint: 'rare', detail: 'rare', occurrenceCount: 1, timestamp: '2026-09-02T09:00:00.000Z' }),
+      sample({ fingerprint: 'common', detail: 'common', occurrenceCount: 20, timestamp: '2026-09-01T01:00:00.000Z' }),
+    ]);
+
+    expect(groups.map((group) => group.detail)).toEqual(['common', 'rare']);
+  });
+
+  it('keeps problems apart when a shared fingerprint hides different details', () => {
+    const groups = groupIssues([
+      sample({ fingerprint: 'shared', detail: 'missing binary a' }),
+      sample({ fingerprint: 'shared', detail: 'missing binary b' }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+  });
+
+  it('falls back to category and message when the sink sent no fingerprint', () => {
+    expect(groupingKey(sample({ fingerprint: '', category: 'api_error', message: 'boom', detail: 'd' }))).toBe(
+      'api_error|boom|d',
+    );
+  });
+
+  it('carries the newest timestamp and fills identifying fields from any member', () => {
+    const groups = groupIssues([
+      sample({ occurrenceCount: 1, timestamp: '2026-09-01T00:00:00.000Z', agentName: null, tool: 'bash' }),
+      sample({ occurrenceCount: 1, timestamp: '2026-09-03T00:00:00.000Z', agentName: 'reviewer', tool: null }),
+    ]);
+
+    expect(groups[0]?.lastSeen).toBe('2026-09-03T00:00:00.000Z');
+    // One incident missing the agent must not blank it for the merged row.
+    expect(groups[0]?.agentName).toBe('reviewer');
+    expect(groups[0]?.tool).toBe('bash');
+  });
+
+  it('is empty for no issues', () => {
+    expect(groupIssues([])).toEqual([]);
+  });
+});

--- a/packages/default/doompi-log/tests/issuesSource.test.ts
+++ b/packages/default/doompi-log/tests/issuesSource.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createIssuesSource } from '../src/adapters/node/issuesSource.ts';
+
+/**
+ * The CLI's output is a foreign process's JSON, so the narrowing matters more
+ * than the happy path: a sink one version off must degrade, not throw.
+ */
+
+describe('the issues source', () => {
+  it('narrows the sink report onto the shape the page reads', async () => {
+    const cliRunner = vi.fn().mockResolvedValue({
+      totalIssues: 69,
+      uniqueIncidents: 27,
+      byCategory: { tool_failure: 33, log_error: 36 },
+      byTool: { bash: 25 },
+      byErrorType: { ENOENT: 20 },
+      issues: [
+        {
+          fingerprint: 'tool_failure|pi|bash||pi.tool_result',
+          occurrenceCount: 4,
+          category: 'tool_failure',
+          timestamp: '2026-09-02T01:05:07.100Z',
+          level: 'warn',
+          message: 'pi.tool_result',
+          detail: 'command not found',
+          tool: 'bash',
+          errorType: 'ENOENT',
+          agentName: 'pi',
+          model: null,
+          statusCode: null,
+        },
+      ],
+    });
+
+    const report = await createIssuesSource({ cliRunner }).query({ limit: 25 });
+
+    expect(report.totalIssues).toBe(69);
+    expect(report.byTool).toEqual({ bash: 25 });
+    expect(report.samples).toEqual([
+      {
+        fingerprint: 'tool_failure|pi|bash||pi.tool_result',
+        // The number a reader acts on: this exact problem happened four times.
+        occurrenceCount: 4,
+        category: 'tool_failure',
+        timestamp: '2026-09-02T01:05:07.100Z',
+        level: 'warn',
+        message: 'pi.tool_result',
+        detail: 'command not found',
+        tool: 'bash',
+        errorType: 'ENOENT',
+        agentName: 'pi',
+        model: null,
+        statusCode: null,
+      },
+    ]);
+  });
+
+  it('treats a sink that sent no occurrence count as one occurrence', async () => {
+    const cliRunner = vi.fn().mockResolvedValue({ issues: [{ category: 'log_error', message: 'boom' }] });
+
+    const report = await createIssuesSource({ cliRunner }).query({ limit: 5 });
+
+    expect(report.samples[0]?.occurrenceCount).toBe(1);
+    // A sink leaves detail null when the message already is the detail.
+    expect(report.samples[0]?.detail).toBe('boom');
+  });
+
+  it('degrades rather than throwing when a sink omits fields', async () => {
+    const cliRunner = vi.fn().mockResolvedValue({ totalIssues: 3 });
+
+    const report = await createIssuesSource({ cliRunner }).query({ limit: 5 });
+
+    expect(report).toEqual({
+      totalIssues: 3,
+      uniqueIncidents: 0,
+      byCategory: {},
+      byTool: {},
+      byErrorType: {},
+      samples: [],
+    });
+  });
+
+  it('drops count entries that are not numbers', async () => {
+    const cliRunner = vi.fn().mockResolvedValue({ byTool: { bash: 4, broken: 'lots' } });
+
+    expect((await createIssuesSource({ cliRunner }).query({ limit: 5 })).byTool).toEqual({ bash: 4 });
+  });
+
+  it('refuses output that is not a report at all', async () => {
+    const cliRunner = vi.fn().mockResolvedValue('not a report');
+
+    await expect(createIssuesSource({ cliRunner }).query({ limit: 5 })).rejects.toThrow(/cannot read/);
+  });
+
+  it('forwards the sample limit and the session filter to the CLI', async () => {
+    const cliRunner = vi.fn().mockResolvedValue({});
+
+    await createIssuesSource({ cliRunner }).query({ limit: 25, sessionId: 'id_abc' });
+
+    expect(cliRunner).toHaveBeenCalledWith({ limit: 25, sessionId: 'id_abc' });
+  });
+});

--- a/packages/default/doompi-log/tests/issuesSourceCli.test.ts
+++ b/packages/default/doompi-log/tests/issuesSourceCli.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The subprocess path, which every other issues test bypasses by injecting a
+ * runner. What matters here is the argv the CLI is actually given and what
+ * happens when it fails, since this is the only transport for issue detail.
+ */
+
+const { resolveLogSinkInstance, execFile } = vi.hoisted(() => ({
+  resolveLogSinkInstance: vi.fn(),
+  execFile: vi.fn(),
+}));
+
+vi.mock('@agimon-ai/log-sink-mcp', () => ({ resolveLogSinkInstance }));
+vi.mock('node:child_process', () => ({ execFile }));
+
+const { createIssuesSource } = await import('../src/adapters/node/issuesSource.ts');
+
+const INSTANCE = { scope: 'local', dbPath: '/tmp/sink/session.db', registeredName: '@agimon-ai/doompi-log' };
+
+type ExecDone = (error: Error | null, stdout: string, stderr: string) => void;
+
+function answerWith(stdout: string, error: Error | null = null, stderr = ''): void {
+  execFile.mockImplementation((_bin: string, _args: string[], _options: unknown, done: ExecDone) => {
+    done(error, stdout, stderr);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resolveLogSinkInstance.mockReturnValue(INSTANCE);
+});
+
+describe('the issues subprocess', () => {
+  it('asks the CLI for agent issues against the resolved database', async () => {
+    answerWith(JSON.stringify({ totalIssues: 2 }));
+
+    await createIssuesSource({}).query({ limit: 25 });
+
+    const args = execFile.mock.calls[0]?.[1] as string[];
+    expect(args).toContain('logs');
+    expect(args).toContain('agent-issues');
+    expect(args[args.indexOf('--limit') + 1]).toBe('25');
+    // The database is passed explicitly rather than left to the subprocess to
+    // resolve from an inherited cwd, which could be a different instance.
+    expect(args[args.indexOf('--db-path') + 1]).toBe('/tmp/sink/session.db');
+    expect(args).not.toContain('--session-id');
+  });
+
+  it('adds the session filter only when one was asked for', async () => {
+    answerWith(JSON.stringify({}));
+
+    await createIssuesSource({}).query({ limit: 5, sessionId: 'id_abc' });
+
+    const args = execFile.mock.calls[0]?.[1] as string[];
+    expect(args[args.indexOf('--session-id') + 1]).toBe('id_abc');
+  });
+
+  it('omits the database flag when no instance resolved', async () => {
+    resolveLogSinkInstance.mockReturnValue(undefined);
+    answerWith(JSON.stringify({}));
+
+    await createIssuesSource({}).query({ limit: 5 });
+
+    expect(execFile.mock.calls[0]?.[1] as string[]).not.toContain('--db-path');
+  });
+
+  it('reports the subprocess stderr rather than a bare exit code', async () => {
+    answerWith('', new Error('exit 1'), 'log-sink-mcp: unknown command');
+
+    await expect(createIssuesSource({}).query({ limit: 5 })).rejects.toThrow('log-sink-mcp: unknown command');
+  });
+
+  it('falls back to the error message when the subprocess said nothing', async () => {
+    answerWith('', new Error('spawn ENOENT'), '');
+
+    await expect(createIssuesSource({}).query({ limit: 5 })).rejects.toThrow('spawn ENOENT');
+  });
+
+  it('refuses output that is not JSON', async () => {
+    answerWith('not json at all');
+
+    await expect(createIssuesSource({}).query({ limit: 5 })).rejects.toThrow(/cannot read/);
+  });
+});

--- a/packages/default/doompi-log/tests/metricsApi.test.ts
+++ b/packages/default/doompi-log/tests/metricsApi.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The browser half. What matters here is not the happy path, which is a JSON
+ * parse, but the three ways this can go wrong on a real page: the hub is
+ * unreachable, the caller replaced the request, and the route answered with an
+ * unavailable body that is a state rather than a failure.
+ */
+
+const { sealedFetch } = vi.hoisted(() => ({ sealedFetch: vi.fn() }));
+vi.mock('@agimon-ai/doompi-web-security/browser', () => ({ sealedTransport: { fetch: sealedFetch } }));
+
+const { fetchIssues, fetchMetrics } = await import('../src/web/metricsApi.ts');
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+describe('the metrics browser client', () => {
+  beforeEach(() => {
+    sealedFetch.mockReset();
+  });
+
+  it('reads through the sealed transport, never bare fetch', async () => {
+    sealedFetch.mockResolvedValue(jsonResponse({ groups: [], timeline: [], tools: [] }));
+
+    await fetchMetrics('model', 'week');
+
+    // A plugin calling fetch directly would send plaintext to the tunnel relay.
+    expect(sealedFetch).toHaveBeenCalledTimes(1);
+    expect(sealedFetch.mock.calls[0]?.[0]).toContain('/api/plugin/log/metrics');
+  });
+
+  it('passes the dimension, period and focus as query parameters', async () => {
+    sealedFetch.mockResolvedValue(jsonResponse({ groups: [], timeline: [], tools: [] }));
+
+    await fetchMetrics('session', 'day', 'abc123');
+
+    const url = String(sealedFetch.mock.calls[0]?.[0]);
+    expect(url).toContain('dimension=session');
+    expect(url).toContain('period=day');
+    expect(url).toContain('focus=abc123');
+  });
+
+  it('omits an empty focus rather than sending a blank filter', async () => {
+    sealedFetch.mockResolvedValue(jsonResponse({ groups: [], timeline: [], tools: [] }));
+
+    await fetchMetrics('model', 'week', '');
+
+    expect(String(sealedFetch.mock.calls[0]?.[0])).not.toContain('focus=');
+  });
+
+  it('passes an unavailable body through as a report, not as an error', async () => {
+    sealedFetch.mockResolvedValue(jsonResponse({ unavailable: 'no-sink', detail: 'nothing listening' }));
+
+    const result = await fetchMetrics('model', 'week');
+
+    // The page needs to name which empty state it is in, so absence must not
+    // be flattened into the generic error string.
+    expect(result).toEqual({ report: { unavailable: 'no-sink', detail: 'nothing listening' } });
+  });
+
+  it('reports an unreachable hub', async () => {
+    sealedFetch.mockRejectedValue(new TypeError('network down'));
+
+    expect(await fetchMetrics('model', 'week')).toEqual({ error: 'The cockpit hub is unreachable.' });
+  });
+
+  it('treats an aborted request as the caller replacing it, not as a failure', async () => {
+    sealedFetch.mockRejectedValue(new DOMException('aborted', 'AbortError'));
+
+    // An empty message so the panel leaves whatever the next request renders.
+    expect(await fetchMetrics('model', 'week')).toEqual({ error: '' });
+  });
+
+  it('surfaces the route error message on a non-ok answer', async () => {
+    sealedFetch.mockResolvedValue(jsonResponse({ error: "Unknown dimension 'workflow-run'." }, 400));
+
+    expect(await fetchMetrics('model', 'week')).toEqual({ error: "Unknown dimension 'workflow-run'." });
+  });
+
+  it('reads a successful non-JSON answer as the API not being mounted', async () => {
+    // A hub serving a bundle without package APIs answers this route with the
+    // SPA shell: status 200, body HTML. That is an uninstalled feature, not a
+    // corrupt response, and the page must be able to say so.
+    sealedFetch.mockResolvedValue(new Response('<!doctype html>', { status: 200 }));
+
+    const result = await fetchMetrics('model', 'week');
+
+    expect(result).toEqual({ report: expect.objectContaining({ unavailable: 'no-api' }) });
+  });
+
+  it('reports the status when a failed answer is not JSON either', async () => {
+    sealedFetch.mockResolvedValue(new Response('bad gateway', { status: 502 }));
+
+    expect(await fetchMetrics('model', 'week')).toEqual({ error: 'The hub answered 502.' });
+  });
+});
+
+describe('the issues browser client', () => {
+  beforeEach(() => {
+    sealedFetch.mockReset();
+  });
+
+  it('reads the issues route and returns the view', async () => {
+    sealedFetch.mockResolvedValue(jsonResponse({ totalIssues: 69, byTool: { bash: 25 } }));
+
+    const result = await fetchIssues();
+
+    expect(String(sealedFetch.mock.calls[0]?.[0])).toBe('/api/plugin/log/issues');
+    expect(result).toEqual({ issues: { totalIssues: 69, byTool: { bash: 25 } } });
+  });
+
+  it('forwards a focused session', async () => {
+    sealedFetch.mockResolvedValue(jsonResponse({}));
+
+    await fetchIssues('id_abc');
+
+    expect(String(sealedFetch.mock.calls[0]?.[0])).toBe('/api/plugin/log/issues?focus=id_abc');
+  });
+
+  it('passes an unavailable body through rather than flattening it', async () => {
+    sealedFetch.mockResolvedValue(jsonResponse({ unavailable: 'no-sink', detail: 'not installed' }));
+
+    expect(await fetchIssues()).toEqual({ issues: { unavailable: 'no-sink', detail: 'not installed' } });
+  });
+
+  it('reads a successful non-JSON answer as the API not being mounted', async () => {
+    sealedFetch.mockResolvedValue(new Response('<!doctype html>', { status: 200 }));
+
+    expect(await fetchIssues()).toEqual({ issues: expect.objectContaining({ unavailable: 'no-api' }) });
+  });
+
+  it('reports an unreachable hub and treats an abort as a replacement', async () => {
+    sealedFetch.mockRejectedValueOnce(new TypeError('down'));
+    expect(await fetchIssues()).toEqual({ error: 'The cockpit hub is unreachable.' });
+
+    sealedFetch.mockRejectedValueOnce(new DOMException('aborted', 'AbortError'));
+    expect(await fetchIssues()).toEqual({ error: '' });
+  });
+
+  it('surfaces a route error and a non-JSON failure status', async () => {
+    sealedFetch.mockResolvedValueOnce(jsonResponse({ error: 'boom' }, 500));
+    expect(await fetchIssues()).toEqual({ error: 'boom' });
+
+    sealedFetch.mockResolvedValueOnce(new Response('nope', { status: 502 }));
+    expect(await fetchIssues()).toEqual({ error: 'The hub answered 502.' });
+  });
+});

--- a/packages/default/doompi-log/tests/metricsSource.test.ts
+++ b/packages/default/doompi-log/tests/metricsSource.test.ts
@@ -140,3 +140,65 @@ describe('historical log metrics source', () => {
     expect(source.lastTransport()).toBeUndefined();
   });
 });
+
+describe('narrowing one query to a single group', () => {
+  it('sends each filter the sink names on the query string', async () => {
+    resolveLogSinkPort.mockResolvedValue({ endpoint: 'http://127.0.0.1:4318' });
+    const fetchMock = vi.fn(async (_input: unknown) => new Response(JSON.stringify(REPORT), { status: 200 }));
+    const source = createMetricsSource({
+      ...IDENTITY,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    await source.query({
+      ...QUERY,
+      filter: { model: 'claude-opus-5', provider: 'anthropic', sessionId: 'id_abc', agentName: 'reviewer' },
+    });
+
+    const url = new URL(String(fetchMock.mock.calls[0]?.[0]));
+    expect(url.searchParams.get('model')).toBe('claude-opus-5');
+    expect(url.searchParams.get('provider')).toBe('anthropic');
+    expect(url.searchParams.get('sessionId')).toBe('id_abc');
+    expect(url.searchParams.get('agentName')).toBe('reviewer');
+  });
+
+  it('omits an empty filter value rather than narrowing to nothing', async () => {
+    resolveLogSinkPort.mockResolvedValue({ endpoint: 'http://127.0.0.1:4318' });
+    const fetchMock = vi.fn(async (_input: unknown) => new Response(JSON.stringify(REPORT), { status: 200 }));
+    const source = createMetricsSource({ ...IDENTITY, fetchImpl: fetchMock as unknown as typeof fetch });
+
+    await source.query({ ...QUERY, filter: { model: '' } });
+
+    expect(new URL(String(fetchMock.mock.calls[0]?.[0])).searchParams.has('model')).toBe(false);
+  });
+
+  it('sends the same filters as flags when it falls back to the CLI', async () => {
+    // The two transports must narrow identically, or a daemon that is merely
+    // unreachable would silently widen the reader's query.
+    resolveLogSinkPort.mockResolvedValue(undefined);
+    execFile.mockImplementation((_bin: string, _args: string[], _options: unknown, done: Function) => {
+      done(null, JSON.stringify(REPORT), '');
+    });
+    const source = createMetricsSource({ ...IDENTITY });
+
+    await source.query({ ...QUERY, filter: { model: 'claude-opus-5', sessionId: 'id_abc' } });
+
+    const args = execFile.mock.calls[0]?.[1] as string[];
+    expect(args).toContain('--model');
+    expect(args[args.indexOf('--model') + 1]).toBe('claude-opus-5');
+    expect(args).toContain('--session-id');
+    expect(args[args.indexOf('--session-id') + 1]).toBe('id_abc');
+  });
+
+  it('passes no filter flags when the caller narrowed nothing', async () => {
+    resolveLogSinkPort.mockResolvedValue(undefined);
+    execFile.mockImplementation((_bin: string, _args: string[], _options: unknown, done: Function) => {
+      done(null, JSON.stringify(REPORT), '');
+    });
+
+    await createMetricsSource({ ...IDENTITY }).query(QUERY);
+
+    const args = execFile.mock.calls[0]?.[1] as string[];
+    expect(args.some((arg) => arg.startsWith('--model') || arg.startsWith('--session-id'))).toBe(false);
+  });
+});

--- a/packages/default/doompi-log/tests/packageShape.test.ts
+++ b/packages/default/doompi-log/tests/packageShape.test.ts
@@ -14,6 +14,8 @@ const CONFIG_FILES = ['tsdown.config.ts', 'tsconfig.json', 'vitest.config.ts', '
 const EXPORT_SUBPATHS = [
   '.',
   './extensions/pi',
+  // The hub-scoped metrics API the cockpit host imports; declared in doompiApi.
+  './hub-api',
   './metrics',
   './metricsSource',
   './tui/metricsOverlay',

--- a/packages/default/doompi-log/tests/web/metricsPanel.test.ts
+++ b/packages/default/doompi-log/tests/web/metricsPanel.test.ts
@@ -1,0 +1,306 @@
+import { renderPlugin } from '@agimon-ai/doompi-web-contracts/testing';
+import { describe, expect, it, vi } from 'vitest';
+import type { IssueSample, MetricsBucket, MetricsGroup, MetricsTool } from '../../src/types/webMetrics.ts';
+import { GroupBars } from '../../src/web/charts/GroupBars.tsx';
+import { TimelineChart } from '../../src/web/charts/TimelineChart.tsx';
+import { IssuesDetail } from '../../src/web/IssuesDetail.tsx';
+import { EmptyForReason, FocusNotice } from '../../src/web/MetricsNotice.tsx';
+import { IssuesSection } from '../../src/web/IssuesSection.tsx';
+import { MetricsReportView } from '../../src/web/MetricsReportView.tsx';
+import { MetricsPanel } from '../../src/web/MetricsPanel.tsx';
+
+/**
+ * The drawn parts of the page, rendered to static markup.
+ *
+ * What this catches is a component that throws on a state the page can reach,
+ * which the host would swallow into a blank panel. The states worth proving
+ * are the degenerate ones: no buckets, one bucket, an all-zero series, and a
+ * field an older hub did not send.
+ */
+
+vi.mock('@agimon-ai/doompi-web-security/browser', () => ({ sealedTransport: { fetch: vi.fn() } }));
+
+const REQUEST = () => Promise.resolve(new Response('{}'));
+
+function bucket(label: string, totalTokens: number): MetricsBucket {
+  return { label, totalTokens, inputTokens: 0, outputTokens: 0 };
+}
+
+function group(key: string, totalTokens: number, issueCount = 0): MetricsGroup {
+  return { key, totalTokens, inputTokens: 0, outputTokens: 0, issueCount, failed: issueCount > 0 };
+}
+
+const TOOLS: MetricsTool[] = [{ name: 'bash', calls: 929, p90TotalTokens: 90 }];
+
+function sample(overrides: Partial<IssueSample> = {}): IssueSample {
+  return {
+    fingerprint: 'f1',
+    occurrenceCount: 1,
+    category: 'log_error',
+    timestamp: '2026-09-02T01:05:07.100Z',
+    level: 'warn',
+    message: 'Failed to connect to pencil',
+    detail: 'Failed to connect to pencil',
+    tool: null,
+    errorType: null,
+    agentName: null,
+    model: null,
+    statusCode: null,
+    ...overrides,
+  };
+}
+
+describe('the metrics panel', () => {
+  it('mounts before any report has arrived', () => {
+    // First paint happens while the fetch is still in flight, so a panel that
+    // needed a report to render would blank the page on every open.
+    const rendered = renderPlugin(MetricsPanel, { request: REQUEST, requestWithStepUp: REQUEST });
+
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.html).toContain('data-testid="metrics-panel"');
+    // The controls are usable before any data lands, so the reader can change
+    // dimension or period while the first request is still in flight.
+    expect(rendered.includes('refresh')).toBe(true);
+  });
+});
+
+describe('the timeline chart', () => {
+  it('names the bucket unit and points at a shorter period when there is only one', () => {
+    const rendered = renderPlugin(TimelineChart, { buckets: [bucket('2026-09-02', 446)], bucketUnit: 'day' });
+
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.includes('one day bucket')).toBe(true);
+    expect(rendered.includes('pick a shorter period')).toBe(true);
+  });
+
+  it('says nothing about the unit when an older hub did not send one', () => {
+    const rendered = renderPlugin(TimelineChart, { buckets: [bucket('2026-09-02', 446)] });
+
+    // The bug this pins: interpolating an absent unit printed the literal
+    // word 'undefined' into the caption on a real page.
+    expect(rendered.includes('undefined')).toBe(false);
+    expect(rendered.includes('one bucket')).toBe(true);
+  });
+
+  it('renders an all-zero series without dividing by zero', () => {
+    const rendered = renderPlugin(TimelineChart, {
+      buckets: [bucket('a', 0), bucket('b', 0)],
+      bucketUnit: 'hour',
+    });
+
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.html).not.toContain('NaN');
+  });
+
+  it('renders an empty series', () => {
+    expect(renderPlugin(TimelineChart, { buckets: [], bucketUnit: 'day' }).error).toBeUndefined();
+  });
+});
+
+describe('the group bars', () => {
+  it('marks a focused row as pressed and shows issue counts', () => {
+    const rendered = renderPlugin(GroupBars, {
+      groups: [group('sonnet', 300, 4), group('opus', 100)],
+      focus: 'sonnet',
+      onFocus: () => undefined,
+    });
+
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.html).toContain('aria-pressed="true"');
+    expect(rendered.includes('sonnet')).toBe(true);
+    expect(rendered.includes('ok')).toBe(true);
+  });
+
+  it('renders as plain rows when the caller offers no drill-down', () => {
+    const rendered = renderPlugin(GroupBars, { groups: [group('sonnet', 300)] });
+
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.html).not.toContain('<button');
+  });
+});
+
+describe('the issues section', () => {
+  it('explains why the detail is behind a click before it is opened', () => {
+    const rendered = renderPlugin(IssuesSection, { tools: TOOLS });
+
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.includes('show detail')).toBe(true);
+    expect(rendered.includes('no issues endpoint')).toBe(true);
+  });
+});
+
+describe('the report view', () => {
+  const report = {
+    generatedAt: '2026-09-02T01:00:00.000Z',
+    dimension: 'session' as const,
+    period: 'week' as const,
+    bucketUnit: 'day',
+    transport: 'http' as const,
+    totals: {
+      totalTokens: 446_016_281,
+      inputTokens: 4482,
+      outputTokens: 1_235_358,
+      cachedTokens: 223_689_619,
+      reasoningTokens: 210_867,
+      groupCount: 4,
+      failedGroups: 1,
+      issueCount: 69,
+    },
+    timeline: [bucket('2026-09-02', 446_016_281)],
+    groups: [group('id_10851018', 300, 5), group('id_ee555783', 100)],
+    tools: TOOLS,
+  };
+
+  it('draws a whole report without throwing', () => {
+    const rendered = renderPlugin(MetricsReportView, { report, onFocus: () => undefined });
+
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.includes('446.0M')).toBe(true);
+    expect(rendered.includes('69 issues')).toBe(true);
+    expect(rendered.includes('1 of 4 sessions failed')).toBe(true);
+  });
+
+  it('says the named parts do not sum to the total', () => {
+    // The defect this pins: 4.5k in and 1.2M out sat beside 446.0M looking
+    // like a breakdown, while being 0.28% of it.
+    const rendered = renderPlugin(MetricsReportView, { report, onFocus: () => undefined });
+
+    expect(rendered.includes('cache reads')).toBe(true);
+    expect(rendered.includes('do not sum to it')).toBe(true);
+  });
+
+  it('warns that session keys are hashed and cannot be opened', () => {
+    const rendered = renderPlugin(MetricsReportView, { report, onFocus: () => undefined });
+
+    expect(rendered.includes('hashed before export')).toBe(true);
+  });
+
+  it('labels the tool token column as a ranking hint, not a measurement', () => {
+    const rendered = renderPlugin(MetricsReportView, { report, onFocus: () => undefined });
+
+    expect(rendered.includes('call counts are exact')).toBe(true);
+  });
+
+  it('renders a field an older hub omitted as unknown rather than zero', () => {
+    const stale = { ...report, totals: { ...report.totals, cachedTokens: undefined as unknown as number } };
+
+    const rendered = renderPlugin(MetricsReportView, { report: stale, onFocus: () => undefined });
+
+    // '0 cache reads' was on a real page while the hub simply had not sent it.
+    expect(rendered.includes('0 cache reads')).toBe(false);
+    expect(rendered.includes('\u2014 cache reads')).toBe(true);
+  });
+});
+
+describe('the issues detail', () => {
+  const view = {
+    totalIssues: 69,
+    uniqueIncidents: 27,
+    byCategory: { log_error: 36, tool_failure: 33 },
+    byTool: { bash: 25, edit: 3 },
+    byErrorType: { ENOENT: 20 },
+    samples: [
+      sample({ occurrenceCount: 20, detail: 'spawn /Applications/Pen.app/out/mcp-server ENOENT', errorType: 'ENOENT' }),
+      sample({
+        fingerprint: 'f2',
+        occurrenceCount: 4,
+        detail: 'pi.tool_result',
+        tool: 'bash',
+        category: 'tool_failure',
+      }),
+      sample({
+        fingerprint: 'f2',
+        occurrenceCount: 4,
+        detail: 'pi.tool_result',
+        tool: 'bash',
+        category: 'tool_failure',
+      }),
+    ],
+  };
+
+  it('ranks distinct problems by how often each happened', () => {
+    const rendered = renderPlugin(IssuesDetail, { view, tools: TOOLS });
+
+    expect(rendered.error).toBeUndefined();
+    // The 20x spawn failure is the thing to fix, so it leads.
+    expect(rendered.includes('20')).toBe(true);
+    expect(rendered.includes('spawn /Applications/Pen.app/out/mcp-server ENOENT')).toBe(true);
+    // Two incidents share a fingerprint and merge into one 8x row.
+    expect(rendered.includes('2 distinct problems')).toBe(true);
+  });
+
+  it('pairs each tool failure count with its call count from the report', () => {
+    const rendered = renderPlugin(IssuesDetail, { view, tools: TOOLS });
+
+    expect(rendered.includes('of 929 calls')).toBe(true);
+  });
+
+  it('admits when a failing tool has no call count to divide by', () => {
+    // The two reports scan on their own limits, so a tool can appear in the
+    // issues report and not in the ranked tool rows.
+    const rendered = renderPlugin(IssuesDetail, { view, tools: [] });
+
+    expect(rendered.includes('of unknown calls')).toBe(true);
+  });
+
+  it('lists the category breakdown beside the ranked problems', () => {
+    const rendered = renderPlugin(IssuesDetail, { view, tools: TOOLS });
+
+    expect(rendered.includes('tool_failure')).toBe(true);
+    expect(rendered.includes('ENOENT')).toBe(true);
+  });
+});
+
+describe('the page notices', () => {
+  it('names each reason the page has nothing to draw', () => {
+    const cases = [
+      ['no-sink', 'no log sink'],
+      ['no-data', 'nothing recorded yet'],
+      ['no-api', 'metrics not installed'],
+    ] as const;
+
+    for (const [reason, title] of cases) {
+      const rendered = renderPlugin(EmptyForReason, { response: { unavailable: reason, detail: 'why' } });
+      expect(rendered.error).toBeUndefined();
+      expect(rendered.includes(title)).toBe(true);
+      expect(rendered.includes('why')).toBe(true);
+    }
+  });
+
+  it('says nothing when the reader narrowed nothing', () => {
+    const rendered = renderPlugin(FocusNotice, {
+      requested: '',
+      applied: undefined,
+      dimension: 'model',
+      onClear: () => undefined,
+    });
+
+    expect(rendered.html).toBe('');
+  });
+
+  it('confirms a narrowing the sink echoed back', () => {
+    const rendered = renderPlugin(FocusNotice, {
+      requested: 'claude-opus-5',
+      applied: 'claude-opus-5',
+      dimension: 'model',
+      onClear: () => undefined,
+    });
+
+    expect(rendered.includes('narrowed to claude-opus-5')).toBe(true);
+  });
+
+  it('refuses to claim a narrowing the sink ignored', () => {
+    // Trusting the request instead of the echo would label the whole machine's
+    // usage as one model's, which is the worst failure this page can have.
+    const rendered = renderPlugin(FocusNotice, {
+      requested: 'claude-opus-5',
+      applied: undefined,
+      dimension: 'model',
+      onClear: () => undefined,
+    });
+
+    expect(rendered.includes('does not support narrowing by model')).toBe(true);
+    expect(rendered.includes('still everything')).toBe(true);
+    expect(rendered.includes('narrowed to')).toBe(false);
+  });
+});

--- a/packages/default/doompi-log/tests/webMetrics.test.ts
+++ b/packages/default/doompi-log/tests/webMetrics.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isMetricsDimension,
+  isMetricsPeriod,
+  isMetricsUnavailable,
+  issuesUrl,
+  METRICS_DIMENSIONS,
+  metricsUrl,
+} from '../src/types/webMetrics.ts';
+
+/**
+ * The vocabulary both halves share. These guards are the gate the route uses
+ * to refuse a dimension the sink has data for but DoomPi never emits, so they
+ * are worth pinning rather than assuming.
+ */
+
+describe('the metrics wire vocabulary', () => {
+  it('offers only the dimensions DoomPi actually emits', () => {
+    // The sink also groups by workflow-run, workflow-name, job and step. No
+    // package emits those attributes, so offering them would draw empty charts.
+    expect([...METRICS_DIMENSIONS]).toEqual(['session', 'agent', 'model', 'provider']);
+    expect(isMetricsDimension('workflow-run')).toBe(false);
+    expect(isMetricsDimension('model')).toBe(true);
+  });
+
+  it('recognises the periods the sink accepts', () => {
+    expect(isMetricsPeriod('day')).toBe(true);
+    expect(isMetricsPeriod('decade')).toBe(false);
+  });
+
+  it('builds a metrics url, adding focus only when there is one', () => {
+    expect(metricsUrl('model', 'week')).toBe('/api/plugin/log/metrics?dimension=model&period=week');
+    expect(metricsUrl('model', 'week', '')).toBe('/api/plugin/log/metrics?dimension=model&period=week');
+    expect(metricsUrl('model', 'week', 'a b')).toContain('focus=a+b');
+  });
+
+  it('builds an issues url with no query when unfocused', () => {
+    expect(issuesUrl()).toBe('/api/plugin/log/issues');
+    expect(issuesUrl('')).toBe('/api/plugin/log/issues');
+    expect(issuesUrl('id_abc')).toBe('/api/plugin/log/issues?focus=id_abc');
+  });
+
+  it('tells an unavailable body from a report', () => {
+    expect(isMetricsUnavailable({ unavailable: 'no-sink', detail: '' })).toBe(true);
+    expect(
+      isMetricsUnavailable({
+        generatedAt: '',
+        dimension: 'model',
+        period: 'week',
+        bucketUnit: 'day',
+        totals: {
+          totalTokens: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          cachedTokens: 0,
+          reasoningTokens: 0,
+          groupCount: 0,
+          failedGroups: 0,
+          issueCount: 0,
+        },
+        timeline: [],
+        groups: [],
+        tools: [],
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/default/doompi-log/tsconfig.json
+++ b/packages/default/doompi-log/tsconfig.json
@@ -23,5 +23,5 @@
     "types": ["node", "vitest/globals"]
   },
   "include": ["src", "tests", "vitest.config.ts", "tsdown.config.ts"],
-  "exclude": ["node_modules", "dist", "coverage"]
+  "exclude": ["node_modules", "dist", "coverage", "src/web", "src/exports/webClient.ts"]
 }

--- a/packages/default/doompi-log/tsconfig.json
+++ b/packages/default/doompi-log/tsconfig.json
@@ -23,5 +23,5 @@
     "types": ["node", "vitest/globals"]
   },
   "include": ["src", "tests", "vitest.config.ts", "tsdown.config.ts"],
-  "exclude": ["node_modules", "dist", "coverage", "src/web", "src/exports/webClient.ts"]
+  "exclude": ["node_modules", "dist", "coverage", "tests/web", "src/web", "src/exports/webClient.ts"]
 }

--- a/packages/default/doompi-log/tsdown.config.ts
+++ b/packages/default/doompi-log/tsdown.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: { '*': 'src/exports/**/*.ts' },
+  // The web client is shipped as source and compiled into the cockpit bundle,
+  // so this node build must not try to bundle React for a browser entry.
+  entry: { '*': ['src/exports/**/*.ts', '!src/exports/webClient.ts'] },
   clean: true,
   dts: { incremental: true, parallel: false, eager: true },
   exports: false,

--- a/packages/default/doompi-mcp/src/web/McpToolMessage.tsx
+++ b/packages/default/doompi-mcp/src/web/McpToolMessage.tsx
@@ -4,6 +4,7 @@ import {
   MessageItemHeader,
   MessageItemStatus,
   type StatusTone,
+  SyntaxText,
   toolTone,
 } from '@agimon-ai/doompi-web-components';
 import type { ToolMessageRenderProps } from '@agimon-ai/doompi-web-contracts';
@@ -50,9 +51,9 @@ function McpBlock({ block }: { block: McpResultBlock }) {
       );
     case 'resource':
       return block.text !== undefined ? (
-        <pre data-testid="tool-result-mcp-resource" className="whitespace-pre-wrap break-words text-doom-dim">
-          {block.text}
-        </pre>
+        // A resource arrives without a name, so its grammar is whatever the
+        // text itself gives away; anything unrecognised stays plain.
+        <SyntaxText data-testid="tool-result-mcp-resource" className="text-doom-dim" text={block.text} />
       ) : (
         <span data-testid="tool-result-mcp-resource" className="truncate text-doom-faint">
           binary {block.mimeType ?? 'resource'} · {block.uri}
@@ -60,9 +61,12 @@ function McpBlock({ block }: { block: McpResultBlock }) {
       );
     case 'structured':
       return (
-        <pre data-testid="tool-result-mcp-structured" className="whitespace-pre-wrap break-words text-doom-dim">
-          {JSON.stringify(block.value, null, 2)}
-        </pre>
+        <SyntaxText
+          data-testid="tool-result-mcp-structured"
+          className="text-doom-dim"
+          grammar="json"
+          text={JSON.stringify(block.value, null, 2)}
+        />
       );
     case 'audio':
       return (

--- a/packages/default/doompi-read/src/web/ReadToolMessage.tsx
+++ b/packages/default/doompi-read/src/web/ReadToolMessage.tsx
@@ -67,7 +67,9 @@ export function ReadToolMessage({ args, result, output, running, isError }: Tool
               ) : null
             ) : body.shown.length === 0 && body.notice === undefined && images.length === 0 ? null : (
               <MessageItemBody data-testid="tool-result-read" className="flex flex-col gap-1">
-                <HashlineLines lines={body.shown} gutter={body.gutter} />
+                {/* A read body is one file with no heading of its own, so the
+                    call's path is what names the grammar for it. */}
+                <HashlineLines lines={body.shown} gutter={body.gutter} path={view.path} />
                 {images.map((image, index) => {
                   const url = `data:${image.mimeType};base64,${image.data}`;
                   return (

--- a/packages/default/doompi-read/src/web/ReadToolMessage.tsx
+++ b/packages/default/doompi-read/src/web/ReadToolMessage.tsx
@@ -6,6 +6,7 @@ import {
   MessageItemHeader,
   MessageItemStatus,
   resultTextLines,
+  ToolPathLink,
   toolTone,
 } from '@agimon-ai/doompi-web-components';
 import type { ToolMessageRenderProps } from '@agimon-ai/doompi-web-contracts';
@@ -31,9 +32,20 @@ function resultImages(content: readonly unknown[]): Array<{ data: string; mimeTy
  * a line-number gutter in the body, collapsed to the TUI's budget until the
  * item expands. A failure shows the tool's message in red instead.
  */
-export function ReadToolMessage({ args, result, output, running, isError }: ToolMessageRenderProps) {
+export function ReadToolMessage({
+  args,
+  result,
+  output,
+  running,
+  isError,
+  fileTabFor,
+  openTransientTab,
+}: ToolMessageRenderProps) {
   const view = readCallView(args);
   const images = resultImages(result?.content ?? []);
+  // A read is the one call whose file the session usually has not changed, so
+  // this is the link that opens it read-only rather than in its history.
+  const tab = fileTabFor(view.path);
   const collapsed = result === null || isError ? null : hashlineBody(result, output, 'read', false);
   return (
     <MessageItem tone={toolTone({ running, isError })} expandable={collapsed !== null && collapsed.hidden > 0}>
@@ -44,7 +56,10 @@ export function ReadToolMessage({ args, result, output, running, isError }: Tool
           <>
             <MessageItemHeader title="read">
               <span data-testid="tool-call-read" className="flex min-w-0 flex-1 items-center gap-2">
-                <span className="truncate text-doom-text">{view.path}</span>
+                <ToolPathLink
+                  path={view.path}
+                  {...(tab === undefined ? {} : { onOpen: () => openTransientTab(tab) })}
+                />
                 {view.details.length > 0 ? (
                   <span className="shrink-0 text-doom-faint">· {view.details.join(' · ')}</span>
                 ) : null}

--- a/packages/default/doompi-runner/src/web/BashToolMessage.tsx
+++ b/packages/default/doompi-runner/src/web/BashToolMessage.tsx
@@ -1,4 +1,5 @@
 import {
+  AnsiText,
   Button,
   FileIcon,
   MessageItem,
@@ -6,6 +7,7 @@ import {
   MessageItemHeader,
   MessageItemStatus,
   type StatusTone,
+  SyntaxText,
   toolTone,
 } from '@agimon-ai/doompi-web-components';
 import type { ToolMessageRenderProps } from '@agimon-ai/doompi-web-contracts';
@@ -29,11 +31,13 @@ const STATUS_TONE: Record<BashStatusTone, StatusTone> = {
 
 /**
  * The bash tool's timeline item, the web half of renderBashCall and
- * renderBashResult: the collapsed command and its modifiers in the header;
- * the streamed tail while running, then the bounded log tail with its
- * one-line summary in the body. A command promoted to a background runner
- * offers the same stop the activity dock does, for as long as the runners
- * channel reports it running.
+ * renderBashResult. Collapsed it is a single header row: the tool name, the
+ * command shortened to one line, its modifiers, and the outcome badge, so a
+ * transcript of many calls stays scannable. Expanding it opens the body: the
+ * command exactly as it was run, then the whole tail the frame carries, each
+ * in its own scroll box so one chatty command cannot own the viewport. A
+ * command promoted to a background runner offers the same stop the activity
+ * dock does, for as long as the runners channel reports it running.
  */
 export function BashToolMessage({
   sessionId,
@@ -58,30 +62,35 @@ export function BashToolMessage({
     runners.store,
     (state) => runnerId !== undefined && runners.select(state, sessionId).stopRequested.includes(runnerId),
   );
-  const command = typeof args.command === 'string' ? formatBashCommand(args.command) : '';
+  const rawCommand = typeof args.command === 'string' ? args.command : '';
+  const command = formatBashCommand(rawCommand);
   const flags = formatBashFlags(args);
-  const collapsed = bashResultView({ details: result?.details, output, expanded: false, isPartial: running, isError });
   const stoppable = sessionId !== null && runnerId !== undefined && run !== undefined && run.exit === undefined;
 
   return (
-    <MessageItem
-      tone={toolTone({ running, isError })}
-      expandable={collapsed.hidden > 0 || details.logPath !== undefined}
-    >
+    <MessageItem tone={toolTone({ running, isError })} expandable>
       {({ expanded }) => {
-        const view = expanded
-          ? bashResultView({ details: result?.details, output, expanded: true, isPartial: running, isError })
-          : collapsed;
+        // Nothing is shown until the card is open, so the body always reads the
+        // unclipped view; the collapsed state has no lines to bound.
+        const view = bashResultView({
+          details: result?.details,
+          output,
+          expanded: true,
+          isPartial: running,
+          isError,
+        });
         return (
           <>
             <MessageItemHeader title="bash">
               <span data-testid="tool-call-bash" className="flex min-w-0 flex-1 items-center gap-2">
                 <span className="min-w-0 flex-1 truncate font-mono text-doom-text">{command}</span>
-                {flags.length > 0 ? <span className="shrink-0 text-doom-faint">· {flags.join(' · ')}</span> : null}
+                {flags.length > 0 ? (
+                  <span className="hidden shrink-0 text-doom-faint sm:inline">· {flags.join(' · ')}</span>
+                ) : null}
               </span>
-              {/* The card only ever shows a bounded tail, and expanding it
-                  shows a longer bounded tail. The whole log is a click away
-                  whether or not the card is open. */}
+              {/* The log and the stop live in the header, not the body: a
+                  collapsed row still has to reach the whole log and still has
+                  to be able to stop a run it promoted to the background. */}
               {run !== undefined && sessionId !== null ? (
                 <Button
                   variant="outline"
@@ -98,53 +107,65 @@ export function BashToolMessage({
                   log
                 </Button>
               ) : null}
+              {stoppable ? (
+                <Button
+                  size="xs"
+                  variant={stopping ? 'outline' : 'danger-outline'}
+                  disabled={stopping}
+                  data-testid="tool-result-bash-stop"
+                  data-stopping={stopping}
+                  title={
+                    stopping ? 'stop requested; the runner reports its own exit' : 'ask the runtime to stop this runner'
+                  }
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    if (sessionId !== null && runnerId !== undefined)
+                      requestRunnerStop(sendSessionFrame, sessionId, runnerId);
+                  }}
+                  className="shrink-0 px-1.5 text-[9px] font-bold"
+                >
+                  {stopping ? 'stopping…' : 'stop'}
+                </Button>
+              ) : null}
             </MessageItemHeader>
-            {view.lines.length > 0 || view.status !== null || stoppable ? (
-              <MessageItemBody data-testid="tool-result-bash" className="flex flex-col gap-1">
+            {expanded ? (
+              <MessageItemBody data-testid="tool-result-bash" className="flex flex-col gap-2">
+                {/* The header had to shorten the command to one row; this is
+                    the command as it was actually run, wrapped rather than
+                    clipped and coloured as the shell it is. */}
+                {rawCommand.length > 0 ? (
+                  <SyntaxText
+                    data-testid="tool-result-bash-command"
+                    grammar="shell"
+                    text={rawCommand}
+                    className="max-h-40 overflow-auto text-doom-text"
+                  />
+                ) : null}
+                {/* The tail arrives with the colours the command wrote: the
+                    log keeps them, and only the model's copy is flattened. */}
                 {view.lines.length > 0 ? (
-                  <pre
-                    className={`${expanded ? 'whitespace-pre-wrap break-words' : 'overflow-hidden whitespace-pre'} font-mono text-doom-dim`}
-                  >
-                    {view.lines.join('\n')}
-                  </pre>
+                  <AnsiText
+                    data-testid="tool-result-bash-output"
+                    text={view.lines.join('\n')}
+                    className="max-h-96 overflow-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] border-doom-border-soft border-t pt-2 font-mono text-doom-dim"
+                  />
                 ) : null}
                 {view.status ? (
                   <MessageItemStatus
                     data-testid="tool-result-bash-status"
                     tone={STATUS_TONE[view.status.tone]}
                     glyph={view.status.glyph}
+                    className="min-w-0"
                   >
-                    {view.status.text}
-                    {view.hidden > 0 ? ` · ${String(view.hidden)} more line(s) above` : ''}
+                    <span className="break-words">{view.status.text}</span>
                   </MessageItemStatus>
                 ) : null}
-                {expanded && details.logPath !== undefined ? (
+                {details.logPath !== undefined ? (
                   // The tail is bounded by the runner; the whole log only ever exists on
                   // disk, so the item names the file rather than pretending this is all.
-                  <span data-testid="tool-result-bash-log" className="truncate text-doom-faint">
+                  <span data-testid="tool-result-bash-log" className="min-w-0 break-all text-doom-faint">
                     full log · <span className="text-doom-dim">{details.logPath}</span>
                   </span>
-                ) : null}
-                {stoppable ? (
-                  <Button
-                    size="xs"
-                    variant={stopping ? 'outline' : 'danger-outline'}
-                    disabled={stopping}
-                    data-testid="tool-result-bash-stop"
-                    data-stopping={stopping}
-                    title={
-                      stopping
-                        ? 'stop requested; the runner reports its own exit'
-                        : 'ask the runtime to stop this runner'
-                    }
-                    onClick={() => {
-                      if (sessionId !== null && runnerId !== undefined)
-                        requestRunnerStop(sendSessionFrame, sessionId, runnerId);
-                    }}
-                    className="self-start px-1.5 text-[8px] font-bold"
-                  >
-                    {stopping ? 'stopping…' : 'stop'}
-                  </Button>
                 ) : null}
               </MessageItemBody>
             ) : null}

--- a/packages/default/doompi-runner/src/web/RunnerLogPanel.tsx
+++ b/packages/default/doompi-runner/src/web/RunnerLogPanel.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, SearchIcon, StatusBadge, type StatusTone } from '@agimon-ai/doompi-web-components';
+import { AnsiText, Button, Input, SearchIcon, StatusBadge, type StatusTone } from '@agimon-ai/doompi-web-components';
 import type { TransientTab, WebPluginSlotProps } from '@agimon-ai/doompi-web-contracts';
 import { useStore } from '@tanstack/react-store';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -249,9 +249,10 @@ export function RunnerLogPanel({ sessionId, runId, sendSessionFrame }: WebPlugin
         ) : lines.length === 0 ? (
           <p className="text-[10px] text-doom-faint">{filtering ? 'nothing matched' : 'the log is empty'}</p>
         ) : (
-          <pre className="whitespace-pre-wrap break-words font-mono text-[10px] leading-[1.6] text-doom-dim">
-            {lines.join('\n')}
-          </pre>
+          <AnsiText
+            text={lines.join('\n')}
+            className="whitespace-pre-wrap break-words font-mono text-[10px] leading-[1.6] text-doom-dim"
+          />
         )}
         <div ref={bottom} />
       </div>

--- a/packages/default/doompi-runner/src/web/RunnersActivitySection.tsx
+++ b/packages/default/doompi-runner/src/web/RunnersActivitySection.tsx
@@ -6,6 +6,7 @@ import type { RunnerRunView } from '../types/webRunners.ts';
 import { formatRunnerUptime } from './format.ts';
 import { runnerLogTab } from './RunnerLogPanel.tsx';
 import { requestRunnerStop, runners } from './runnersStore.ts';
+import { useRunnerTail } from './runnerTail.ts';
 
 const TICK_MS = 10_000;
 
@@ -39,69 +40,102 @@ export function RunnersActivitySection({ sessionId, sendSessionFrame, openTransi
 
   return (
     <div data-testid="activity-runner-runs" className="flex flex-col gap-0.5">
-      {running.map((run: RunnerRunView) => {
-        const stopRequested = session.stopRequested.includes(run.id);
-        return (
-          <Button
-            key={run.id}
-            variant="ghost"
-            size="card"
-            data-testid={`activity-runner-${run.id}`}
-            data-runner-tone="running"
-            title="open this runner's log"
-            onClick={() => {
-              if (sessionId === null) return;
-              openTransientTab(runnerLogTab(run));
-            }}
-            className="min-w-0 gap-0.5 rounded-[5px] px-1 py-1 hover:bg-doom-panel"
-          >
-            <span className="flex min-w-0 items-center gap-1.5">
-              <Dot tone="yellow" pulse />
-              <span className="min-w-0 flex-1 truncate text-left text-[10px] font-bold text-doom-hi">{run.name}</span>
-              <span className="shrink-0 text-[9px] text-doom-faint">
-                {formatRunnerUptime(run.startedAt, now)}
-                {run.interactive ? ' · tty' : ''}
-              </span>
-              {sessionId !== null ? (
-                <Button
-                  asChild
-                  variant={stopRequested ? 'outline' : 'danger-outline'}
-                  size="xs"
-                  data-testid={`activity-runner-stop-${run.id}`}
-                  data-stopping={stopRequested}
-                  title={
-                    stopRequested
-                      ? 'stop requested; the runner reports its own exit'
-                      : 'ask the runtime to stop this runner'
-                  }
-                  className="px-1.5 text-[8px] font-bold"
-                >
-                  {/* The row is already a button, so the stop control lends it
-                      the primitive's styling rather than nesting a second one. */}
-                  <span
-                    role="button"
-                    tabIndex={stopRequested ? -1 : 0}
-                    aria-disabled={stopRequested}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      if (!stopRequested) requestRunnerStop(sendSessionFrame, sessionId, run.id);
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key !== 'Enter' && event.key !== ' ') return;
-                      event.preventDefault();
-                      event.stopPropagation();
-                      if (!stopRequested) requestRunnerStop(sendSessionFrame, sessionId, run.id);
-                    }}
-                  >
-                    {stopRequested ? 'stopping…' : 'stop'}
-                  </span>
-                </Button>
-              ) : null}
-            </span>
-            <span className="truncate pl-3 text-left text-[9px] text-doom-faint">{run.command}</span>
-          </Button>
-        );
-      })}
+      {running.map((run: RunnerRunView) => (
+        <RunnerRow
+          key={run.id}
+          run={run}
+          now={now}
+          stopRequested={session.stopRequested.includes(run.id)}
+          sessionId={sessionId}
+          sendSessionFrame={sendSessionFrame}
+          openTransientTab={openTransientTab}
+        />
+      ))}
     </div>
+  );
+}
+
+/**
+ * One running runner: its name, how long it has been up, a stop control, and
+ * one line of what it is doing. Its own component because the tail line is a
+ * subscription per row, and a row that scrolls out of the dock closes it.
+ */
+function RunnerRow({
+  run,
+  now,
+  stopRequested,
+  sessionId,
+  sendSessionFrame,
+  openTransientTab,
+}: {
+  run: RunnerRunView;
+  now: number;
+  stopRequested: boolean;
+} & Pick<WebPluginSlotProps, 'sessionId' | 'sendSessionFrame' | 'openTransientTab'>) {
+  const tail = useRunnerTail(sessionId, run.id, run.state === 'running');
+  return (
+    <Button
+      variant="ghost"
+      size="card"
+      data-testid={`activity-runner-${run.id}`}
+      data-runner-tone="running"
+      title="open this runner's log"
+      onClick={() => {
+        if (sessionId === null) return;
+        openTransientTab(runnerLogTab(run));
+      }}
+      className="min-w-0 gap-0.5 rounded-[5px] px-1 py-1 hover:bg-doom-panel"
+    >
+      <span className="flex min-w-0 items-center gap-1.5">
+        <Dot tone="yellow" pulse />
+        <span className="min-w-0 flex-1 truncate text-left text-[10px] font-bold text-doom-hi">{run.name}</span>
+        <span className="shrink-0 text-[9px] text-doom-faint">
+          {formatRunnerUptime(run.startedAt, now)}
+          {run.interactive ? ' · tty' : ''}
+        </span>
+        {sessionId !== null ? (
+          <Button
+            asChild
+            variant={stopRequested ? 'outline' : 'danger-outline'}
+            size="xs"
+            data-testid={`activity-runner-stop-${run.id}`}
+            data-stopping={stopRequested}
+            title={
+              stopRequested ? 'stop requested; the runner reports its own exit' : 'ask the runtime to stop this runner'
+            }
+            className="px-1.5 text-[8px] font-bold"
+          >
+            {/* The row is already a button, so the stop control lends it
+                the primitive's styling rather than nesting a second one. */}
+            <span
+              role="button"
+              tabIndex={stopRequested ? -1 : 0}
+              aria-disabled={stopRequested}
+              onClick={(event) => {
+                event.stopPropagation();
+                if (!stopRequested) requestRunnerStop(sendSessionFrame, sessionId, run.id);
+              }}
+              onKeyDown={(event) => {
+                if (event.key !== 'Enter' && event.key !== ' ') return;
+                event.preventDefault();
+                event.stopPropagation();
+                if (!stopRequested) requestRunnerStop(sendSessionFrame, sessionId, run.id);
+              }}
+            >
+              {stopRequested ? 'stopping…' : 'stop'}
+            </span>
+          </Button>
+        ) : null}
+      </span>
+      {/* What it is doing, falling back to what it was asked to do until the
+          first line of output arrives. */}
+      <span
+        data-testid={`activity-runner-detail-${run.id}`}
+        data-detail={tail === undefined ? 'command' : 'tail'}
+        className="truncate pl-3 text-left text-[9px] text-doom-faint"
+      >
+        {tail ?? run.command}
+      </span>
+    </Button>
   );
 }

--- a/packages/default/doompi-runner/src/web/runnerTail.ts
+++ b/packages/default/doompi-runner/src/web/runnerTail.ts
@@ -1,0 +1,82 @@
+import { ansiSpans } from '@agimon-ai/doompi-web-components';
+import { useEffect, useState } from 'react';
+import { fetchRunnerLog, followRunnerLog, type RunnerLogFollow } from './logApi.ts';
+
+/**
+ * The newest line a running runner has written, for a row that has one line to
+ * spend.
+ *
+ * The dock answers "what is happening", and a command that has not changed
+ * since it started answers "what was asked". The last line of the log is the
+ * closest thing to progress the cockpit can show without opening the log, so a
+ * row that is still running trades its command for it.
+ *
+ * The line comes from the same two calls the log panel makes: read the tail,
+ * then follow the stream from exactly where that read ended. Nothing new goes
+ * on the wire, and a runner nobody is looking at is not followed, because the
+ * stream lives and dies with the row.
+ */
+
+/** Enough lines that a trailing blank, or a final progress redraw, is not the whole answer. */
+const TAIL_REQUEST_LINES = 5;
+
+/**
+ * The last line worth showing, as plain text.
+ *
+ * Blank lines are skipped, because a log that ends with a newline would
+ * otherwise report nothing at all. Colour is dropped rather than rendered: the
+ * row is nine pixels of faint text beside a name and a stop control, and a
+ * green tick from someone else's palette in the middle of it reads as damage.
+ */
+export function plainTailLine(lines: readonly string[]): string | undefined {
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const text = ansiSpans(lines[index] ?? '')
+      .map((span) => span.text)
+      .join('')
+      .trim();
+    if (text.length > 0) return text;
+  }
+  return undefined;
+}
+
+/**
+ * The newest log line of a running runner, or undefined for a runner that is
+ * finished, unreachable, or has not written anything yet. The caller decides
+ * what to show instead; this hook never invents a placeholder.
+ */
+export function useRunnerTail(sessionId: string | null, runId: string, running: boolean): string | undefined {
+  // Kept with the run it belongs to, so a row that is reused for another
+  // runner shows nothing rather than the previous runner's output.
+  const [tail, setTail] = useState<{ runId: string; text: string } | undefined>(undefined);
+
+  useEffect(() => {
+    if (!running || sessionId === null) return;
+    let live = true;
+    let follow: RunnerLogFollow | undefined;
+    const controller = new AbortController();
+    void fetchRunnerLog(sessionId, runId, { lines: TAIL_REQUEST_LINES }, controller.signal).then((result) => {
+      // A log the hub cannot serve leaves the row on its command, which is
+      // still true; the log tab is where an unreachable runner is diagnosed.
+      if (!live || 'error' in result) return;
+      const initial = plainTailLine(result.slice.text.split('\n'));
+      if (initial !== undefined) setTail({ runId, text: initial });
+      if (!result.slice.running) return;
+      follow = followRunnerLog(sessionId, runId, result.slice.fileSize, {
+        onEvent: (event) => {
+          const next = plainTailLine(event.lines);
+          if (live && next !== undefined) setTail({ runId, text: next });
+        },
+        // A dropped stream freezes the line at the last one that arrived. The
+        // row is a glance, and reconnecting it would cost more than it says.
+        onError: () => undefined,
+      });
+    });
+    return () => {
+      live = false;
+      controller.abort();
+      follow?.close();
+    };
+  }, [sessionId, runId, running]);
+
+  return running && tail?.runId === runId ? tail.text : undefined;
+}

--- a/packages/default/doompi-runner/src/web/tsconfig.json
+++ b/packages/default/doompi-runner/src/web/tsconfig.json
@@ -19,5 +19,5 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]
   },
-  "include": [".", "../types", "../exports/webClient.ts"]
+  "include": [".", "../types", "../exports/webClient.ts", "../../tests/web"]
 }

--- a/packages/default/doompi-runner/tests/web/runnerTail.test.ts
+++ b/packages/default/doompi-runner/tests/web/runnerTail.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { plainTailLine } from '../../src/web/runnerTail.ts';
+
+const ESC = '\u001B[';
+
+describe('plainTailLine', () => {
+  it('takes the last line that has something on it', () => {
+    expect(plainTailLine(['first', 'second'])).toBe('second');
+    // A log file ends with a newline, so a naive split ends in a blank.
+    expect(plainTailLine(['built in 812ms', ''])).toBe('built in 812ms');
+    expect(plainTailLine(['done', '   ', '\t'])).toBe('done');
+  });
+
+  it('drops the colour a program wrote, because the row is nine faint pixels', () => {
+    expect(plainTailLine([`${ESC}1m${ESC}32m\u2713 42 passed${ESC}39m${ESC}0m`])).toBe('✓ 42 passed');
+  });
+
+  it('has nothing to say about a log with no output yet', () => {
+    expect(plainTailLine([])).toBeUndefined();
+    expect(plainTailLine([''])).toBeUndefined();
+    expect(plainTailLine([`${ESC}0m`])).toBeUndefined();
+  });
+});

--- a/packages/default/doompi-runner/tsconfig.json
+++ b/packages/default/doompi-runner/tsconfig.json
@@ -23,5 +23,5 @@
     "types": ["node", "vitest/globals"]
   },
   "include": ["src", "tests", "vitest.config.ts", "tsdown.config.ts"],
-  "exclude": ["node_modules", "dist", "coverage", "src/web", "src/exports/webClient.ts"]
+  "exclude": ["node_modules", "dist", "coverage", "tests/web", "src/web", "src/exports/webClient.ts"]
 }

--- a/packages/minor/doompi-workflow/src/web/StepTerminalPanel.tsx
+++ b/packages/minor/doompi-workflow/src/web/StepTerminalPanel.tsx
@@ -1,10 +1,9 @@
-import { Badge, Button, StatusBadge, StreamCursor } from '@agimon-ai/doompi-web-components';
+import { AnsiLine, Badge, Button, StatusBadge, StreamCursor } from '@agimon-ai/doompi-web-components';
 import type { TransientTab, WebPluginSlotProps } from '@agimon-ai/doompi-web-contracts';
 import { useStore } from '@tanstack/react-store';
 import { type KeyboardEvent as ReactKeyboardEvent, useCallback, useEffect, useRef, useState } from 'react';
 import type { WorkflowRunView } from '../types/webWorkflows.ts';
 import type { WorkflowTerminalCapabilitiesView } from '../types/webWorkflowTerminal.ts';
-import { ansiSpans } from './ansiSpans.ts';
 import { followScreen, releaseControl, sendKeys, takeControl } from './terminalApi.ts';
 import { workflows } from './workflowsStore.ts';
 
@@ -53,23 +52,10 @@ export function stepTerminalTab(run: WorkflowRunView, job: string, step?: string
 }
 
 function ScreenLine({ line }: { line: string }) {
-  const spans = ansiSpans(line);
-  if (spans.length === 0) return <span className="block h-[15px]" />;
-  return (
-    <span className="block whitespace-pre">
-      {spans.map((span, index) => (
-        <span
-          key={index}
-          className={`${span.className ?? ''} ${span.bold ? 'font-bold' : ''} ${span.faint ? 'opacity-60' : ''} ${
-            span.italic ? 'italic' : ''
-          } ${span.underline ? 'underline' : ''} ${span.inverse ? 'bg-doom-text text-doom-deep' : ''}`}
-          style={span.color === undefined ? undefined : { color: span.color }}
-        >
-          {span.text}
-        </span>
-      ))}
-    </span>
-  );
+  // A blank row still has to hold the grid open, so an empty line keeps its
+  // height rather than collapsing the screen by one row.
+  if (line.length === 0) return <span className="block h-[15px]" />;
+  return <AnsiLine line={line} className="block whitespace-pre" />;
 }
 
 /**

--- a/packages/minor/doompi-workflow/src/web/WorkflowsPanel.tsx
+++ b/packages/minor/doompi-workflow/src/web/WorkflowsPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  AnsiLine,
   Button,
   ChevronDownIcon,
   cn,
@@ -35,7 +36,6 @@ import type {
 } from '../types/webWorkflows.ts';
 import type { WorkflowTerminalCapabilitiesView } from '../types/webWorkflowTerminal.ts';
 import { ArtifactsPane, artifactTab } from './ArtifactsPane.tsx';
-import { ansiSpans } from './ansiSpans.ts';
 import { catalog, closeCatalog, closeLaunch, openCatalog, openLaunch } from './catalogStore.ts';
 import { LaunchWorkflowDialog } from './LaunchWorkflowDialog.tsx';
 import { formatRunDuration } from './runDuration.ts';
@@ -331,23 +331,10 @@ function StepRow({
 }
 
 function ScreenLine({ line }: { line: string }) {
-  const spans = ansiSpans(line);
-  if (spans.length === 0) return <span className="block h-[15px]" />;
-  return (
-    <span className="block whitespace-pre">
-      {spans.map((span, index) => (
-        <span
-          key={index}
-          className={`${span.className ?? ''} ${span.bold ? 'font-bold' : ''} ${span.faint ? 'opacity-60' : ''} ${
-            span.italic ? 'italic' : ''
-          } ${span.underline ? 'underline' : ''} ${span.inverse ? 'bg-doom-text text-doom-deep' : ''}`}
-          style={span.color === undefined ? undefined : { color: span.color }}
-        >
-          {span.text}
-        </span>
-      ))}
-    </span>
-  );
+  // A blank row still has to hold the grid open, so an empty line keeps its
+  // height rather than collapsing the screen by one row.
+  if (line.length === 0) return <span className="block h-[15px]" />;
+  return <AnsiLine line={line} className="block whitespace-pre" />;
 }
 
 function InlineStepOutput({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1480,6 +1480,15 @@ importers:
       '@agimon-ai/doompi-telemetry':
         specifier: workspace:*
         version: link:../../core/doompi-telemetry
+      '@agimon-ai/doompi-web-components':
+        specifier: workspace:*
+        version: link:../../core/doompi-web-components
+      '@agimon-ai/doompi-web-contracts':
+        specifier: workspace:*
+        version: link:../../core/doompi-web-contracts
+      '@agimon-ai/doompi-web-security':
+        specifier: workspace:*
+        version: link:../../core/doompi-web-security
       '@agimon-ai/log-sink-mcp':
         specifier: 0.29.19
         version: 0.29.19(@earendil-works/pi-coding-agent@0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)
@@ -1496,12 +1505,24 @@ importers:
       '@earendil-works/pi-tui':
         specifier: 0.84.4
         version: 0.84.4
+      '@tanstack/react-store':
+        specifier: 0.11.1
+        version: 0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/store':
+        specifier: 0.11.1
+        version: 0.11.1
       '@types/node':
         specifier: 26.4.0
         version: 26.4.0
+      '@types/react':
+        specifier: 19.2.18
+        version: 19.2.18
       '@vitest/coverage-v8':
         specifier: 4.1.11
         version: 4.1.11(vitest@4.1.11)
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
       tsdown:
         specifier: 0.22.14
         version: 0.22.14(typescript@7.0.2)
@@ -10047,17 +10068,13 @@ snapshots:
 
   '@hexagon/base64@1.1.28': {}
 
-  '@hono/node-server@1.19.17(hono@4.13.3)':
+  '@hono/node-server@1.19.17(hono@4.13.5)':
     dependencies:
-      hono: 4.13.3
+      hono: 4.13.5
 
   '@hono/node-server@2.0.10(hono@4.12.34)':
     dependencies:
       hono: 4.12.34
-
-  '@hono/node-server@2.1.1(hono@4.13.3)':
-    dependencies:
-      hono: 4.13.3
 
   '@hono/node-server@2.1.1(hono@4.13.5)':
     dependencies:
@@ -10364,7 +10381,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.17(hono@4.13.3)
+      '@hono/node-server': 1.19.17(hono@4.13.5)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -10374,7 +10391,7 @@ snapshots:
       eventsource-parser: 3.1.1
       express: 5.2.1
       express-rate-limit: 8.6.2(express@5.2.1)
-      hono: 4.13.3
+      hono: 4.13.5
       jose: 6.2.9
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -10386,7 +10403,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.17(hono@4.13.3)
+      '@hono/node-server': 1.19.17(hono@4.13.5)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -10396,7 +10413,7 @@ snapshots:
       eventsource-parser: 3.1.1
       express: 5.2.1
       express-rate-limit: 8.6.2(express@5.2.1)
-      hono: 4.13.3
+      hono: 4.13.5
       jose: 6.2.9
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -10408,7 +10425,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.1.1(hono@4.13.3)
+      '@hono/node-server': 2.1.1(hono@4.13.5)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -10418,7 +10435,7 @@ snapshots:
       eventsource-parser: 3.1.1
       express: 5.2.1
       express-rate-limit: 8.6.2(express@5.2.1)
-      hono: 4.13.3
+      hono: 4.13.5
       jose: 6.2.9
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1495,6 +1495,9 @@ importers:
       '@deepseek-ai/cordis':
         specifier: 4.0.1
         version: 4.0.1
+      hono:
+        specifier: 4.13.5
+        version: 4.13.5
     devDependencies:
       '@agimon-ai/doompi-ui':
         specifier: workspace:*


### PR DESCRIPTION
## What this changes

Adds the issues panel to `doompi-log` (issues source, grouping, web section with charts and a report view), the context dock in the cockpit (context catalog and projection services, context panel, composition plumbing), tool cost accounting in `doompi-ui`, a shared tool path link component, and the file preview panel in `doompi-file-edit`.

Also widens the `.dockerignore` `tmp` and `logs` patterns to `**/tmp` and `**/logs` so nested local artifacts stay out of the CI image.

## Why

The cockpit had no way to surface log issues or show what a session's context is made of, and tool cost was not accounted for anywhere. The `.dockerignore` change is a side fix: a stray `packages/default/doompi-file-edit/tmp` capture reached the local CI image and failed `pnpm audit:workspace` there, which the wider pattern now prevents.

## Checks

Run these locally before asking for review. CI runs the same set.

- [x] `pnpm lint:vibe --preflight-only`
- [x] Affected Nx targets pass: `lint`, `typecheck`, `build`, `test`
- [x] `pnpm fmt:check`
- [ ] Packed-install system tests, if this is a release change: `pnpm nx run-many -t test-system`

Everything above was run inside Docker against `Dockerfile.ci` (node 22.22.1, pnpm 11.1.3), covering the full `quality` job plus the `browser` job: `runner:check`, `audit:workspace`, `fmt:check`, `hooks:check`, `build`, `examples:check`, `lint`, `lint:vibe --preflight-only`, `typecheck`, `test`, `cockpit:build`, and the 157-spec Playwright suite. All green.

The packed-install gate (`pnpm build` plus `test-system`) was not run locally. This is not a release change, so CI covers it.

## Scope

- [x] Package boundaries are respected (`packages/core`, `packages/default`, `packages/minor`, `packages/clients`, `layers/`, `packages/tooling`)
- [x] Doom-to-Doom dependencies stay `workspace:*`
- [x] Package exports, Pi entries, resources, runtime ordering, and RMUX LFS payloads are preserved
- [ ] No unrelated changes bundled in

This branch carries three commits. Two of them, `552f30d` (shared ansi/syntax text components and the context dock) and `8b95ef8` (runner log stream in the e2e fixture), were already sitting unpushed on `main` before this work started and came along with the branch. The third, `ffdf232`, is the change described above.

## Risk

The container used for verification is arm64 Linux while CI runs x86_64, so architecture-sensitive behaviour is unverified here. No new external dependencies, no changes to the release workflows or to anything that runs on the self-hosted runner, and no change to the trust boundary.
