### PR TITLE
fix(doompi-web): isolate synchronized plugins by session

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "audit:workspace": "node scripts/audit-workspace.mjs",
     "build": "nx run-many -t build",
     "cockpit": "pnpm cockpit:build && pnpm doompi-web",
-    "cockpit:build": "nx run-many -t build -p @agimon-ai/doompi @agimon-ai/doompi-server @agimon-ai/doompi-web @agimon-ai/doompi-file-edit @agimon-ai/doompi-log @agimon-ai/doompi-mcp @agimon-ai/doompi-prompt @agimon-ai/doompi-task @agimon-ai/doompi-team @agimon-ai/doompi-voice @agimon-ai/doompi-workflow @agimon-ai/doompi-user-feedback",
+    "cockpit:build": "nx run-many -t build -p @agimon-ai/doompi @agimon-ai/doompi-server @agimon-ai/doompi-web @agimon-ai/doompi-autocompact @agimon-ai/doompi-edit @agimon-ai/doompi-file-edit @agimon-ai/doompi-goal @agimon-ai/doompi-grep @agimon-ai/doompi-help @agimon-ai/doompi-hook @agimon-ai/doompi-log @agimon-ai/doompi-loop @agimon-ai/doompi-mcp @agimon-ai/doompi-plan @agimon-ai/doompi-prompt @agimon-ai/doompi-read @agimon-ai/doompi-runner @agimon-ai/doompi-sandbox @agimon-ai/doompi-task @agimon-ai/doompi-team @agimon-ai/doompi-user-feedback @agimon-ai/doompi-voice @agimon-ai/doompi-workflow",
     "examples:check": "node scripts/check-examples.mjs",
     "hooks:check": "node scripts/emit-hooks.mjs --check",
     "hooks:write": "node scripts/emit-hooks.mjs --write",

--- a/packages/clients/doompi-desktop/scripts/desktopRuntimePlugin.ts
+++ b/packages/clients/doompi-desktop/scripts/desktopRuntimePlugin.ts
@@ -26,6 +26,7 @@ const DOOMPI_RUNTIME_PACKAGES = new Set([
 ]);
 const DOOMPI_PACKAGE_DIRECTORIES = ['core', 'default', 'minor'] as const;
 const PLATFORM_PACKAGE_SUFFIX = /-(darwin|linux)-(arm64|x64)$/u;
+const EXTERNAL_RUNTIME_PACKAGES = new Set(['@earendil-works/pi-coding-agent']);
 
 const WEB_RUNTIME_PACKAGES = new Set([
   '@agimon-ai/doompi-extension-contracts',
@@ -52,13 +53,14 @@ export function desktopRuntimePlugin(options: DesktopRuntimePluginOptions): Plug
     apply: 'build',
     enforce: 'pre',
     resolveId(source) {
+      if (isExternalRuntimePackage(source)) return { id: source, external: true };
       const packageName = dependencyPackageName(source);
       if (packageName === undefined || !packageName.includes(target)) return null;
       runtimePackages.add(packageName);
       return { id: source, external: true };
     },
     transform(source, id) {
-      if (id.includes('/doompi/src/adapters/modules/moduleResolution.')) {
+      if (id.includes('/doompi/') && id.includes('/src/adapters/modules/moduleResolution.')) {
         const original = 'path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))))';
         if (source.includes(original)) {
           return source.replace(original, `(process.env.DOOMPI_PACKAGE_ROOT || ${original})`);
@@ -207,6 +209,11 @@ function dependencyPackageName(source: string): string | undefined {
   return name === undefined || name === '' || path.isAbsolute(source) ? undefined : name;
 }
 
+/** Keeps identity-sensitive runtime packages outside the generated bundle. */
+export function isExternalRuntimePackage(source: string): boolean {
+  const packageName = dependencyPackageName(source);
+  return packageName !== undefined && EXTERNAL_RUNTIME_PACKAGES.has(packageName);
+}
 function copyRuntimePackages(
   workspaceRoot: string,
   destinationRoot: string,

--- a/packages/clients/doompi-desktop/src/adapters/hubProcess.ts
+++ b/packages/clients/doompi-desktop/src/adapters/hubProcess.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { hubArguments, hubEnvironment } from '../services/hubLaunch.ts';
 import type { HubLaunchPlan, RunningHub } from '../types/hub.ts';
 
-const HEALTH_TIMEOUT_MS = 30_000;
+const HEALTH_TIMEOUT_MS = 120_000;
 const HEALTH_POLL_MS = 150;
 const STOP_TIMEOUT_MS = 10_000;
 

--- a/packages/clients/doompi-desktop/src/services/hubLaunch.ts
+++ b/packages/clients/doompi-desktop/src/services/hubLaunch.ts
@@ -32,13 +32,16 @@ export function hubEnvironment(base: NodeJS.ProcessEnv, entry: string): NodeJS.P
   return {
     ...inherited,
     ELECTRON_RUN_AS_NODE: '1',
-    NODE_PATH: artifact('native', 'node_modules'),
+    // Resolve the staged DoomPi package before native-only shims so sync can
+    // register its real Pi extension entry instead of the minimal native manifest.
+    NODE_PATH: [artifact('node_modules'), artifact('native', 'node_modules')].join(path.delimiter),
     DOOMPI_SERVER_COMMAND: artifact('doompi-server', 'dist', 'bin', 'serve.mjs'),
     // Desktop owns an isolated DPI composition rather than changing the user's
     // persisted Pi integration. Sync and sessions must use that same entry point.
     DOOMPI_AGENT_COMMAND: artifact('doompi', 'dist', 'bin', 'dpi.mjs'),
     DOOMPI_SYNC_COMMAND: artifact('doompi', 'dist', 'bin', 'dpi.mjs'),
     DOOMPI_PACKAGE_ROOT: artifact('doompi', 'dist', 'src'),
+    DOOMPI_BOOTSTRAP_ENTRY: artifact('doompi', 'dist', 'src', 'extensions', 'entries', 'doom.mjs'),
     DOOMPI_PACKAGE_CATALOG: artifact('catalog', 'index.json'),
     DOOMPI_NPM_CLI: artifact('vendor', 'npm', 'bin', 'npm-cli.js'),
     DOOMPI_WEB_MODULE: pathToFileURL(artifact('doompi-web', 'dist', 'index.mjs')).href,

--- a/packages/clients/doompi-desktop/tests/unit/desktopRuntimePlugin.test.ts
+++ b/packages/clients/doompi-desktop/tests/unit/desktopRuntimePlugin.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { isExternalRuntimePackage } from '../../scripts/desktopRuntimePlugin.ts';
+import runtimeConfig from '../../vite.runtime.config.ts';
+
+describe('desktop runtime externals', () => {
+  it('keeps Pi imports on the staged package instance', () => {
+    expect(isExternalRuntimePackage('@earendil-works/pi-coding-agent')).toBe(true);
+    expect(isExternalRuntimePackage('@earendil-works/pi-coding-agent/client')).toBe(true);
+  });
+
+  it('continues bundling unrelated dependencies', () => {
+    expect(isExternalRuntimePackage('@earendil-works/pi-server')).toBe(false);
+  });
+});
+
+describe('desktop DoomPi entrypoints', () => {
+  it('stages the entries needed to sync a repository', () => {
+    expect(runtimeConfig).toMatchObject({
+      build: {
+        rollupOptions: {
+          input: {
+            'doompi/dist/src/extensions/entries/doom': expect.any(String),
+            'doompi/dist/src/extensions/entries/styleSystem': expect.any(String),
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/clients/doompi-desktop/tests/unit/hubLaunch.test.ts
+++ b/packages/clients/doompi-desktop/tests/unit/hubLaunch.test.ts
@@ -46,13 +46,18 @@ describe('the runtime handed to the cockpit', () => {
     expect(environment.DOOMPI_AGENT_COMMAND).toBe(path.join('/runtime', 'doompi', 'dist', 'bin', 'dpi.mjs'));
     expect(environment.DOOMPI_SYNC_COMMAND).toBe(path.join('/runtime', 'doompi', 'dist', 'bin', 'dpi.mjs'));
     expect(environment.DOOMPI_PACKAGE_ROOT).toBe(path.join('/runtime', 'doompi', 'dist', 'src'));
+    expect(environment.DOOMPI_BOOTSTRAP_ENTRY).toBe(
+      path.join('/runtime', 'doompi', 'dist', 'src', 'extensions', 'entries', 'doom.mjs'),
+    );
     expect(environment.DOOMPI_PACKAGE_CATALOG).toBe(path.join('/runtime', 'catalog', 'index.json'));
     expect(environment.DOOMPI_NPM_CLI).toBe(path.join('/runtime', 'vendor', 'npm', 'bin', 'npm-cli.js'));
     expect(environment.DOOMPI_WEB_MODULE).toBe('file:///runtime/doompi-web/dist/index.mjs');
     expect(environment.DOOMPI_WEB_DIST).toBeUndefined();
     expect(environment.DOOMPI_WEB_PACKAGE_ROOT).toBe(path.join('/runtime', 'doompi-web'));
     expect(environment.DOOMPI_VITE_PACKAGE_ROOT).toBe(path.join('/runtime', 'vendor', 'vite'));
-    expect(environment.NODE_PATH).toBe(path.join('/runtime', 'native', 'node_modules'));
+    expect(environment.NODE_PATH).toBe(
+      [path.join('/runtime', 'node_modules'), path.join('/runtime', 'native', 'node_modules')].join(path.delimiter),
+    );
     expect(environment.DOOMPI_RMUX_BINARY).toBe(
       path.join(
         '/runtime',

--- a/packages/clients/doompi-desktop/vite.runtime.config.ts
+++ b/packages/clients/doompi-desktop/vite.runtime.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
         'doompi/dist/src/adapters/syncedRuntimeBuilder': source(
           'packages/core/doompi/src/adapters/syncedRuntimeBuilder.ts',
         ),
+        'doompi/dist/src/extensions/entries/doom': source('packages/core/doompi/src/extensions/entries/doom.ts'),
         'doompi/dist/src/extensions/entries/cordisFinalizer': source(
           'packages/core/doompi/src/extensions/entries/cordisFinalizer.ts',
         ),
@@ -43,6 +44,9 @@ export default defineConfig({
         ),
         'doompi/dist/src/extensions/entries/ollamaProvider': source(
           'packages/core/doompi/src/extensions/entries/ollamaProvider.ts',
+        ),
+        'doompi/dist/src/extensions/entries/styleSystem': source(
+          'packages/core/doompi/src/extensions/entries/styleSystem.ts',
         ),
         'doompi/dist/src/extensions/entries/transitionCoordinator': source(
           'packages/core/doompi/src/extensions/entries/transitionCoordinator.ts',

--- a/packages/clients/doompi-web/package.json
+++ b/packages/clients/doompi-web/package.json
@@ -70,6 +70,8 @@
     "@agimon-ai/doompi-web-components": "workspace:*",
     "@agimon-ai/doompi-web-contracts": "workspace:*",
     "@agimon-ai/doompi-web-security": "workspace:*",
+    "@codemirror/state": "6.7.1",
+    "@codemirror/view": "6.43.9",
     "@earendil-works/pi-client": "0.84.4",
     "@earendil-works/pi-coding-agent": "0.84.4",
     "@earendil-works/pi-protocol": "0.84.4",

--- a/packages/clients/doompi-web/src/adapters/bundlePublication.ts
+++ b/packages/clients/doompi-web/src/adapters/bundlePublication.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
+import path from 'node:path';
 import type { SignedBundleManifest } from '@agimon-ai/doompi-web-security';
 import { createBundleSigner, type BundleSigner } from '@agimon-ai/doompi-web-security/node';
 
@@ -26,6 +27,14 @@ export interface BundlePublication {
   current(): PublishedBundle | undefined;
   trust(): BundleTrustView | undefined;
   refresh(): PublishedBundle | undefined;
+}
+
+/** Signed immutable plugin compositions addressable by identity and revision. */
+export interface PluginBundlePublication {
+  publish(compositionId: string, assetsDir: string): PublishedBundle | undefined;
+  get(compositionId: string, revision: number): PublishedBundle | undefined;
+  publicKey(): string | undefined;
+  close(): void;
 }
 
 export interface BundlePublicationOptions {
@@ -152,5 +161,82 @@ export function createBundlePublication(options: BundlePublicationOptions): Bund
         : { publicKey: published.signed.publicKey, revision: published.signed.manifest.revision };
     },
     refresh,
+  };
+}
+
+const PLUGIN_PUBLICATION_LIMIT = 32;
+
+/**
+ * Signs synchronized plugin generations without replacing the stable shell publication.
+ *
+ * Publications are retained by the exact identity and revision advertised to pages, so
+ * a concurrent sync cannot pair an old manifest with bytes from a new generation.
+ */
+export function createPluginBundlePublication(
+  stateDir: string,
+  onNotice: (message: string) => void = () => {},
+): PluginBundlePublication {
+  let signer: BundleSigner | undefined;
+  try {
+    signer = createBundleSigner(stateDir, onNotice);
+  } catch (error) {
+    onNotice(`plugin compositions could not be signed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const byComposition = new Map<string, PublishedBundle>();
+  const byRoute = new Map<string, PublishedBundle>();
+  const publicationRoot =
+    signer === undefined ? undefined : fs.mkdtempSync(path.join(stateDir, 'plugin-publications-'));
+  let closed = false;
+  const routeKey = (compositionId: string, revision: number): string => `${compositionId}:${String(revision)}`;
+  const publish = (compositionId: string, assetsDir: string): PublishedBundle | undefined => {
+    if (closed) return undefined;
+    const existing = byComposition.get(compositionId);
+    if (existing !== undefined) return existing;
+    if (signer === undefined || publicationRoot === undefined) return undefined;
+    const stagingRoot = fs.mkdtempSync(path.join(publicationRoot, '.staging-'));
+    const snapshot = path.join(stagingRoot, 'assets');
+    try {
+      fs.cpSync(assetsDir, snapshot, { recursive: true });
+      const signed = signer.sign(snapshot);
+      if (signed === undefined) {
+        onNotice(`plugin composition '${compositionId}' is empty and cannot be published`);
+        return undefined;
+      }
+      const retainedDirectory = path.join(publicationRoot, `${compositionId}-${String(signed.manifest.revision)}`);
+      fs.renameSync(snapshot, retainedDirectory);
+      const published = { signed, assetsDir: retainedDirectory };
+      byComposition.set(compositionId, published);
+      byRoute.set(routeKey(compositionId, signed.manifest.revision), published);
+      while (byRoute.size > PLUGIN_PUBLICATION_LIMIT) {
+        const oldest = byRoute.entries().next().value as [string, PublishedBundle] | undefined;
+        if (oldest === undefined) break;
+        byRoute.delete(oldest[0]);
+        for (const [id, candidate] of byComposition) {
+          if (candidate === oldest[1]) byComposition.delete(id);
+        }
+        fs.rmSync(oldest[1].assetsDir, { recursive: true, force: true });
+      }
+      return published;
+    } catch (error) {
+      onNotice(
+        `plugin composition '${compositionId}' could not be signed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return undefined;
+    } finally {
+      fs.rmSync(stagingRoot, { recursive: true, force: true });
+    }
+  };
+
+  return {
+    publish,
+    get: (compositionId, revision) => byRoute.get(routeKey(compositionId, revision)),
+    publicKey: () => signer?.publicKey(),
+    close: () => {
+      if (closed) return;
+      closed = true;
+      byComposition.clear();
+      byRoute.clear();
+      if (publicationRoot !== undefined) fs.rmSync(publicationRoot, { recursive: true, force: true });
+    },
   };
 }

--- a/packages/clients/doompi-web/src/adapters/httpServer.ts
+++ b/packages/clients/doompi-web/src/adapters/httpServer.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { serve } from '@hono/node-server';
@@ -12,12 +13,11 @@ import { readSyncState, type SyncState } from '@agimon-ai/doompi/services/syncSt
 import type { DoomTelemetry } from '@agimon-ai/doompi-telemetry';
 import { BUNDLE_MANIFEST_ROUTE, assetFor } from '@agimon-ai/doompi-web-security';
 import { createPiHubService } from './piHubService.ts';
-import { createSyncGuard, type SyncGuard } from './syncGuard.ts';
+import { createSyncGuard } from './syncGuard.ts';
 import { createPiWebSocketListener } from './piWebSocketListener.ts';
 import { type Context, Hono } from 'hono';
 import { getCookie } from 'hono/cookie';
 import { bodyLimit } from 'hono/body-limit';
-import type { WebHubChannel } from '@agimon-ai/doompi-web-contracts';
 import {
   DOOM_API_ROUTE_PREFIX,
   type DoomApi,
@@ -26,7 +26,7 @@ import {
 } from '@agimon-ai/doompi-extension-contracts/package-api';
 import { loadPackageApis, PACKAGE_API_DIR_ENV } from '@agimon-ai/doompi-extension-contracts/package-api-loader';
 import { insideSandbox } from '@agimon-ai/doompi-extension-contracts/sandbox-harness';
-import { findRepositoryRoot } from '@agimon-ai/doompi/utils/repository';
+import { findRepositoryRoot, resolveDoomConfigurationRoot } from '@agimon-ai/doompi/utils/repository';
 import { sessionFileHeaders } from '../services/fileMedia.ts';
 import { contentTypeFor, resolveAssetPath } from '../services/staticAssets.ts';
 import { MAX_SESSION_FILE_BYTES, SESSION_FILE_ROUTE } from '../types/media.ts';
@@ -37,7 +37,6 @@ import {
   DIRECTORIES_API_ROUTE,
   HISTORY_REQUEST_TYPE,
   HUB_PROTOCOL_VERSION,
-  HUB_RESYNCED_TYPE,
   HUB_ROLE,
   SESSIONS_API_ROUTE,
   SESSIONS_SNAPSHOT_TYPE,
@@ -58,7 +57,7 @@ import { ATTACH_TYPE, type SessionFrame } from '../types/session.ts';
 import { readGitStatus } from './gitStatus.ts';
 import { readRegistryRecords, watchRegistry } from './registryWatcher.ts';
 import { createServerSpawner } from './serverSpawner.ts';
-import { createSessionHub, type SessionHub } from './sessionHub.ts';
+import { createSessionHub, type SessionHub, type SessionHubOptions } from './sessionHub.ts';
 import { allowedOriginsFromEnv } from '../services/remoteGuardPolicy.ts';
 import { describeStranded, planSessionMigration } from '../services/sessionMigration.ts';
 import { registerAuthRoutes } from './authRoutes.ts';
@@ -66,7 +65,7 @@ import { registerSettingsRoutes } from './settingsRoutes.ts';
 import { createProviderAuth } from './providerAuth.ts';
 import { createRemoteGuard } from './remoteGuard.ts';
 import { createRemoteAccess } from './remoteAccess.ts';
-import { createBundlePublication } from './bundlePublication.ts';
+import { createBundlePublication, createPluginBundlePublication } from './bundlePublication.ts';
 import { createLiveWebPush, type LiveWebPush } from './webPush.ts';
 import { createRemoteAccessStore } from './remoteAccessStore.ts';
 import { registerRemoteRoutes } from './remoteRoutes.ts';
@@ -100,7 +99,7 @@ import {
   shutdownWebTelemetry,
   WEB_TELEMETRY_ROUTE,
 } from './webTelemetry.ts';
-import { resolveWebComposition } from './webComposition.ts';
+import { resolveSessionWebArtifacts } from './sessionWebComposition.ts';
 
 // Pi's protocol rides its own socket so the DoomPi channel keeps the
 // vocabulary the protocol has no shape for: dialogs, minor modes, selection.
@@ -114,6 +113,8 @@ const WEB_PACKAGE_ROOT_ENV = 'DOOMPI_WEB_PACKAGE_ROOT';
 /** Comma-separated origins the operator allows past the guard, for dev setups this package cannot guess. */
 const ALLOW_ORIGIN_ENV = 'DOOMPI_WEB_ALLOW_ORIGIN';
 const RAW_BUNDLE_PREFIX = '/bundle-assets/';
+const PLUGIN_BUNDLE_PREFIX = '/api/web-plugins/';
+const VERIFIED_PLUGIN_PREFIX = '/verified-plugins/';
 const PWA_ASSET_PREFIX = '/pwa/';
 const SEALED_HTTP_VERSION = 1;
 /** Upper bound for any body accepted from the tunnel before route-specific limits. */
@@ -312,7 +313,7 @@ function threadKey(sessionId: string, threadId: string): string {
 function buildHub(
   options: WebServerOptions,
   notice: (message: string) => void,
-  channels: readonly WebHubChannel[],
+  plugins: Pick<SessionHubOptions, 'loadChannels' | 'webComposition'>,
   telemetry: DoomTelemetry,
 ): SessionHub {
   return createSessionHub({
@@ -323,7 +324,7 @@ function buildHub(
       onNotice: notice,
     }),
     readGit: readGitStatus,
-    channels,
+    ...plugins,
     telemetry,
     onNotice: notice,
   });
@@ -486,60 +487,27 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
       return undefined;
     }
   };
-  const compositionRoot = (directory: string): string | undefined => {
-    const repository = repositoryRoot(directory);
-    if (repository !== undefined) return repository;
-    const globalRoot = globalDoomConfigDirectory();
+  const compositionRoot = (directory: string): string => {
+    const home = os.homedir();
+    const root = resolveDoomConfigurationRoot(directory, home);
+    if (root === globalDoomConfigDirectory(home)) return root;
     try {
-      return readSyncRegistration(globalRoot)?.root;
-    } catch (error) {
-      notice(`global cockpit composition is unreadable (${describeError(error)})`);
-      return undefined;
+      return fs.realpathSync(root);
+    } catch {
+      return path.resolve(root);
     }
   };
   const pinnedRoot = options.compositionDir === undefined ? undefined : repositoryRoot(options.compositionDir);
   if (options.compositionDir !== undefined && pinnedRoot === undefined) {
     throw new Error(`Cockpit composition directory is not inside a repository: ${options.compositionDir}`);
   }
-  const initialRecords = readRegistryRecords(options.registryDir, notice);
-  const liveRoots = initialRecords
-    .map((record) => compositionRoot(record.cwd))
-    .filter((root): root is string => root !== undefined);
-  const compositionRoots = [...new Set(pinnedRoot === undefined ? liveRoots : [pinnedRoot])].sort((left, right) =>
-    left.localeCompare(right),
-  );
-  const syncGuards = new Map<string, SyncGuard>();
-  for (const root of compositionRoots) {
-    syncGuards.set(root, createSyncGuard({ repoRoot: root, onNotice: notice }));
-  }
-  await Promise.all([...syncGuards.values()].map(async (guard) => await guard.ensureSynced()));
-  const resolveComposition = async () =>
-    await resolveWebComposition({
-      repositoryRoots: compositionRoots,
-      stateDirectory: store.directory,
-      onNotice: notice,
-    });
-  // A repository whose web plugins cannot be bundled must not stop the hub
-  // from binding. Serving the packaged cockpit loses the plugins, which the
-  // notice says out loud, but a reachable hub can still be used to fix them;
-  // a hub that refused to start could not.
-  let startupComposition: Awaited<ReturnType<typeof resolveComposition>>;
-  try {
-    startupComposition = await resolveComposition();
-  } catch (error) {
-    notice(`the cockpit composition is unavailable (${describeError(error)}); serving the packaged bundle`);
-    startupComposition = undefined;
-  }
-  let served = {
-    assetsDir: resolveAssetsDir(options.assetsDir, startupComposition, notice),
-    apiDirectory: startupComposition?.apiDirectory,
-  };
-  const ensureSessionSynced = async (directory: string): Promise<void> => {
-    const root = compositionRoot(directory);
-    if (root === undefined) return;
-    const existing = syncGuards.get(root);
-    if (existing !== undefined) {
-      await existing.ensureSynced();
+  const cockpitRoot = globalDoomConfigDirectory(os.homedir());
+  const cockpitSyncGuard = createSyncGuard({ repoRoot: cockpitRoot, onNotice: notice });
+  await cockpitSyncGuard.ensureSynced();
+
+  const ensureRootSynced = async (root: string): Promise<void> => {
+    if (root === cockpitRoot) {
+      await cockpitSyncGuard.ensureSynced();
       return;
     }
     const guard = createSyncGuard({ repoRoot: root, onNotice: notice });
@@ -549,7 +517,55 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
       guard.close();
     }
   };
-  const hub = buildHub(options, notice, await loadHubChannels(served.assetsDir, notice), telemetry);
+  const ensureSessionSynced = async (directory: string): Promise<void> =>
+    await ensureRootSynced(compositionRoot(directory));
+  const initialRecords = readRegistryRecords(options.registryDir, notice);
+  const initialRoots = [
+    ...initialRecords.map((record) => compositionRoot(record.cwd)),
+    ...(pinnedRoot === undefined ? [] : [compositionRoot(pinnedRoot)]),
+  ];
+  await Promise.all([...new Set(initialRoots)].map(async (root) => await ensureRootSynced(root)));
+
+  // The shell is package-owned and stable. Synchronized roots contribute only
+  // immutable session plugin compositions and session-local hub channels.
+  const served = {
+    assetsDir: resolveAssetsDir(options.assetsDir, undefined, notice),
+    apiDirectory: undefined,
+  };
+  const pluginPublication = createPluginBundlePublication(store.directory, notice);
+  const hub = buildHub(
+    options,
+    notice,
+    {
+      loadChannels: async (record) => {
+        const root = compositionRoot(record.cwd);
+        await ensureRootSynced(root);
+        const registration = readSyncRegistration(root);
+        return registration?.webDirectory === null || registration?.webDirectory === undefined
+          ? []
+          : await loadHubChannels(registration.webDirectory, notice);
+      },
+      webComposition: (record, channels) => {
+        const artifacts = resolveSessionWebArtifacts(compositionRoot(record.cwd));
+        if (artifacts === undefined) return undefined;
+        const published = pluginPublication.publish(artifacts.id, artifacts.pluginsDir);
+        if (published === undefined) return undefined;
+        const revision = published.signed.manifest.revision;
+        const route = `${PLUGIN_BUNDLE_PREFIX}${artifacts.id}/${String(revision)}`;
+        return {
+          id: artifacts.id,
+          revision,
+          manifestUrl: `${route}/manifest`,
+          rawAssetBaseUrl: `${route}/assets`,
+          verifiedAssetBaseUrl: `${VERIFIED_PLUGIN_PREFIX}${artifacts.id}/${String(revision)}`,
+          entryPath: artifacts.entryPath,
+          stylePaths: artifacts.stylePaths,
+          channels: [...channels],
+        };
+      },
+    },
+    telemetry,
+  );
   // Threads are journals the data channels can name (a subagent run's own
   // session file); the hub tails one only while a page follows it.
   const threads = createThreadJournals({
@@ -951,6 +967,18 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
     if (!isRecord(body) || typeof body.cwd !== 'string' || body.cwd === '') {
       return context.json({ error: 'A cwd string is required.' }, 400);
     }
+    let stats: fs.Stats;
+    try {
+      stats = fs.statSync(body.cwd);
+    } catch {
+      return context.json({ error: `No such directory: ${body.cwd}` }, 400);
+    }
+    if (!path.isAbsolute(body.cwd) || !stats.isDirectory()) {
+      return context.json(
+        { error: `The working directory must be an absolute path to a directory, received "${body.cwd}".` },
+        400,
+      );
+    }
     const name = typeof body.name === 'string' && body.name !== '' ? body.name : undefined;
     await ensureSessionSynced(body.cwd);
     const outcome = await hub.create({ cwd: body.cwd, name, trace: readTraceContext(context.req.raw.headers) });
@@ -1190,7 +1218,7 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
           if (
             typeof parsed.type === 'string' &&
             hub.channelTypes().includes(parsed.type) &&
-            (subscriptions.has(sessionId) || hub.channelReceivesWithoutSubscription(parsed.type))
+            (subscriptions.has(sessionId) || hub.channelReceivesWithoutSubscription(sessionId, parsed.type))
           ) {
             hub.receiveChannel(sessionId, parsed.type, parsed.payload, connectionId);
             return;
@@ -1359,6 +1387,33 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
       'X-Content-Type-Options': 'nosniff',
     });
   });
+  app.get(`${PLUGIN_BUNDLE_PREFIX}*`, (context) => {
+    const requested = new URL(context.req.url).pathname;
+    const matched = /^\/api\/web-plugins\/([a-f0-9]{64})\/([1-9][0-9]*)\/(manifest|assets(\/.*))$/u.exec(requested);
+    const revision = matched === null ? undefined : Number(matched[2]);
+    const published =
+      matched === null || !Number.isSafeInteger(revision)
+        ? undefined
+        : pluginPublication.get(matched[1] ?? '', revision as number);
+    if (matched === null || published === undefined) {
+      return context.text('That signed plugin composition is unavailable.', 404);
+    }
+    if (matched[3] === 'manifest') {
+      return context.json(published.signed, 200, { 'Cache-Control': 'no-store' });
+    }
+    const asset = assetFor(published.signed.manifest, matched[4] ?? '');
+    const file = asset === undefined ? undefined : resolveAssetPath(published.assetsDir, asset.path);
+    const body = file === undefined ? undefined : readAsset(file);
+    if (asset === undefined || file === undefined || body === undefined) {
+      return context.text('Plugin composition asset not found.', 404);
+    }
+    return context.body(new Uint8Array(body), 200, {
+      'Cache-Control': 'no-store',
+      'Content-Length': String(body.byteLength),
+      'Content-Type': asset.contentType,
+      'X-Content-Type-Options': 'nosniff',
+    });
+  });
   app.get(BUNDLE_MANIFEST_ROUTE, (context) => {
     const current = publication.current();
     if (current === undefined) return context.json({ error: 'No signed cockpit bundle is available.' }, 503);
@@ -1400,24 +1455,13 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
     return context.text('Not found.', 404);
   });
 
-  // A rebuilt bundle only changes on disk, so re-resolve the synchronized
-  // registrations and tell every page to stage the replacement.
-  const refreshServedComposition = async (): Promise<void> => {
-    try {
-      const rebuilt = await resolveComposition();
-      if (rebuilt !== undefined && rebuilt.webDirectory !== served.assetsDir) {
-        served = { assetsDir: rebuilt.webDirectory, apiDirectory: rebuilt.apiDirectory };
-        notice(`serving the rebuilt cockpit bundle from ${served.assetsDir}`);
-      }
-      publication.refresh();
-      broadcast({ type: HUB_RESYNCED_TYPE }, false);
-    } catch (error) {
-      notice(`the rebuilt cockpit composition is unavailable (${describeError(error)}); keeping the served bundle`);
+  // Only the global cockpit configuration is watched. A completed global sync
+  // reloads the matching sessions' plugins without replacing the stable shell.
+  cockpitSyncGuard.watch(() => {
+    for (const record of hub.records()) {
+      if (compositionRoot(record.cwd) === cockpitRoot) hub.reloadChannels(record.id);
     }
-  };
-  for (const guard of syncGuards.values()) {
-    guard.watch(() => void refreshServedComposition());
-  }
+  });
 
   return new Promise<WebServer>((resolve, reject) => {
     const server = serve({ fetch: app.fetch, port: options.port, hostname: host }, (info) => {
@@ -1434,7 +1478,7 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
         await remote.close();
         await new Promise<void>((done) => {
           threads.close();
-          for (const guard of syncGuards.values()) guard.close();
+          cockpitSyncGuard.close();
           void localProtocolServer.close();
           void remoteProtocolServer.close();
           disconnectLivePush();
@@ -1442,6 +1486,7 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
           hub.close();
           providerAuth.close();
           for (const handler of pluginApis) handler.close();
+          pluginPublication.close();
           // An upgraded socket leaves the HTTP server's connection tracking,
           // so only the WebSocket server can let go of it. Without this the
           // close callback waits on a browser that has no reason to leave.
@@ -1459,6 +1504,7 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
       });
     });
     server.once('error', (error) => {
+      cockpitSyncGuard.close();
       threads.close();
       disconnectLivePush();
       livePush?.close();
@@ -1466,6 +1512,7 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
       providerAuth.close();
       void remote.close();
       for (const handler of pluginApis) handler.close();
+      pluginPublication.close();
       void telemetry.shutdown();
       reject(error);
     });

--- a/packages/clients/doompi-web/src/adapters/sessionHub.ts
+++ b/packages/clients/doompi-web/src/adapters/sessionHub.ts
@@ -28,6 +28,7 @@ import {
   type SessionBacklogFrame,
   type SessionGitStatus,
   type SessionSummary,
+  type SessionWebComposition,
 } from '../types/hub.ts';
 import type { SessionRecord } from '../types/registry.ts';
 import { REPLAY_TYPE, type BridgeState, type SessionFrame } from '../types/session.ts';
@@ -111,8 +112,12 @@ export interface SessionHubOptions {
   spawner?: SessionSpawner;
   /** Injectable for tests; defaults to asking git about the session cwd. */
   readGit?: (cwd: string) => Promise<SessionGitStatus | undefined>;
-  /** The hub's data channels (built-in and plugin-provided sources). */
+  /** Base channels installed into every session-local channel registry. */
   channels?: readonly WebHubChannel[];
+  /** Dynamically loads the channel composition resolved for one session. */
+  loadChannels?: (record: SessionRecord) => Promise<readonly WebHubChannel[]>;
+  /** Advertises the signed client composition paired with one session's loaded channels. */
+  webComposition?: (record: SessionRecord, channelTypes: readonly string[]) => SessionWebComposition | undefined;
   /** Injectable for tests; defaults to SIGTERM, which doompi-server treats as a clean stop. */
   signal?: (pid: number) => void;
   /** How long a restart waits for the stopped server to withdraw its record. */
@@ -148,12 +153,14 @@ export interface SessionHub {
   channelFrames(sessionId: string): ChannelFrame[];
   /** The journal behind one thread of a session, from the first data channel that names it; undefined until one does. */
   threadJournal(sessionId: string, threadId: string): string | undefined;
-  /** Whether a channel accepts authenticated acknowledgements after subscription changes. */
-  channelReceivesWithoutSubscription(frameType: string): boolean;
+  /** Whether one session's channel accepts authenticated acknowledgements after subscription changes. */
+  channelReceivesWithoutSubscription(sessionId: string, frameType: string): boolean;
   /** Routes a page payload to exactly one loaded channel for a live session. */
   receiveChannel(sessionId: string, frameType: string, payload: unknown, connectionId: string): void;
   /** Withdraws connection-scoped channel state when a page socket closes. */
   disconnectChannels(connectionId: string): void;
+  /** Reloads one session's channels after its synchronized generation changes. */
+  reloadChannels(sessionId: string): void;
   command(sessionId: string, frame: SessionFrame): void;
   create(input: SpawnSessionInput): Promise<SpawnOutcome>;
   /**
@@ -211,6 +218,9 @@ interface ManagedSession {
    * cannot let a later command overtake an earlier one.
    */
   commands: Promise<void>;
+  /** Channel definitions and sources loaded only for this session's composition. */
+  channels: StartedChannel[];
+  channelLoadToken: symbol;
 }
 
 interface StartedChannel {
@@ -389,57 +399,38 @@ export function createSessionHub(options: SessionHubOptions): SessionHub {
     return true;
   };
 
-  const startedChannels: StartedChannel[] = (options.channels ?? []).map((channel) => ({
-    channel,
-    frameType: channel.frameType,
-    source: channel.start({
-      sessions: () => [...sessions.values()].map((managed) => scopeOf(managed.record)),
-      publish: (sessionId, payload) => {
-        if (closed) return;
-        emit({ kind: 'channel', frameType: channel.frameType, sessionId, payload });
-      },
-      publishToConnection: (connectionId, sessionId, payload) => {
-        if (closed || connectionId === '') return false;
-        emit({ kind: 'channel', frameType: channel.frameType, sessionId, payload, connectionId });
-        return true;
-      },
-      requestSessionApi: async (scope, request) => {
-        const managed = sessions.get(scope.sessionId);
-        if (managed === undefined || managed.record.cwd !== scope.cwd || managed.record.apiSocketPath === undefined)
-          return Response.json({ error: 'Session API unavailable.' }, { status: 404 });
-        const token = readTokenFile(managed.record);
-        const headers = new Headers({ authorization: `Bearer ${token}` });
-        return await proxyToSocket({
-          socketPath: managed.record.apiSocketPath,
-          path: sessionApiPath(request),
-          method: request.method,
-          headers,
-          body: request.body ?? null,
-          ...(request.signal === undefined ? {} : { signal: request.signal }),
-        });
-      },
-      onNotice: (message) => options.onNotice?.(message),
-    }),
-  }));
-
-  const toSummary = (managed: ManagedSession): SessionSummary => ({
-    id: managed.record.id,
-    name: managed.presence.sessionName ?? managed.record.name,
-    cwd: managed.record.cwd,
-    createdAt: managed.record.createdAt,
-    updatedAt: managed.presence.updatedAt,
-    phase: managed.presence.phase,
-    phaseSince: managed.presence.phaseSince,
-    attach: managed.attach,
-    ...(managed.attachReason === undefined ? {} : { attachReason: managed.attachReason }),
-    pendingMessageCount: managed.presence.pendingMessageCount,
-    everPrompted: managed.presence.everPrompted,
-    awaitingInput: managed.presence.awaitingInput,
-    ...(managed.presence.lastSettledAt === undefined ? {} : { lastSettledAt: managed.presence.lastSettledAt }),
-    socketPath: managed.record.socketPath,
-    ...(managed.record.apiSocketPath === undefined ? {} : { apiSocketPath: managed.record.apiSocketPath }),
-    ...(managed.git === undefined ? {} : { git: managed.git }),
-  });
+  const toSummary = (managed: ManagedSession): SessionSummary => {
+    let webComposition: SessionWebComposition | undefined;
+    try {
+      webComposition = options.webComposition?.(
+        managed.record,
+        managed.channels.map((channel) => channel.frameType),
+      );
+    } catch (error) {
+      options.onNotice?.(
+        `session ${managed.record.id} plugin composition unavailable (${error instanceof Error ? error.message : String(error)})`,
+      );
+    }
+    return {
+      id: managed.record.id,
+      name: managed.presence.sessionName ?? managed.record.name,
+      cwd: managed.record.cwd,
+      createdAt: managed.record.createdAt,
+      updatedAt: managed.presence.updatedAt,
+      phase: managed.presence.phase,
+      phaseSince: managed.presence.phaseSince,
+      attach: managed.attach,
+      ...(managed.attachReason === undefined ? {} : { attachReason: managed.attachReason }),
+      pendingMessageCount: managed.presence.pendingMessageCount,
+      everPrompted: managed.presence.everPrompted,
+      awaitingInput: managed.presence.awaitingInput,
+      ...(managed.presence.lastSettledAt === undefined ? {} : { lastSettledAt: managed.presence.lastSettledAt }),
+      socketPath: managed.record.socketPath,
+      ...(managed.record.apiSocketPath === undefined ? {} : { apiSocketPath: managed.record.apiSocketPath }),
+      ...(managed.git === undefined ? {} : { git: managed.git }),
+      ...(webComposition === undefined ? {} : { webComposition }),
+    };
+  };
 
   const pushSummary = (managed: ManagedSession): void => {
     const summary = toSummary(managed);
@@ -447,6 +438,86 @@ export function createSessionHub(options: SessionHubOptions): SessionHub {
     if (json === managed.lastSummaryJson) return;
     managed.lastSummaryJson = json;
     emit({ kind: 'upsert', session: summary });
+  };
+
+  const closeSessionChannels = (managed: ManagedSession): void => {
+    for (const started of managed.channels) {
+      started.source.sessionRemoved?.(managed.record.id);
+      started.source.close();
+    }
+    managed.channels = [];
+  };
+
+  const startSessionChannels = async (managed: ManagedSession): Promise<void> => {
+    const token = managed.channelLoadToken;
+    let definitions: readonly WebHubChannel[];
+    try {
+      const dynamic = options.loadChannels === undefined ? [] : await options.loadChannels(managed.record);
+      definitions = [...(options.channels ?? []), ...dynamic];
+    } catch (error) {
+      options.onNotice?.(
+        `session ${managed.record.id} hub plugins unavailable (${error instanceof Error ? error.message : String(error)})`,
+      );
+      return;
+    }
+    if (closed || sessions.get(managed.record.id) !== managed || managed.channelLoadToken !== token) return;
+
+    const seen = new Set<string>();
+    const scope = scopeOf(managed.record);
+    for (const channel of definitions) {
+      if (seen.has(channel.frameType)) {
+        options.onNotice?.(
+          `duplicate web channel '${channel.frameType}' dropped for session ${managed.record.id}; frame types are session-local`,
+        );
+        continue;
+      }
+      seen.add(channel.frameType);
+      try {
+        const source = channel.start({
+          sessions: () => [scopeOf(managed.record)],
+          publish: (sessionId, payload) => {
+            if (closed || sessionId !== managed.record.id) return;
+            emit({ kind: 'channel', frameType: channel.frameType, sessionId, payload });
+          },
+          publishToConnection: (connectionId, sessionId, payload) => {
+            if (closed || connectionId === '' || sessionId !== managed.record.id) return false;
+            emit({ kind: 'channel', frameType: channel.frameType, sessionId, payload, connectionId });
+            return true;
+          },
+          requestSessionApi: async (requestedScope, request) => {
+            const current = sessions.get(requestedScope.sessionId);
+            if (
+              current !== managed ||
+              current.record.cwd !== requestedScope.cwd ||
+              current.record.apiSocketPath === undefined
+            ) {
+              return Response.json({ error: 'Session API unavailable.' }, { status: 404 });
+            }
+            const token = readTokenFile(current.record);
+            const headers = new Headers({ authorization: `Bearer ${token}` });
+            return await proxyToSocket({
+              socketPath: current.record.apiSocketPath,
+              path: sessionApiPath(request),
+              method: request.method,
+              headers,
+              body: request.body ?? null,
+              ...(request.signal === undefined ? {} : { signal: request.signal }),
+            });
+          },
+          onNotice: (message) => options.onNotice?.(message),
+        });
+        managed.channels.push({ channel, frameType: channel.frameType, source });
+        source.sessionAdded?.(scope);
+        const payload = source.payloadFor(scope);
+        if (payload !== undefined)
+          emit({ kind: 'channel', frameType: channel.frameType, sessionId: scope.sessionId, payload });
+      } catch (error) {
+        options.onNotice?.(
+          `web channel '${channel.frameType}' failed for session ${managed.record.id} (${error instanceof Error ? error.message : String(error)})`,
+        );
+      }
+    }
+    pushSummary(managed);
   };
 
   const refreshGit = (managed: ManagedSession): void => {
@@ -579,6 +650,8 @@ export function createSessionHub(options: SessionHubOptions): SessionHub {
       restoredJournal: false,
       frameCount: 0,
       commands: Promise.resolve(),
+      channels: [],
+      channelLoadToken: Symbol(record.id),
     };
     sessions.set(record.id, managed);
     options.onNotice?.(`session ${record.id} (${record.name}) appeared`);
@@ -586,7 +659,7 @@ export function createSessionHub(options: SessionHubOptions): SessionHub {
     startAttachment(managed);
     pushSummary(managed);
     refreshGit(managed);
-    for (const channel of startedChannels) channel.source.sessionAdded?.(scopeOf(record));
+    void startSessionChannels(managed);
   };
 
   const reconcile = (records: SessionRecord[]): void => {
@@ -612,6 +685,8 @@ export function createSessionHub(options: SessionHubOptions): SessionHub {
     for (const [id, managed] of sessions) {
       if (seen.has(id)) continue;
       managed.attachment?.close();
+      managed.channelLoadToken = Symbol(id);
+      closeSessionChannels(managed);
       sessions.delete(id);
       const ring = managed.ring.snapshot();
       emitTelemetry('web.session.summary', {
@@ -620,7 +695,6 @@ export function createSessionHub(options: SessionHubOptions): SessionHub {
         'session.state': 'removed',
       });
       emitTelemetry('web.session.lifecycle', { 'session.state': 'removed', 'session.count': sessions.size });
-      for (const channel of startedChannels) channel.source.sessionRemoved?.(id);
       options.onNotice?.(`session ${id} left`);
       emit({ kind: 'removed', sessionId: id });
     }
@@ -682,14 +756,16 @@ export function createSessionHub(options: SessionHubOptions): SessionHub {
       };
     },
     channelTypes() {
-      return startedChannels.map((channel) => channel.frameType);
+      return [
+        ...new Set([...sessions.values()].flatMap((managed) => managed.channels.map((channel) => channel.frameType))),
+      ];
     },
     channelFrames(sessionId) {
       const managed = sessions.get(sessionId);
       if (!managed) return [];
       const scope = scopeOf(managed.record);
       const frames: ChannelFrame[] = [];
-      for (const channel of startedChannels) {
+      for (const channel of managed.channels) {
         const payload = channel.source.payloadFor(scope);
         if (payload !== undefined) frames.push({ type: channel.frameType, sessionId, payload });
       }
@@ -699,26 +775,40 @@ export function createSessionHub(options: SessionHubOptions): SessionHub {
       const managed = sessions.get(sessionId);
       if (!managed) return undefined;
       const scope = scopeOf(managed.record);
-      for (const channel of startedChannels) {
+      for (const channel of managed.channels) {
         const journal = channel.source.threadJournal?.(scope, threadId);
         if (journal !== undefined) return journal;
       }
       return undefined;
     },
-    channelReceivesWithoutSubscription(frameType) {
-      return startedChannels.some(
-        (candidate) => candidate.frameType === frameType && candidate.channel.receiveWithoutSubscription === true,
+    channelReceivesWithoutSubscription(sessionId, frameType) {
+      return (
+        sessions
+          .get(sessionId)
+          ?.channels.some(
+            (candidate) => candidate.frameType === frameType && candidate.channel.receiveWithoutSubscription === true,
+          ) ?? false
       );
     },
     receiveChannel(sessionId, frameType, payload, connectionId) {
       const managed = sessions.get(sessionId);
       if (managed === undefined || connectionId === '') return;
-      const started = startedChannels.find((candidate) => candidate.frameType === frameType);
+      const started = managed.channels.find((candidate) => candidate.frameType === frameType);
       started?.channel.receive?.(scopeOf(managed.record), payload, { connectionId });
     },
     disconnectChannels(connectionId) {
       if (connectionId === '') return;
-      for (const started of startedChannels) started.channel.disconnected?.({ connectionId });
+      for (const managed of sessions.values()) {
+        for (const started of managed.channels) started.channel.disconnected?.({ connectionId });
+      }
+    },
+    reloadChannels(sessionId) {
+      const managed = sessions.get(sessionId);
+      if (managed === undefined) return;
+      managed.channelLoadToken = Symbol(sessionId);
+      closeSessionChannels(managed);
+      pushSummary(managed);
+      void startSessionChannels(managed);
     },
     command(sessionId, frame) {
       const managed = sessions.get(sessionId);
@@ -827,9 +917,10 @@ export function createSessionHub(options: SessionHubOptions): SessionHub {
     close() {
       closed = true;
       options.source.close();
-      for (const channel of startedChannels) channel.source.close();
       if (gitTimer) clearInterval(gitTimer);
       for (const managed of sessions.values()) {
+        managed.channelLoadToken = Symbol(managed.record.id);
+        closeSessionChannels(managed);
         managed.attachment?.close();
         emitTelemetry('web.session.summary', {
           frames: managed.frameCount,

--- a/packages/clients/doompi-web/src/adapters/sessionWebComposition.ts
+++ b/packages/clients/doompi-web/src/adapters/sessionWebComposition.ts
@@ -1,0 +1,59 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { readSyncRegistration } from '@agimon-ai/doompi/services';
+
+const CLIENT_ENTRY = 'composition.js';
+const VITE_MANIFEST = 'manifest.json';
+
+export interface SessionWebArtifacts {
+  id: string;
+  pluginsDir: string;
+  entryPath: string;
+  stylePaths: string[];
+}
+
+interface ViteManifestEntry {
+  file?: unknown;
+  isEntry?: unknown;
+  css?: unknown;
+}
+
+function stylePaths(manifestPath: string): string[] {
+  const parsed: unknown = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return [];
+  const entries = Object.values(parsed as Record<string, ViteManifestEntry>);
+  const entry = entries.find((candidate) => candidate.isEntry === true && candidate.file === CLIENT_ENTRY);
+  const styles = [
+    ...(entry !== undefined && Array.isArray(entry.css) ? entry.css : []),
+    ...entries.map((candidate) => candidate.file).filter((file) => typeof file === 'string' && file.endsWith('.css')),
+  ];
+  return [...new Set(styles)]
+    .filter((value): value is string => typeof value === 'string' && value !== '')
+    .map((value) => `/${value.replace(/^\/+/, '')}`);
+}
+
+/** Resolves the immutable standalone plugin artifacts emitted by the root's latest sync. */
+export function resolveSessionWebArtifacts(configurationRoot: string): SessionWebArtifacts | undefined {
+  const registration = readSyncRegistration(configurationRoot);
+  if (registration?.webDirectory === null || registration?.webDirectory === undefined) return undefined;
+  const pluginsDir = path.join(path.dirname(registration.webDirectory), 'plugins');
+  const entryFile = path.join(pluginsDir, CLIENT_ENTRY);
+  const manifestFile = path.join(pluginsDir, VITE_MANIFEST);
+  if (!fs.existsSync(entryFile) || !fs.existsSync(manifestFile)) return undefined;
+  const id = createHash('sha256')
+    .update(
+      JSON.stringify({
+        root: registration.root,
+        generation: registration.generation,
+        stateSha256: registration.stateSha256,
+      }),
+    )
+    .digest('hex');
+  return {
+    id,
+    pluginsDir,
+    entryPath: `/${CLIENT_ENTRY}`,
+    stylePaths: stylePaths(manifestFile),
+  };
+}

--- a/packages/clients/doompi-web/src/adapters/syncGuard.ts
+++ b/packages/clients/doompi-web/src/adapters/syncGuard.ts
@@ -8,6 +8,8 @@ import { repositoryDoomPiCli } from './bundledServer.ts';
 const DOOMPI_PACKAGE = '@agimon-ai/doompi';
 const AGENT_COMMAND_ENV = 'DOOMPI_AGENT_COMMAND';
 const SYNC_COMMAND_ENV = 'DOOMPI_SYNC_COMMAND';
+const BOOTSTRAP_ENTRY_ENV = 'DOOMPI_BOOTSTRAP_ENTRY';
+const HARNESS_ROOT_ENV = 'DOOMPI_ROOT';
 const CLI_SEGMENTS = ['dist', 'bin', 'cli.mjs'];
 const SYNC_ARGS = ['sync'];
 /** How often the watcher re-reads the drift inputs. */
@@ -28,8 +30,8 @@ export interface SyncGuardOptions {
   onNotice?: (message: string) => void;
   /** Test seam for running the sync itself; returning nothing reads as success. */
   runSync?: (repoRoot: string) => Promise<SyncRunOutcome | void>;
-  /** Test seam for the drift read. */
-  readDrift?: (repoRoot: string) => { fresh: boolean; reasons: readonly string[] };
+  /** Test seam for the per-repository drift read and launcher-owned Doom entry. */
+  readDrift?: (repoRoot: string, expectedBootstrapEntry?: string) => { fresh: boolean; reasons: readonly string[] };
   /** Test seam over repository discovery. */
   findRoot?: (cwd: string) => string;
   intervalMs?: number;
@@ -75,7 +77,11 @@ function syncCliFor(repoRoot: string): string {
 function spawnSync(repoRoot: string): Promise<SyncRunOutcome> {
   const cli = syncCliFor(repoRoot);
   return new Promise((resolve) => {
-    const child = spawn(process.execPath, [cli, ...SYNC_ARGS], { cwd: repoRoot, stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawn(process.execPath, [cli, ...SYNC_ARGS], {
+      cwd: repoRoot,
+      env: { ...process.env, [HARNESS_ROOT_ENV]: repoRoot },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
     const tail: string[] = [];
     const keep = (chunk: Buffer): void => {
       tail.push(chunk.toString());
@@ -113,7 +119,10 @@ export function createSyncGuard(options: SyncGuardOptions): SyncGuard {
     }
   }
   const runSync = options.runSync ?? ((root: string) => spawnSync(root));
-  const readDrift = options.readDrift ?? ((root: string) => readSyncDrift({ repoRoot: root }));
+  const expectedBootstrapEntry = process.env[BOOTSTRAP_ENTRY_ENV];
+  const readDrift =
+    options.readDrift ??
+    ((root: string, entry?: string) => readSyncDrift({ repoRoot: root, expectedBootstrapEntry: entry }));
   const baseInterval = options.intervalMs ?? WATCH_INTERVAL_MS;
   let inFlight: Promise<boolean> | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -141,7 +150,7 @@ export function createSyncGuard(options: SyncGuardOptions): SyncGuard {
       }
       return false;
     }
-    const remaining = readDrift(repoRoot);
+    const remaining = readDrift(repoRoot, expectedBootstrapEntry);
     if (!remaining.fresh) {
       consecutiveFailures += 1;
       const message = `sync completed but did not resolve drift (${describeSyncDrift({ fresh: false, reasons: remaining.reasons as never })})`;
@@ -162,7 +171,7 @@ export function createSyncGuard(options: SyncGuardOptions): SyncGuard {
     // Joining the run already in flight is what makes concurrent launches
     // wait for one sync instead of starting several.
     if (inFlight) return inFlight;
-    const drift = readDrift(repoRoot);
+    const drift = readDrift(repoRoot, expectedBootstrapEntry);
     if (drift.fresh) return false;
     inFlight = syncOnce(drift).finally(() => {
       inFlight = undefined;
@@ -191,7 +200,7 @@ export function createSyncGuard(options: SyncGuardOptions): SyncGuard {
           schedule();
           return;
         }
-        const drift = readDrift(repoRoot);
+        const drift = readDrift(repoRoot, expectedBootstrapEntry);
         if (drift.fresh) {
           schedule();
           return;

--- a/packages/clients/doompi-web/src/adapters/webBundler.ts
+++ b/packages/clients/doompi-web/src/adapters/webBundler.ts
@@ -3,7 +3,13 @@ import path from 'node:path';
 import { PLUGIN_ROOTS_FILE } from '../services/webDevRoots.ts';
 import { SERVER_REGISTRY_FILE, webHostPackageRoot, writeSyncWebPluginModules } from './webPluginGenerate.ts';
 import { scanWebPlugins } from './webPluginScan.ts';
-import { webPluginCssAlias, webPluginOverridePlugin } from './webPluginVite.ts';
+import {
+  WEB_PLUGIN_RUNTIME_SPECIFIERS,
+  webPluginCssAlias,
+  webPluginOverridePlugin,
+  webPluginRuntimeAliases,
+  webPluginRuntimeGlobal,
+} from './webPluginVite.ts';
 
 /** Shared runtime packages every plugin's client code must resolve to the host copies. */
 const DEDUPED_RUNTIMES = [
@@ -26,14 +32,16 @@ const DEDUPED_RUNTIMES = [
 export interface BundleCockpitWebOptions {
   /** Package roots to scan for doompiWeb manifests, usually the installed composition. */
   pluginRoots: readonly string[];
-  /** Output directory; receives web/ (the bundle), generated/ (the entry modules), and pluginRoots.json. */
+  /** Output directory; receives web/, plugins/, generated/, and pluginRoots.json. */
   outDir: string;
   onNotice?: (message: string) => void;
 }
 
 export interface BundleCockpitWebResult {
-  /** Public assets directory. Server-only registry metadata remains beside it. */
+  /** Full synchronized SPA retained for CLI compatibility. */
   assetsDir: string;
+  /** Standalone session plugin composition artifacts. */
+  pluginsDir: string;
   pluginIds: string[];
 }
 
@@ -58,6 +66,7 @@ export async function bundleCockpitWeb(options: BundleCockpitWebOptions): Promis
 
   const generatedDir = path.join(options.outDir, 'generated');
   const assetsDir = path.join(options.outDir, 'web');
+  const pluginsDir = path.join(options.outDir, 'plugins');
   const generated = writeSyncWebPluginModules(plugins, generatedDir);
   const roots = [...new Set(options.pluginRoots.map((root) => path.resolve(root)))];
   fs.writeFileSync(path.join(options.outDir, PLUGIN_ROOTS_FILE), `${JSON.stringify(roots, null, 2)}\n`);
@@ -78,7 +87,7 @@ export async function bundleCockpitWeb(options: BundleCockpitWebOptions): Promis
     plugins: [webPluginOverridePlugin(clientRoot, generated), react(), tailwindcss()],
     resolve: {
       dedupe: [...DEDUPED_RUNTIMES],
-      alias: [webPluginCssAlias(generated)],
+      alias: [...webPluginRuntimeAliases(clientRoot), webPluginCssAlias(generated)],
     },
     build: {
       outDir: assetsDir,
@@ -87,6 +96,40 @@ export async function bundleCockpitWeb(options: BundleCockpitWebOptions): Promis
     },
   });
 
+  await build({
+    configFile: false,
+    envDir: false,
+    logLevel: 'warn',
+    base: './',
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      dedupe: [...DEDUPED_RUNTIMES],
+      alias: [webPluginCssAlias(generated)],
+    },
+    build: {
+      cssCodeSplit: false,
+      outDir: pluginsDir,
+      emptyOutDir: true,
+      sourcemap: false,
+      assetsInlineLimit: 0,
+      manifest: 'manifest.json',
+      rollupOptions: {
+        input: generated.compositionModulePath,
+        external: [...WEB_PLUGIN_RUNTIME_SPECIFIERS],
+        output: {
+          format: 'iife',
+          name: 'DoomPiWebPluginCompositionBundle',
+          entryFileNames: 'composition.js',
+          globals: Object.fromEntries(
+            WEB_PLUGIN_RUNTIME_SPECIFIERS.map((specifier) => [specifier, webPluginRuntimeGlobal(specifier)]),
+          ),
+          assetFileNames: 'assets/[name]-[hash][extname]',
+        },
+      },
+    },
+  });
+  fs.writeFileSync(path.join(pluginsDir, 'index.html'), '<!doctype html>\n<title>DoomPi plugin composition</title>\n');
+
   fs.writeFileSync(path.join(options.outDir, SERVER_REGISTRY_FILE), generated.serverRegistry);
-  return { assetsDir, pluginIds: plugins.map((plugin) => plugin.pluginId) };
+  return { assetsDir, pluginsDir, pluginIds: plugins.map((plugin) => plugin.pluginId) };
 }

--- a/packages/clients/doompi-web/src/adapters/webPluginGenerate.ts
+++ b/packages/clients/doompi-web/src/adapters/webPluginGenerate.ts
@@ -98,10 +98,13 @@ function pluginSourceRoot(plugin: DeclaredWebPlugin): string {
   return path.dirname(path.join(plugin.packageDir, plugin.client.entry));
 }
 
-function renderCssModule(plugins: readonly DeclaredWebPlugin[]): string {
-  const lines = [`/* ${HEADER.slice(3)} */`];
+function renderCssModule(plugins: readonly DeclaredWebPlugin[], leadingSourceRoots: readonly string[]): string {
+  // Sync CSS is compiled from a generated directory, so Tailwind cannot infer
+  // the stable shell tree from app.css. Its caller names that tree explicitly
+  // so later plugin utilities do not override missing responsive shell utilities.
+  const lines = [`/* ${HEADER.slice(3)} */`, ...leadingSourceRoots.map((root) => `@source "${root}";`)];
   for (const plugin of plugins) {
-    if (plugin.isHost) continue; // The host tree is already inside Tailwind's scan root.
+    if (plugin.isHost) continue;
     lines.push(`@source "${pluginSourceRoot(plugin)}";`);
   }
   lines.push('');
@@ -136,7 +139,7 @@ export function renderBuiltinWebPluginModules(): Map<string, string> {
   return new Map([
     [BUILTIN_CLIENT_MODULE, renderClientModule(plugins, 'relative')],
     [BUILTIN_HUB_MODULE, renderBuiltinHubModule(plugins)],
-    [BUILTIN_CSS_MODULE, renderCssModule(plugins)],
+    [BUILTIN_CSS_MODULE, renderCssModule(plugins, [])],
   ]);
 }
 
@@ -167,6 +170,7 @@ export function ensureBuiltinWebPluginModules({ check = false }: { check?: boole
 
 export interface SyncGeneratedModules {
   clientModulePath: string;
+  compositionModulePath: string;
   cssModulePath: string;
   serverRegistry: string;
 }
@@ -183,8 +187,18 @@ export function writeSyncWebPluginModules(
 ): SyncGeneratedModules {
   fs.mkdirSync(generatedDir, { recursive: true });
   const clientModulePath = path.join(generatedDir, 'webPlugins.generated.ts');
+  const compositionModulePath = path.join(generatedDir, 'webPluginComposition.generated.ts');
   const cssModulePath = path.join(generatedDir, 'webPluginSources.generated.css');
   fs.writeFileSync(clientModulePath, renderClientModule(plugins, 'absolute'));
-  fs.writeFileSync(cssModulePath, renderCssModule(plugins));
-  return { clientModulePath, cssModulePath, serverRegistry: renderServerRegistry(plugins) };
+  fs.writeFileSync(
+    compositionModulePath,
+    `${HEADER}\nimport '${pathToFileURL(path.join(packageRoot, 'src', 'web', 'styles', 'app.css')).href}';\nimport { webPlugins } from './webPlugins.generated.ts';\n\nglobalThis.DoomPiWebPluginComposition = webPlugins;\n`,
+  );
+  fs.writeFileSync(cssModulePath, renderCssModule(plugins, [path.join(packageRoot, 'src', 'web')]));
+  return {
+    clientModulePath,
+    compositionModulePath,
+    cssModulePath,
+    serverRegistry: renderServerRegistry(plugins),
+  };
 }

--- a/packages/clients/doompi-web/src/adapters/webPluginVite.ts
+++ b/packages/clients/doompi-web/src/adapters/webPluginVite.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { readSyncRegistration } from '@agimon-ai/doompi/services';
 import type { Alias, Plugin } from 'vite';
@@ -6,6 +7,50 @@ import { devPluginRoots, PLUGIN_ROOTS_ENV, PLUGIN_ROOTS_FILE } from '../services
 import type { SyncGeneratedModules } from './webPluginGenerate.ts';
 
 const DOOMPI_ROOT_ENV = 'DOOMPI_ROOT';
+
+export const WEB_PLUGIN_RUNTIME_SPECIFIERS = [
+  'react',
+  'react/jsx-runtime',
+  'react/jsx-dev-runtime',
+  'react-dom',
+  'react-dom/client',
+  '@tanstack/store',
+  '@tanstack/react-store',
+  '@agimon-ai/doompi-web-contracts',
+  '@agimon-ai/doompi-web-components',
+  '@agimon-ai/doompi-web-security/browser',
+  '@codemirror/state',
+  '@codemirror/view',
+] as const;
+
+const WEB_PLUGIN_RUNTIME_PROPERTIES: Record<(typeof WEB_PLUGIN_RUNTIME_SPECIFIERS)[number], string> = {
+  react: 'react',
+  'react/jsx-runtime': 'reactJsxRuntime',
+  'react/jsx-dev-runtime': 'reactJsxDevRuntime',
+  'react-dom': 'reactDom',
+  'react-dom/client': 'reactDomClient',
+  '@tanstack/store': 'tanstackStore',
+  '@tanstack/react-store': 'tanstackReactStore',
+  '@agimon-ai/doompi-web-contracts': 'webContracts',
+  '@agimon-ai/doompi-web-components': 'webComponents',
+  '@agimon-ai/doompi-web-security/browser': 'webSecurityBrowser',
+  '@codemirror/state': 'codemirrorState',
+  '@codemirror/view': 'codemirrorView',
+};
+
+/** Rollup expression for a shared module supplied by the session shell. */
+export function webPluginRuntimeGlobal(specifier: (typeof WEB_PLUGIN_RUNTIME_SPECIFIERS)[number]): string {
+  return `globalThis.DoomPiWebPluginRuntime.${WEB_PLUGIN_RUNTIME_PROPERTIES[specifier]}`;
+}
+
+/** Resolves generated JSX imports from the host instead of a plugin's optional React peer tree. */
+export function webPluginRuntimeAliases(clientRoot: string): Alias[] {
+  const runtimeRequire = createRequire(path.join(clientRoot, 'index.html'));
+  return WEB_PLUGIN_RUNTIME_SPECIFIERS.filter((specifier) => specifier.startsWith('react/jsx-')).map((specifier) => ({
+    find: new RegExp(`^${specifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'u'),
+    replacement: runtimeRequire.resolve(specifier),
+  }));
+}
 
 /**
  * Swaps the committed builtin registry modules for generated ones. A

--- a/packages/clients/doompi-web/src/pwa/bundleCache.ts
+++ b/packages/clients/doompi-web/src/pwa/bundleCache.ts
@@ -2,12 +2,23 @@ export const PWA_DATABASE = 'doompi-pwa';
 export const PWA_DATABASE_VERSION = 1;
 export const PWA_STATE_STORE = 'state';
 export const ACTIVE_BUNDLE_KEY = 'active-bundle';
+const PLUGIN_COMPOSITION_KEY_PREFIX = 'plugin-composition:';
 
 export interface ActiveBundleState {
   signerPublicKey: string;
   manifestDigest: string;
   revision: number;
   cacheName: string;
+}
+
+export interface VerifiedPluginCompositionState {
+  compositionId: string;
+  signerPublicKey: string;
+  manifestDigest: string;
+  revision: number;
+  cacheName: string;
+  verifiedAssetBaseUrl: string;
+  lastUsedAt: number;
 }
 
 function requestValue<T>(request: IDBRequest<T>): Promise<T> {
@@ -72,6 +83,64 @@ export async function clearActiveBundle(): Promise<void> {
   try {
     const transaction = database.transaction(PWA_STATE_STORE, 'readwrite', { durability: 'strict' });
     transaction.objectStore(PWA_STATE_STORE).delete(ACTIVE_BUNDLE_KEY);
+    await transactionDone(transaction);
+  } finally {
+    database.close();
+  }
+}
+
+function pluginCompositionKey(compositionId: string): string {
+  return `${PLUGIN_COMPOSITION_KEY_PREFIX}${compositionId}`;
+}
+
+export async function readVerifiedPluginComposition(
+  compositionId: string,
+): Promise<VerifiedPluginCompositionState | undefined> {
+  const database = await openPwaDatabase();
+  try {
+    const transaction = database.transaction(PWA_STATE_STORE, 'readonly');
+    const value = await requestValue(transaction.objectStore(PWA_STATE_STORE).get(pluginCompositionKey(compositionId)));
+    await transactionDone(transaction);
+    return value as VerifiedPluginCompositionState | undefined;
+  } finally {
+    database.close();
+  }
+}
+
+export async function listVerifiedPluginCompositions(): Promise<VerifiedPluginCompositionState[]> {
+  const database = await openPwaDatabase();
+  try {
+    const transaction = database.transaction(PWA_STATE_STORE, 'readonly');
+    const store = transaction.objectStore(PWA_STATE_STORE);
+    const keys = await requestValue(store.getAllKeys());
+    const values = await Promise.all(
+      keys
+        .filter((key): key is string => typeof key === 'string' && key.startsWith(PLUGIN_COMPOSITION_KEY_PREFIX))
+        .map(async (key) => (await requestValue(store.get(key))) as VerifiedPluginCompositionState),
+    );
+    await transactionDone(transaction);
+    return values;
+  } finally {
+    database.close();
+  }
+}
+
+export async function commitVerifiedPluginComposition(state: VerifiedPluginCompositionState): Promise<void> {
+  const database = await openPwaDatabase();
+  try {
+    const transaction = database.transaction(PWA_STATE_STORE, 'readwrite', { durability: 'strict' });
+    transaction.objectStore(PWA_STATE_STORE).put(state, pluginCompositionKey(state.compositionId));
+    await transactionDone(transaction);
+  } finally {
+    database.close();
+  }
+}
+
+export async function clearVerifiedPluginComposition(compositionId: string): Promise<void> {
+  const database = await openPwaDatabase();
+  try {
+    const transaction = database.transaction(PWA_STATE_STORE, 'readwrite', { durability: 'strict' });
+    transaction.objectStore(PWA_STATE_STORE).delete(pluginCompositionKey(compositionId));
     await transactionDone(transaction);
   } finally {
     database.close();

--- a/packages/clients/doompi-web/src/pwa/serviceWorker.ts
+++ b/packages/clients/doompi-web/src/pwa/serviceWorker.ts
@@ -7,12 +7,27 @@ import {
   verifySignedBundleManifest,
 } from '@agimon-ai/doompi-web-security/browser';
 import { BUNDLE_UPDATED_MESSAGE, type BundleUpdatedMessage } from '../types/bundle.ts';
-import { clearActiveBundle, commitActiveBundle, readActiveBundle, type ActiveBundleState } from './bundleCache.ts';
+import {
+  clearActiveBundle,
+  clearVerifiedPluginComposition,
+  commitActiveBundle,
+  commitVerifiedPluginComposition,
+  listVerifiedPluginCompositions,
+  readActiveBundle,
+  readVerifiedPluginComposition,
+  type ActiveBundleState,
+  type VerifiedPluginCompositionState,
+} from './bundleCache.ts';
 
 const worker = self as unknown as ServiceWorkerGlobalScope;
 const RAW_BUNDLE_PREFIX = '/bundle-assets/';
 const CACHE_PREFIX = 'doompi-bundle-';
+const PLUGIN_CACHE_PREFIX = 'doompi-plugin-';
+const PLUGIN_NETWORK_PREFIX = '/api/web-plugins/';
+const VERIFIED_PLUGIN_PREFIX = '/verified-plugins/';
+const MAX_VERIFIED_PLUGIN_COMPOSITIONS = 16;
 const ACTIVATE_MESSAGE = 'doompi:activate-bundle';
+const ACTIVATE_PLUGIN_MESSAGE = 'doompi:activate-plugin-composition';
 const REFRESH_MESSAGE = 'doompi:refresh-bundle';
 const RESET_MESSAGE = 'doompi:reset-bundle-trust';
 
@@ -26,11 +41,24 @@ interface RefreshBundleMessage {
   type: typeof REFRESH_MESSAGE;
 }
 
+interface ActivatePluginCompositionMessage {
+  type: typeof ACTIVATE_PLUGIN_MESSAGE;
+  compositionId: string;
+  revision: number;
+  manifestUrl: string;
+  rawAssetBaseUrl: string;
+  verifiedAssetBaseUrl: string;
+}
+
 interface ResetBundleMessage {
   type: typeof RESET_MESSAGE;
 }
 
-type WorkerRequest = ActivateBundleMessage | RefreshBundleMessage | ResetBundleMessage;
+type WorkerRequest =
+  | ActivateBundleMessage
+  | ActivatePluginCompositionMessage
+  | RefreshBundleMessage
+  | ResetBundleMessage;
 
 type WorkerReply = { ok: true; revision?: number } | { ok: false; code: string; message: string };
 
@@ -41,6 +69,37 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function parseWorkerRequest(value: unknown): WorkerRequest | undefined {
   if (!isRecord(value) || typeof value.type !== 'string') return undefined;
   if (value.type === REFRESH_MESSAGE || value.type === RESET_MESSAGE) return { type: value.type };
+  if (value.type === ACTIVATE_PLUGIN_MESSAGE) {
+    if (
+      typeof value.compositionId !== 'string' ||
+      !/^[a-f0-9]{64}$/u.test(value.compositionId) ||
+      !Number.isSafeInteger(value.revision) ||
+      Number(value.revision) < 1 ||
+      typeof value.manifestUrl !== 'string' ||
+      typeof value.rawAssetBaseUrl !== 'string' ||
+      typeof value.verifiedAssetBaseUrl !== 'string'
+    ) {
+      return undefined;
+    }
+    const revision = Number(value.revision);
+    const route = `${PLUGIN_NETWORK_PREFIX}${value.compositionId}/${String(revision)}`;
+    const verified = `${VERIFIED_PLUGIN_PREFIX}${value.compositionId}/${String(revision)}`;
+    if (
+      value.manifestUrl !== `${route}/manifest` ||
+      value.rawAssetBaseUrl !== `${route}/assets` ||
+      value.verifiedAssetBaseUrl !== verified
+    ) {
+      return undefined;
+    }
+    return {
+      type: ACTIVATE_PLUGIN_MESSAGE,
+      compositionId: value.compositionId,
+      revision,
+      manifestUrl: value.manifestUrl,
+      rawAssetBaseUrl: value.rawAssetBaseUrl,
+      verifiedAssetBaseUrl: value.verifiedAssetBaseUrl,
+    };
+  }
   if (
     value.type !== ACTIVATE_MESSAGE ||
     typeof value.publicKey !== 'string' ||
@@ -51,7 +110,6 @@ function parseWorkerRequest(value: unknown): WorkerRequest | undefined {
   }
   return { type: ACTIVATE_MESSAGE, publicKey: value.publicKey, minimumRevision: Number(value.minimumRevision) };
 }
-
 function hex(bytes: ArrayBuffer): string {
   return [...new Uint8Array(bytes)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
 }
@@ -89,6 +147,154 @@ async function fetchManifest(): Promise<unknown> {
   });
   if (!response.ok) throw new Error(`The signed manifest request failed (${String(response.status)}).`);
   return await response.json();
+}
+
+async function fetchPluginManifest(manifestUrl: string): Promise<unknown> {
+  const response = await fetch(manifestUrl, {
+    credentials: 'include',
+    cache: 'no-store',
+    redirect: 'error',
+  });
+  if (!response.ok || response.redirected || new URL(response.url).origin !== worker.location.origin) {
+    throw new Error(`The signed plugin manifest request failed (${String(response.status)}).`);
+  }
+  return await response.json();
+}
+
+async function prunePluginCompositions(): Promise<void> {
+  const states = (await listVerifiedPluginCompositions()).sort((left, right) => right.lastUsedAt - left.lastUsedAt);
+  for (const stale of states.slice(MAX_VERIFIED_PLUGIN_COMPOSITIONS)) {
+    try {
+      await clearVerifiedPluginComposition(stale.compositionId);
+      await caches.delete(stale.cacheName);
+    } catch {
+      // A later activation retries pruning. Never invalidate the composition being activated.
+    }
+  }
+}
+
+async function activatePluginComposition(request: ActivatePluginCompositionMessage): Promise<WorkerReply> {
+  const host = await readActiveBundle();
+  if (host === undefined) {
+    return { ok: false, code: 'no-pin', message: 'No trusted cockpit signing key is pinned.' };
+  }
+  const previous = await readVerifiedPluginComposition(request.compositionId);
+  if (previous !== undefined && previous.signerPublicKey !== host.signerPublicKey) {
+    return { ok: false, code: 'signer-mismatch', message: 'The plugin signer does not match the cockpit signer.' };
+  }
+
+  let envelope: unknown;
+  try {
+    envelope = await fetchPluginManifest(request.manifestUrl);
+  } catch (error) {
+    return { ok: false, code: 'manifest-fetch', message: error instanceof Error ? error.message : String(error) };
+  }
+  const verified = await verifySignedBundleManifest(envelope, host.signerPublicKey, request.revision);
+  if (!verified.ok || verified.manifest.revision !== request.revision) {
+    return { ok: false, code: 'manifest-verification', message: 'The signed plugin manifest was refused.' };
+  }
+  const digest = await manifestDigest(verified.manifest);
+  if (previous?.revision === request.revision) {
+    if (previous.manifestDigest !== digest) {
+      return { ok: false, code: 'revision-conflict', message: 'The plugin revision was reused for different bytes.' };
+    }
+    if (await caches.has(previous.cacheName)) {
+      await commitVerifiedPluginComposition({ ...previous, lastUsedAt: Date.now() });
+      return { ok: true, revision: previous.revision };
+    }
+  }
+
+  const cacheName = `${PLUGIN_CACHE_PREFIX}${request.compositionId}-${String(request.revision)}-${digest.slice(0, 16)}`;
+  await caches.delete(cacheName);
+  const staging = await caches.open(cacheName);
+  try {
+    for (const asset of verified.manifest.assets) {
+      const source = `${request.rawAssetBaseUrl}${asset.path}`;
+      const response = await fetch(source, {
+        credentials: 'include',
+        cache: 'no-store',
+        redirect: 'error',
+      });
+      if (!response.ok || response.redirected || new URL(response.url).origin !== worker.location.origin) {
+        throw new Error(`The raw plugin asset ${asset.path} was unavailable.`);
+      }
+      const bytes = await response.arrayBuffer();
+      const assetResult = await verifyBundleAsset(verified.manifest, asset.path, bytes);
+      if (!assetResult.ok) throw new Error(`The raw plugin asset ${asset.path} failed ${assetResult.failure.code}.`);
+      await staging.put(
+        `${request.verifiedAssetBaseUrl}${asset.path}`,
+        new Response(bytes, {
+          status: 200,
+          headers: {
+            'Cache-Control': 'no-store',
+            'Content-Length': String(asset.byteLength),
+            'Content-Type': asset.contentType,
+            'X-Content-Type-Options': 'nosniff',
+          },
+        }),
+      );
+    }
+    const next: VerifiedPluginCompositionState = {
+      compositionId: request.compositionId,
+      signerPublicKey: host.signerPublicKey,
+      manifestDigest: digest,
+      revision: request.revision,
+      cacheName,
+      verifiedAssetBaseUrl: request.verifiedAssetBaseUrl,
+      lastUsedAt: Date.now(),
+    };
+    await commitVerifiedPluginComposition(next);
+    try {
+      if (previous !== undefined && previous.cacheName !== next.cacheName) await caches.delete(previous.cacheName);
+      await prunePluginCompositions();
+    } catch {
+      // The committed cache is usable. Cleanup is best effort and must not roll it back.
+    }
+    return { ok: true, revision: next.revision };
+  } catch (error) {
+    await caches.delete(cacheName);
+    return { ok: false, code: 'asset-verification', message: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+const pluginActivations = new Map<string, Promise<WorkerReply>>();
+
+function queuePluginActivation(request: ActivatePluginCompositionMessage): Promise<WorkerReply> {
+  const previous = pluginActivations.get(request.compositionId) ?? Promise.resolve({ ok: true } as WorkerReply);
+  const activation = previous.then(
+    async () => await activatePluginComposition(request),
+    async () => await activatePluginComposition(request),
+  );
+  pluginActivations.set(request.compositionId, activation);
+  void activation.then(
+    () => {
+      if (pluginActivations.get(request.compositionId) === activation) pluginActivations.delete(request.compositionId);
+    },
+    () => {
+      if (pluginActivations.get(request.compositionId) === activation) pluginActivations.delete(request.compositionId);
+    },
+  );
+  return activation;
+}
+
+async function verifiedPluginResponse(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const [compositionId, revisionText] = url.pathname.slice(VERIFIED_PLUGIN_PREFIX.length).split('/', 2);
+  if (compositionId === undefined || revisionText === undefined) {
+    return new Response('That verified plugin asset is unavailable.', { status: 404 });
+  }
+  const state = await readVerifiedPluginComposition(compositionId);
+  if (
+    state === undefined ||
+    String(state.revision) !== revisionText ||
+    !url.pathname.startsWith(`${state.verifiedAssetBaseUrl}/`)
+  ) {
+    return new Response('That verified plugin asset is unavailable.', { status: 404 });
+  }
+  const cache = await caches.open(state.cacheName);
+  return (
+    (await cache.match(url.pathname)) ?? new Response('That verified plugin asset is unavailable.', { status: 404 })
+  );
 }
 
 async function activateBundle(publicKey: string, minimumRevision: number): Promise<WorkerReply> {
@@ -172,7 +378,10 @@ async function activateBundle(publicKey: string, minimumRevision: number): Promi
 async function handleMessage(request: WorkerRequest): Promise<WorkerReply> {
   if (request.type === RESET_MESSAGE) {
     for (const held of await caches.keys()) {
-      if (held.startsWith(CACHE_PREFIX)) await caches.delete(held);
+      if (held.startsWith(CACHE_PREFIX) || held.startsWith(PLUGIN_CACHE_PREFIX)) await caches.delete(held);
+    }
+    for (const plugin of await listVerifiedPluginCompositions()) {
+      await clearVerifiedPluginComposition(plugin.compositionId);
     }
     await clearActiveBundle();
     return { ok: true };
@@ -180,6 +389,7 @@ async function handleMessage(request: WorkerRequest): Promise<WorkerReply> {
   if (request.type === ACTIVATE_MESSAGE) {
     return await activateBundle(request.publicKey, request.minimumRevision);
   }
+  if (request.type === ACTIVATE_PLUGIN_MESSAGE) return await queuePluginActivation(request);
   const current = await readActiveBundle();
   if (current === undefined) return { ok: false, code: 'no-pin', message: 'No host signing key is pinned.' };
   return await activateBundle(current.signerPublicKey, current.revision);
@@ -267,7 +477,12 @@ async function revalidateOnNavigation(): Promise<void> {
 
 worker.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
-  if (url.origin !== worker.location.origin || trustedNetworkPath(url.pathname)) return;
+  if (url.origin !== worker.location.origin) return;
+  if (url.pathname.startsWith(VERIFIED_PLUGIN_PREFIX)) {
+    event.respondWith(verifiedPluginResponse(event.request));
+    return;
+  }
+  if (trustedNetworkPath(url.pathname)) return;
   // A navigation is the one moment a returning device is reliably online and
   // between pages, so it is where the pin gets questioned. Scheduled here, while
   // the event is certainly still extendable, and kept off the response path: a

--- a/packages/clients/doompi-web/src/pwa/workerClient.ts
+++ b/packages/clients/doompi-web/src/pwa/workerClient.ts
@@ -1,3 +1,5 @@
+import type { SessionWebComposition } from '../types/hub.ts';
+
 export interface BundleActivationRequest {
   publicKey: string;
   minimumRevision: number;
@@ -49,6 +51,17 @@ async function requestWorker(message: object): Promise<WorkerResult> {
 
 export async function activateVerifiedBundle(request: BundleActivationRequest): Promise<WorkerResult> {
   return await requestWorker({ type: 'doompi:activate-bundle', ...request });
+}
+
+export async function activateVerifiedPluginComposition(composition: SessionWebComposition): Promise<WorkerResult> {
+  return await requestWorker({
+    type: 'doompi:activate-plugin-composition',
+    compositionId: composition.id,
+    revision: composition.revision,
+    manifestUrl: composition.manifestUrl,
+    rawAssetBaseUrl: composition.rawAssetBaseUrl,
+    verifiedAssetBaseUrl: composition.verifiedAssetBaseUrl,
+  });
 }
 
 export async function refreshVerifiedBundle(): Promise<WorkerResult> {

--- a/packages/clients/doompi-web/src/types/hub.ts
+++ b/packages/clients/doompi-web/src/types/hub.ts
@@ -8,7 +8,7 @@ import type { BridgeState, SessionFrame } from './session.ts';
  * Field naming follows @earendil-works/pi-protocol so a future swap to the
  * upstream session server stays a transport change, not a rename.
  */
-export const HUB_PROTOCOL_VERSION = 1;
+export const HUB_PROTOCOL_VERSION = 2;
 
 /** Role marker in the health payload; doompi-server probes for it before binding the port. */
 export const HUB_ROLE = 'hub';
@@ -48,6 +48,26 @@ export interface SessionGitStatus {
   dirty: boolean;
 }
 
+/** One immutable, signed client composition resolved for a session. */
+export interface SessionWebComposition {
+  /** Stable identity of the synchronized root and generation. */
+  id: string;
+  /** Monotonic signing revision advertised by the manifest. */
+  revision: number;
+  /** Same-origin signed-manifest route read by the trusted service worker. */
+  manifestUrl: string;
+  /** Same-origin prefix for the untrusted source bytes verified by the worker. */
+  rawAssetBaseUrl: string;
+  /** Worker-owned prefix from which the page may execute verified bytes. */
+  verifiedAssetBaseUrl: string;
+  /** Absolute path below both asset prefixes to the composition script. */
+  entryPath: string;
+  /** Absolute paths below both asset prefixes, replaced when this session is focused. */
+  stylePaths: string[];
+  /** Frame types owned by the matching session-local hub composition. */
+  channels: string[];
+}
+
 /**
  * Everything the rail needs to render one session without subscribing to it.
  */
@@ -79,6 +99,8 @@ export interface SessionSummary {
   apiSocketPath?: string;
   /** Omitted when the cwd is not a git repository or git is unavailable. */
   git?: SessionGitStatus;
+  /** Signed plugin composition independently resolved for this session. */
+  webComposition?: SessionWebComposition;
 }
 
 /**

--- a/packages/clients/doompi-web/src/web/app/Providers.tsx
+++ b/packages/clients/doompi-web/src/web/app/Providers.tsx
@@ -5,7 +5,8 @@ import { PairingApprovalDialog } from '../features/remote/PairingApprovalDialog.
 import { RemoteAccessDialog } from '../features/remote/RemoteAccessDialog.tsx';
 import { RemoteBanner } from '../features/remote/RemoteBanner.tsx';
 import { ThreadView } from '../features/session/ThreadView.tsx';
-import { installWebPlugins, startWebPlugins, webPluginDiagnostics } from '../lib/pluginRegistry.ts';
+import { installWebPlugins, webPluginDiagnostics } from '../lib/pluginRegistry.ts';
+import { startSessionWebPluginRuntime } from '../lib/pluginRuntime.ts';
 import { bindThreadRenderer } from '../lib/threadRenderer.ts';
 import { onHubConnected, sendFrame, sendHubFrame } from '../lib/transport.ts';
 import { routeTree } from '../routes/routeTree.tsx';
@@ -46,8 +47,8 @@ export function Providers() {
     let cancelled = false;
     void restoreSealedSession().then(() => {
       if (cancelled) return;
+      stopPlugins = startSessionWebPluginRuntime({ sendSessionFrame: sendFrame, sendHubFrame, onHubConnected });
       stopRuntime = startSessionRuntime();
-      stopPlugins = startWebPlugins({ sendSessionFrame: sendFrame, sendHubFrame, onHubConnected });
       // One read at start; after that the hub pushes state, so nothing polls.
       void refreshRemoteState();
       void restoreLivePushRegistration();

--- a/packages/clients/doompi-web/src/web/app/sessionRuntime.ts
+++ b/packages/clients/doompi-web/src/web/app/sessionRuntime.ts
@@ -19,7 +19,8 @@ import {
   REMOTE_STATE_TYPE,
   type RemoteAccessStateView,
 } from '../../types/remoteAccess.ts';
-import { dispatchChannelFrame, dropPluginSessionData } from '../lib/pluginRegistry.ts';
+import { dispatchChannelFrame } from '../lib/pluginRegistry.ts';
+import { focusSessionWebPlugins, removeSessionWebPluginRuntime } from '../lib/pluginRuntime.ts';
 import { startProtocolRuntime } from './protocolRuntime.ts';
 import { bindTransport, notifyHubConnected, releaseTransport, sendHubFrame } from '../lib/transport.ts';
 import { createSessionSocket, sessionSocketUrl } from '../lib/wsClient.ts';
@@ -135,6 +136,7 @@ export function startSessionRuntime(): () => void {
   const syncSubscription = (force = false): void => {
     const { activeId, byId } = sessionsStore.state;
     const target = activeId !== null && activeId in byId ? activeId : null;
+    void focusSessionWebPlugins(target, target === null ? undefined : byId[target].summary.webComposition);
     protocol.focus(target);
     if (!force && target === subscribed) return;
     if (subscribed !== null && subscribed !== target) sendHubFrame(unsubscribeFrame(subscribed));
@@ -183,10 +185,11 @@ export function startSessionRuntime(): () => void {
           applySessionRemoved(frame);
           dropComposerState(frame.sessionId);
           dropSessionStore(frame.sessionId);
-          dropPluginSessionData(frame.sessionId);
+          removeSessionWebPluginRuntime(frame.sessionId);
           dropThreads(frame.sessionId);
           dropTransientTabs(frame.sessionId);
           if (subscribed === frame.sessionId) subscribed = null;
+          syncSubscription();
           return;
         }
         case SESSION_BACKLOG_TYPE: {
@@ -279,6 +282,7 @@ export function startSessionRuntime(): () => void {
   return () => {
     stopBundleWatch();
     subscription.unsubscribe();
+    void focusSessionWebPlugins(null, undefined);
     protocol.stop();
     releaseTransport();
     socket.close();

--- a/packages/clients/doompi-web/src/web/features/session/ToolCard.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/ToolCard.tsx
@@ -12,6 +12,7 @@ import { imagesFromContent, type ToolEntry } from '../../lib/sessionModel.ts';
 import { toolMessageProps } from '../../lib/toolMessageProps.ts';
 import { useActiveSession } from '../../stores/sessionStore.ts';
 import { usePluginSlotProps } from '../../stores/usePluginSlotProps.ts';
+import { useWebPluginRegistry } from '../../stores/useWebPluginRegistry.ts';
 
 const MAX_PREVIEW_LINES = 12;
 
@@ -206,6 +207,7 @@ function HostToolMessage({ entry }: { entry: ToolEntry }) {
  * throws, and stands in for a tool nobody claims.
  */
 export function ToolCard({ entry, sessionId }: { entry: ToolEntry; sessionId: string | null }) {
+  useWebPluginRegistry();
   const statuses = useActiveSession((state) => state.statuses);
   const slotProps = usePluginSlotProps(sessionId);
   const renderer = pluginToolRenderer(entry.name, statuses);

--- a/packages/clients/doompi-web/src/web/lib/composition.ts
+++ b/packages/clients/doompi-web/src/web/lib/composition.ts
@@ -1,7 +1,14 @@
 import type { SelectionAxisContribution, TransientTab } from '@agimon-ai/doompi-web-contracts';
 import { useCallback, useSyncExternalStore } from 'react';
 import type { MinorModeProjection, MinorModeRecordProjection } from '../../types/hub.ts';
-import { pluginActivityGroups, pluginFileLinks, pluginMinorModes, pluginSelectionAxes } from './pluginRegistry.ts';
+import {
+  pluginActivityGroups,
+  pluginFileLinks,
+  pluginMinorModes,
+  pluginSelectionAxes,
+  subscribeWebPluginRegistry,
+  webPluginRegistryRevision,
+} from './pluginRegistry.ts';
 import { stripAnsi } from './statusLine.ts';
 
 export interface SelectionAxis {
@@ -206,18 +213,35 @@ export interface ActivityGroup {
   placement?: 'bottom';
 }
 
-/** Subscribe once to every package-owned source that can change a group's active state. */
+/** Subscribe to package-owned activity sources, rewiring when the focused composition changes. */
 function subscribeActivitySources(listener: () => void): () => void {
-  const subscriptions = pluginActivityGroups().flatMap((source) =>
-    source.activeSource === undefined ? [] : [source.activeSource.subscribe(listener)],
-  );
-  return () => subscriptions.forEach((unsubscribe) => unsubscribe());
+  let subscriptions: (() => void)[] = [];
+  const unsubscribeSources = (): void => {
+    subscriptions.forEach((unsubscribe) => unsubscribe());
+    subscriptions = [];
+  };
+  const subscribeSources = (): void => {
+    subscriptions = pluginActivityGroups().flatMap((source) =>
+      source.activeSource === undefined ? [] : [source.activeSource.subscribe(listener)],
+    );
+  };
+  subscribeSources();
+  const unsubscribeRegistry = subscribeWebPluginRegistry(() => {
+    unsubscribeSources();
+    subscribeSources();
+    listener();
+  });
+  return () => {
+    unsubscribeRegistry();
+    unsubscribeSources();
+  };
 }
 
 function activitySourceFingerprint(sessionId: string | null): string {
-  return pluginActivityGroups()
+  const activeSources = pluginActivityGroups()
     .map((source) => (source.activeSource?.isActive(sessionId) === true ? '1' : '0'))
     .join('');
+  return `${webPluginRegistryRevision()}:${activeSources}`;
 }
 
 /**
@@ -288,14 +312,31 @@ export function useActivityGroups(
 export type FileLinkResolver = (path: string) => TransientTab | undefined;
 
 function subscribeFileLinks(listener: () => void): () => void {
-  const subscriptions = pluginFileLinks().map((source) => source.subscribe(listener));
-  return () => subscriptions.forEach((unsubscribe) => unsubscribe());
+  let subscriptions: (() => void)[] = [];
+  const unsubscribeSources = (): void => {
+    subscriptions.forEach((unsubscribe) => unsubscribe());
+    subscriptions = [];
+  };
+  const subscribeSources = (): void => {
+    subscriptions = pluginFileLinks().map((source) => source.subscribe(listener));
+  };
+  subscribeSources();
+  const unsubscribeRegistry = subscribeWebPluginRegistry(() => {
+    unsubscribeSources();
+    subscribeSources();
+    listener();
+  });
+  return () => {
+    unsubscribeRegistry();
+    unsubscribeSources();
+  };
 }
 
 function fileLinkFingerprint(sessionId: string | null): string {
-  return pluginFileLinks()
+  const sourceFingerprints = pluginFileLinks()
     .map((source) => source.fingerprint(sessionId))
     .join('\n');
+  return `${webPluginRegistryRevision()}:${sourceFingerprints}`;
 }
 
 /**

--- a/packages/clients/doompi-web/src/web/lib/pluginRegistry.ts
+++ b/packages/clients/doompi-web/src/web/lib/pluginRegistry.ts
@@ -129,8 +129,24 @@ function emptyState(): RegistryState {
   };
 }
 
-let state = emptyState();
-let installed = false;
+let defaultState = emptyState();
+let installingState = defaultState;
+let defaultInstalled = false;
+const sessionStates = new Map<string, RegistryState>();
+const pendingSessionFrames = new Map<string, Map<string, Record<string, unknown>>>();
+const MAX_PENDING_CHANNEL_TYPES = 64;
+let activeSessionId: string | null = null;
+let registryRevision = 0;
+const registryListeners = new Set<() => void>();
+
+function activeState(): RegistryState {
+  return (activeSessionId === null ? undefined : sessionStates.get(activeSessionId)) ?? defaultState;
+}
+
+function emitRegistryChange(): void {
+  registryRevision += 1;
+  for (const listener of registryListeners) listener();
+}
 
 /** The TUI's leader alphabet: one lowercase letter or digit per segment. */
 const LEADER_KEY = /^[a-z0-9]$/;
@@ -196,7 +212,7 @@ function claim(owners: Map<string, string>, thing: SharedNamespace, id: string, 
     throw new Error(`Web plugin '${pluginId}' declares ${thing.replace('-', ' ')} '${id}' twice.`);
   }
   if (holder !== undefined) {
-    state.diagnostics.push({
+    installingState.diagnostics.push({
       pluginId,
       kind: `duplicate-${thing}`,
       message: `Web plugin '${pluginId}' ${thing.replace('-', ' ')} '${id}' is already provided by '${holder}'; keeping the first.`,
@@ -241,9 +257,9 @@ const byDisplayOrder = (left: { order?: number; name: string }, right: { order?:
   (left.order ?? DEFAULT_FILL_ORDER) - (right.order ?? DEFAULT_FILL_ORDER) || left.name.localeCompare(right.name);
 
 function placeFill(pluginId: string, fill: SlotFillContribution): void {
-  const declaration = state.slots.get(fill.slot);
+  const declaration = installingState.slots.get(fill.slot);
   if (declaration === undefined) {
-    state.diagnostics.push({
+    installingState.diagnostics.push({
       pluginId,
       kind: 'orphan-fill',
       message: `Web plugin '${pluginId}' fills slot '${fill.slot}', which no installed plugin declares; nothing is placed.`,
@@ -254,7 +270,7 @@ function placeFill(pluginId: string, fill: SlotFillContribution): void {
   if (data !== undefined && declaration.parse !== undefined) {
     const parsed = declaration.parse(data);
     if (parsed === null) {
-      state.diagnostics.push({
+      installingState.diagnostics.push({
         pluginId,
         kind: 'rejected-fill',
         message: `Web plugin '${pluginId}' fill '${fill.id}' into '${fill.slot}' was rejected by the slot's parse gate.`,
@@ -271,8 +287,8 @@ function placeFill(pluginId: string, fill: SlotFillContribution): void {
     ...(data === undefined ? {} : { data }),
     ...(fill.component === undefined ? {} : { component: fill.component }),
   };
-  const list = state.fills.get(fill.slot);
-  if (list === undefined) state.fills.set(fill.slot, [placed]);
+  const list = installingState.fills.get(fill.slot);
+  if (list === undefined) installingState.fills.set(fill.slot, [placed]);
   else list.push(placed);
 }
 
@@ -287,13 +303,13 @@ function resolveLeaderConflicts(bindings: readonly PendingBinding[]): void {
       );
     }
     if (conflict.kind === 'leaf-override') {
-      state.diagnostics.push({
+      installingState.diagnostics.push({
         pluginId: loser,
         kind: 'leader-leaf-override',
         message: `Web plugin '${loser}' Leader Space leaf '${conflict.path}' ('${conflict.loser.id}') is taken over by '${winner}' ('${conflict.winner.id}').`,
       });
     } else {
-      state.diagnostics.push({
+      installingState.diagnostics.push({
         pluginId: loser,
         kind: 'leader-group-label',
         message: `Web plugin '${loser}' words Leader Space group '${conflict.path}' differently from '${winner}', which named it first; keeping the first label.`,
@@ -302,140 +318,202 @@ function resolveLeaderConflicts(bindings: readonly PendingBinding[]): void {
   }
 }
 
-export function installWebPlugins(plugins: readonly WebPluginDefinition[]): void {
-  if (installed) throw new Error('Web plugins are already installed.');
-  const owners: Record<SharedNamespace, Map<string, string>> = {
-    plugin: new Map(),
-    tab: new Map(),
-    channel: new Map(),
-    tool: new Map(),
-    'activity-group': new Map(),
-    'minor-mode': new Map(),
-    'selection-axis': new Map(),
-    'palette-command': new Map(),
-    'settings-section': new Map(),
-  };
-  const pendingFills: PendingFill[] = [];
-  const pendingSections: PendingSection[] = [];
-  const pendingBindings: PendingBinding[] = [];
-  const pendingSlots: SlotDeclaration[] = [];
+function buildWebPluginState(plugins: readonly WebPluginDefinition[]): RegistryState {
+  const previous = installingState;
+  installingState = emptyState();
+  try {
+    const owners: Record<SharedNamespace, Map<string, string>> = {
+      plugin: new Map(),
+      tab: new Map(),
+      channel: new Map(),
+      tool: new Map(),
+      'activity-group': new Map(),
+      'minor-mode': new Map(),
+      'selection-axis': new Map(),
+      'palette-command': new Map(),
+      'settings-section': new Map(),
+    };
+    const pendingFills: PendingFill[] = [];
+    const pendingSections: PendingSection[] = [];
+    const pendingBindings: PendingBinding[] = [];
+    const pendingSlots: SlotDeclaration[] = [];
 
-  // Phase 1: collect, in the generated (registrationOrder, pluginId) order.
-  for (const plugin of plugins) {
-    if (RESERVED_PLUGIN_IDS.has(plugin.id)) {
-      throw new Error(`Web plugin id '${plugin.id}' is reserved for a host slot.`);
+    // Phase 1: collect, in the generated (registrationOrder, pluginId) order.
+    for (const plugin of plugins) {
+      if (RESERVED_PLUGIN_IDS.has(plugin.id)) {
+        throw new Error(`Web plugin id '${plugin.id}' is reserved for a host slot.`);
+      }
+      if (owners.plugin.has(plugin.id)) {
+        installingState.diagnostics.push({
+          pluginId: plugin.id,
+          kind: 'duplicate-plugin',
+          message: `Web plugin id '${plugin.id}' is declared twice; keeping the first definition.`,
+        });
+        continue;
+      }
+      owners.plugin.set(plugin.id, plugin.id);
+      installingState.plugins.push(plugin);
+      for (const tab of plugin.tabs ?? []) {
+        if (claim(owners.tab, 'tab', tab.id, plugin.id)) installingState.tabs.push(tab);
+      }
+      // A panel and a section both become a /settings/:id route, so the two
+      // share one id namespace rather than racing to own the same URL.
+      for (const section of plugin.settingsSections ?? []) {
+        if (claim(owners['settings-section'], 'settings-section', section.id, plugin.id)) {
+          installingState.settingsSections.push(section);
+        }
+      }
+      for (const panel of plugin.settingsPanels ?? []) {
+        if (claim(owners['settings-section'], 'settings-section', panel.id, plugin.id)) {
+          installingState.settingsPanels.push({ pluginId: plugin.id, ...panel });
+        }
+      }
+      for (const channel of plugin.channels ?? []) {
+        if (claim(owners.channel, 'channel', channel.channel, plugin.id))
+          installingState.channels.set(channel.channel, channel);
+      }
+      for (const command of plugin.paletteCommands ?? []) {
+        if (claim(owners['palette-command'], 'palette-command', command.id, plugin.id))
+          installingState.commands.push(command);
+      }
+      for (const binding of plugin.leaderBindings ?? []) {
+        checkLeaderBinding(plugin.id, binding);
+        pendingBindings.push({ pluginId: plugin.id, binding });
+      }
+      for (const axis of plugin.selectionAxes ?? []) {
+        if (claim(owners['selection-axis'], 'selection-axis', axis.name, plugin.id))
+          installingState.selectionAxes.push(axis);
+      }
+      for (const mode of plugin.minorModes ?? []) {
+        if (claim(owners['minor-mode'], 'minor-mode', mode.name, plugin.id)) installingState.minorModes.push(mode);
+      }
+      for (const group of plugin.activityGroups ?? []) {
+        if (claim(owners['activity-group'], 'activity-group', group.name, plugin.id))
+          installingState.activityGroups.push(group);
+      }
+      for (const renderer of plugin.toolRenderers ?? []) {
+        for (const tool of renderer.tools) {
+          if (claim(owners.tool, 'tool', tool, plugin.id)) installingState.toolRenderers.set(tool, renderer);
+        }
+        if (renderer.matches !== undefined) installingState.toolMatchers.push(renderer);
+      }
+      const declared = new Set<string>();
+      for (const declaration of plugin.slots ?? []) {
+        checkSlotDeclaration(plugin.id, declared, declaration);
+        pendingSlots.push(declaration);
+      }
+      const filled = new Set<string>();
+      for (const fill of plugin.fills ?? []) {
+        checkFill(plugin.id, filled, fill);
+        pendingFills.push({ pluginId: plugin.id, fill });
+      }
+      for (const surface of plugin.overlays ?? []) {
+        pendingFills.push({ pluginId: plugin.id, fill: surfaceFill(HOST_SLOTS.overlay, surface) });
+      }
+      for (const surface of plugin.railSections ?? []) {
+        pendingFills.push({ pluginId: plugin.id, fill: surfaceFill(HOST_SLOTS.rail, surface) });
+      }
+      for (const surface of plugin.selectionBarItems ?? []) {
+        pendingFills.push({ pluginId: plugin.id, fill: surfaceFill(HOST_SLOTS.selectionBar, surface) });
+      }
+      for (const surface of plugin.composerActions ?? []) {
+        pendingFills.push({ pluginId: plugin.id, fill: surfaceFill(HOST_SLOTS.composerActions, surface) });
+      }
+      for (const section of plugin.activitySections ?? []) pendingSections.push({ pluginId: plugin.id, section });
+      if (plugin.fileLinks !== undefined) installingState.fileLinks.push(plugin.fileLinks);
     }
-    if (owners.plugin.has(plugin.id)) {
-      state.diagnostics.push({
-        pluginId: plugin.id,
-        kind: 'duplicate-plugin',
-        message: `Web plugin id '${plugin.id}' is declared twice; keeping the first definition.`,
+
+    // Phase 2: resolve by name, now that every declaration is known.
+    for (const slot of Object.values(HOST_SLOTS)) installingState.slots.set(slot, { slot });
+    for (const group of installingState.activityGroups) {
+      installingState.slots.set(activityGroupSlot(group.name), { slot: activityGroupSlot(group.name) });
+    }
+    for (const declaration of pendingSlots) installingState.slots.set(declaration.slot, declaration);
+    for (const { pluginId, section } of pendingSections) {
+      const keyed = activityGroupSlot(section.id);
+      pendingFills.push({
+        pluginId,
+        fill: surfaceFill(installingState.slots.has(keyed) ? keyed : HOST_SLOTS.activity, section),
       });
-      continue;
     }
-    owners.plugin.set(plugin.id, plugin.id);
-    state.plugins.push(plugin);
-    for (const tab of plugin.tabs ?? []) {
-      if (claim(owners.tab, 'tab', tab.id, plugin.id)) state.tabs.push(tab);
-    }
-    // A panel and a section both become a /settings/:id route, so the two
-    // share one id namespace rather than racing to own the same URL.
-    for (const section of plugin.settingsSections ?? []) {
-      if (claim(owners['settings-section'], 'settings-section', section.id, plugin.id)) {
-        state.settingsSections.push(section);
-      }
-    }
-    for (const panel of plugin.settingsPanels ?? []) {
-      if (claim(owners['settings-section'], 'settings-section', panel.id, plugin.id)) {
-        state.settingsPanels.push({ pluginId: plugin.id, ...panel });
-      }
-    }
-    for (const channel of plugin.channels ?? []) {
-      if (claim(owners.channel, 'channel', channel.channel, plugin.id)) state.channels.set(channel.channel, channel);
-    }
-    for (const command of plugin.paletteCommands ?? []) {
-      if (claim(owners['palette-command'], 'palette-command', command.id, plugin.id)) state.commands.push(command);
-    }
-    for (const binding of plugin.leaderBindings ?? []) {
-      checkLeaderBinding(plugin.id, binding);
-      pendingBindings.push({ pluginId: plugin.id, binding });
-    }
-    for (const axis of plugin.selectionAxes ?? []) {
-      if (claim(owners['selection-axis'], 'selection-axis', axis.name, plugin.id)) state.selectionAxes.push(axis);
-    }
-    for (const mode of plugin.minorModes ?? []) {
-      if (claim(owners['minor-mode'], 'minor-mode', mode.name, plugin.id)) state.minorModes.push(mode);
-    }
-    for (const group of plugin.activityGroups ?? []) {
-      if (claim(owners['activity-group'], 'activity-group', group.name, plugin.id)) state.activityGroups.push(group);
-    }
-    for (const renderer of plugin.toolRenderers ?? []) {
-      for (const tool of renderer.tools) {
-        if (claim(owners.tool, 'tool', tool, plugin.id)) state.toolRenderers.set(tool, renderer);
-      }
-      if (renderer.matches !== undefined) state.toolMatchers.push(renderer);
-    }
-    const declared = new Set<string>();
-    for (const declaration of plugin.slots ?? []) {
-      checkSlotDeclaration(plugin.id, declared, declaration);
-      pendingSlots.push(declaration);
-    }
-    const filled = new Set<string>();
-    for (const fill of plugin.fills ?? []) {
-      checkFill(plugin.id, filled, fill);
-      pendingFills.push({ pluginId: plugin.id, fill });
-    }
-    for (const surface of plugin.overlays ?? []) {
-      pendingFills.push({ pluginId: plugin.id, fill: surfaceFill(HOST_SLOTS.overlay, surface) });
-    }
-    for (const surface of plugin.railSections ?? []) {
-      pendingFills.push({ pluginId: plugin.id, fill: surfaceFill(HOST_SLOTS.rail, surface) });
-    }
-    for (const surface of plugin.selectionBarItems ?? []) {
-      pendingFills.push({ pluginId: plugin.id, fill: surfaceFill(HOST_SLOTS.selectionBar, surface) });
-    }
-    for (const surface of plugin.composerActions ?? []) {
-      pendingFills.push({ pluginId: plugin.id, fill: surfaceFill(HOST_SLOTS.composerActions, surface) });
-    }
-    for (const section of plugin.activitySections ?? []) pendingSections.push({ pluginId: plugin.id, section });
-    if (plugin.fileLinks !== undefined) state.fileLinks.push(plugin.fileLinks);
-  }
+    for (const { pluginId, fill } of pendingFills) placeFill(pluginId, fill);
+    for (const list of installingState.fills.values()) list.sort(byFillOrder);
 
-  // Phase 2: resolve by name, now that every declaration is known.
-  for (const slot of Object.values(HOST_SLOTS)) state.slots.set(slot, { slot });
-  for (const group of state.activityGroups) {
-    state.slots.set(activityGroupSlot(group.name), { slot: activityGroupSlot(group.name) });
+    resolveLeaderConflicts(pendingBindings);
+    installingState.leaderBindings.push(...pendingBindings.map((entry) => entry.binding));
+    installingState.selectionAxes.sort(byDisplayOrder);
+    installingState.minorModes.sort(byDisplayOrder);
+    installingState.activityGroups.sort(byDisplayOrder);
+    return installingState;
+  } finally {
+    installingState = previous;
   }
-  for (const declaration of pendingSlots) state.slots.set(declaration.slot, declaration);
-  for (const { pluginId, section } of pendingSections) {
-    const keyed = activityGroupSlot(section.id);
-    pendingFills.push({ pluginId, fill: surfaceFill(state.slots.has(keyed) ? keyed : HOST_SLOTS.activity, section) });
-  }
-  for (const { pluginId, fill } of pendingFills) placeFill(pluginId, fill);
-  for (const list of state.fills.values()) list.sort(byFillOrder);
+}
 
-  resolveLeaderConflicts(pendingBindings);
-  state.leaderBindings.push(...pendingBindings.map((entry) => entry.binding));
-  state.selectionAxes.sort(byDisplayOrder);
-  state.minorModes.sort(byDisplayOrder);
-  state.activityGroups.sort(byDisplayOrder);
-  installed = true;
+export function installWebPlugins(plugins: readonly WebPluginDefinition[]): void {
+  if (defaultInstalled) throw new Error('Web plugins are already installed.');
+  defaultState = buildWebPluginState(plugins);
+  installingState = defaultState;
+  defaultInstalled = true;
 }
 
 /** Unit-test escape hatch; production installs exactly once. */
 export function resetWebPlugins(): void {
-  state = emptyState();
-  installed = false;
+  defaultState = emptyState();
+  installingState = defaultState;
+  defaultInstalled = false;
+  sessionStates.clear();
+  pendingSessionFrames.clear();
+  activeSessionId = null;
+  emitRegistryChange();
+}
+
+/** Installs one session's independently synchronized plugin definitions. */
+export function installSessionWebPlugins(sessionId: string, plugins: readonly WebPluginDefinition[]): void {
+  const state = buildWebPluginState(plugins);
+  sessionStates.set(sessionId, state);
+  const pending = pendingSessionFrames.get(sessionId);
+  if (pending !== undefined) {
+    pendingSessionFrames.delete(sessionId);
+    for (const frame of pending.values()) dispatchFrameToState(state, frame);
+  }
+  if (sessionId === activeSessionId) emitRegistryChange();
+}
+
+/** Selects which session composition the no-argument contribution readers expose. */
+export function activateWebPluginSession(sessionId: string | null): void {
+  if (activeSessionId === sessionId) return;
+  activeSessionId = sessionId;
+  emitRegistryChange();
+}
+
+/** Removes one session registry after its plugin-owned stores have been dropped. */
+export function removeSessionWebPlugins(sessionId: string): void {
+  const sessionState = sessionStates.get(sessionId);
+  pendingSessionFrames.delete(sessionId);
+  if (sessionState === undefined) return;
+  for (const channel of sessionState.channels.values()) channel.drop(sessionId);
+  sessionStates.delete(sessionId);
+  if (sessionId === activeSessionId) emitRegistryChange();
+}
+
+export function subscribeWebPluginRegistry(listener: () => void): () => void {
+  registryListeners.add(listener);
+  return () => registryListeners.delete(listener);
+}
+
+export function webPluginRegistryRevision(): number {
+  return registryRevision;
 }
 
 /** What the install had to resolve between plugins; empty for a composition whose plugins never collide. */
 export function webPluginDiagnostics(): readonly InstallDiagnostic[] {
-  return state.diagnostics;
+  return activeState().diagnostics;
 }
 
 /** Every installed plugin definition, in install order; the settings page lists them. */
 export function installedWebPlugins(): readonly WebPluginDefinition[] {
-  return state.plugins;
+  return activeState().plugins;
 }
 
 export interface InstalledRepositorySettingsPanel extends RepositorySettingsPanelContribution {
@@ -444,8 +522,8 @@ export interface InstalledRepositorySettingsPanel extends RepositorySettingsPane
 
 /** Package panels placed under the host's repository controls, in stable display order. */
 export function pluginRepositorySettingsPanels(): readonly InstalledRepositorySettingsPanel[] {
-  return state.plugins
-    .flatMap((plugin) =>
+  return activeState()
+    .plugins.flatMap((plugin) =>
       plugin.repositorySettingsPanel === undefined ? [] : [{ pluginId: plugin.id, ...plugin.repositorySettingsPanel }],
     )
     .sort(
@@ -456,7 +534,7 @@ export function pluginRepositorySettingsPanels(): readonly InstalledRepositorySe
 }
 
 export function webTabs(): readonly TabContribution[] {
-  return state.tabs;
+  return activeState().tabs;
 }
 
 /**
@@ -464,7 +542,7 @@ export function webTabs(): readonly TabContribution[] {
  * at the reader so the menu and the page agree without either sorting twice.
  */
 export function pluginSettingsSections(): readonly SettingsSectionContribution[] {
-  return state.settingsSections;
+  return activeState().settingsSections;
 }
 
 export interface InstalledSettingsPanel extends SettingsPanelContribution {
@@ -473,36 +551,36 @@ export interface InstalledSettingsPanel extends SettingsPanelContribution {
 
 /** The settings pages plugins draw themselves, in install order; the reader sorts them with the sections. */
 export function pluginSettingsPanels(): readonly InstalledSettingsPanel[] {
-  return state.settingsPanels;
+  return activeState().settingsPanels;
 }
 
 /** The fills placed into one slot, in slot order; empty for a slot nobody declared. */
 export function slotFills(slot: string): readonly ResolvedFill[] {
-  return state.fills.get(slot) ?? [];
+  return activeState().fills.get(slot) ?? [];
 }
 
 export function paletteCommands(): readonly PaletteCommandContribution[] {
-  return state.commands;
+  return activeState().commands;
 }
 
 /** Leader Space bindings from every installed plugin, in install order: a later binding on a bound leaf wins. */
 export function pluginLeaderBindings(): readonly LeaderBindingContribution[] {
-  return state.leaderBindings;
+  return activeState().leaderBindings;
 }
 
 /** Selection-axis declarations from every installed plugin, in display order. */
 export function pluginSelectionAxes(): readonly SelectionAxisContribution[] {
-  return state.selectionAxes;
+  return activeState().selectionAxes;
 }
 
 /** Minor-mode declarations from every installed plugin, in display order. */
 export function pluginMinorModes(): readonly MinorModeContribution[] {
-  return state.minorModes;
+  return activeState().minorModes;
 }
 
 /** Activity-dock group declarations from every installed plugin, in display order. */
 export function pluginActivityGroups(): readonly ActivityGroupContribution[] {
-  return state.activityGroups;
+  return activeState().activityGroups;
 }
 
 /**
@@ -514,7 +592,7 @@ export function pluginActivityGroups(): readonly ActivityGroupContribution[] {
  * file.
  */
 export function pluginFileLinks(): readonly FileLinkSource[] {
-  return state.fileLinks;
+  return activeState().fileLinks;
 }
 
 /**
@@ -528,7 +606,8 @@ export function pluginToolRenderer(
   statuses: Readonly<Record<string, string>> = {},
 ): ToolRendererContribution | undefined {
   return (
-    state.toolRenderers.get(toolName) ?? state.toolMatchers.find((renderer) => renderer.matches?.(toolName, statuses))
+    activeState().toolRenderers.get(toolName) ??
+    activeState().toolMatchers.find((renderer) => renderer.matches?.(toolName, statuses))
   );
 }
 
@@ -537,7 +616,7 @@ export function pluginToolRenderer(
  * channel claims it, so the demux can fall through silently the way unknown
  * frames always have.
  */
-export function dispatchChannelFrame(frame: Record<string, unknown>): boolean {
+function dispatchFrameToState(state: RegistryState, frame: Record<string, unknown>): boolean {
   if (typeof frame.type !== 'string' || typeof frame.sessionId !== 'string') return false;
   const channel = state.channels.get(frame.type);
   if (channel === undefined) return false;
@@ -546,19 +625,46 @@ export function dispatchChannelFrame(frame: Record<string, unknown>): boolean {
   return true;
 }
 
+export function dispatchChannelFrame(frame: Record<string, unknown>): boolean {
+  if (typeof frame.type !== 'string' || typeof frame.sessionId !== 'string') return false;
+  const state = sessionStates.get(frame.sessionId);
+  if (state !== undefined) return dispatchFrameToState(state, frame);
+  if (activeSessionId === null) return dispatchFrameToState(defaultState, frame);
+  const pending = pendingSessionFrames.get(frame.sessionId) ?? new Map<string, Record<string, unknown>>();
+  if (!pending.has(frame.type) && pending.size >= MAX_PENDING_CHANNEL_TYPES) {
+    const oldest = pending.keys().next().value as string | undefined;
+    if (oldest !== undefined) pending.delete(oldest);
+  }
+  pending.set(frame.type, frame);
+  pendingSessionFrames.set(frame.sessionId, pending);
+  return false;
+}
+
 /** Session teardown: every channel forgets the session's data. */
 export function dropPluginSessionData(sessionId: string): void {
-  for (const channel of state.channels.values()) channel.drop(sessionId);
+  pendingSessionFrames.delete(sessionId);
+  const state = sessionStates.get(sessionId) ?? (activeSessionId === null ? defaultState : undefined);
+  for (const channel of state?.channels.values() ?? []) channel.drop(sessionId);
 }
 
 /** Starts every plugin runtime in install order; the disposer runs in reverse. */
-export function startWebPlugins(runtime: WebPluginRuntime): () => void {
+export function startPluginDefinitions(plugins: readonly WebPluginDefinition[], runtime: WebPluginRuntime): () => void {
   const disposers: Array<() => void> = [];
-  for (const plugin of state.plugins) {
-    const dispose = plugin.start?.(runtime);
-    if (dispose) disposers.push(dispose);
-  }
-  return () => {
+  const disposeStarted = (): void => {
     for (const dispose of disposers.reverse()) dispose();
   };
+  try {
+    for (const plugin of plugins) {
+      const dispose = plugin.start?.(runtime);
+      if (dispose) disposers.push(dispose);
+    }
+  } catch (error) {
+    disposeStarted();
+    throw error;
+  }
+  return disposeStarted;
+}
+
+export function startWebPlugins(runtime: WebPluginRuntime): () => void {
+  return startPluginDefinitions(activeState().plugins, runtime);
 }

--- a/packages/clients/doompi-web/src/web/lib/pluginRuntime.ts
+++ b/packages/clients/doompi-web/src/web/lib/pluginRuntime.ts
@@ -1,0 +1,251 @@
+import * as TanstackReactStore from '@tanstack/react-store';
+import * as TanstackStore from '@tanstack/store';
+import * as WebComponents from '@agimon-ai/doompi-web-components';
+import * as WebContracts from '@agimon-ai/doompi-web-contracts';
+import * as WebSecurityBrowser from '@agimon-ai/doompi-web-security/browser';
+import type { WebPluginDefinition, WebPluginRuntime } from '@agimon-ai/doompi-web-contracts';
+import * as CodeMirrorState from '@codemirror/state';
+import * as CodeMirrorView from '@codemirror/view';
+import * as React from 'react';
+import * as ReactDom from 'react-dom';
+import * as ReactDomClient from 'react-dom/client';
+import * as ReactJsxDevRuntime from 'react/jsx-dev-runtime';
+import * as ReactJsxRuntime from 'react/jsx-runtime';
+import { activateVerifiedPluginComposition } from '../../pwa/workerClient.ts';
+import type { SessionWebComposition } from '../../types/hub.ts';
+import {
+  activateWebPluginSession,
+  installSessionWebPlugins,
+  installedWebPlugins,
+  removeSessionWebPlugins,
+  startPluginDefinitions,
+  startWebPlugins,
+  webPluginDiagnostics,
+} from './pluginRegistry.ts';
+
+export const WEB_PLUGIN_RUNTIME_GLOBAL = 'DoomPiWebPluginRuntime';
+export const WEB_PLUGIN_COMPOSITION_GLOBAL = 'DoomPiWebPluginComposition';
+
+/** Host-owned module singletons consumed by independently built plugin compositions. */
+export interface WebPluginRuntimeModules {
+  react: typeof React;
+  reactJsxRuntime: typeof ReactJsxRuntime;
+  reactJsxDevRuntime: typeof ReactJsxDevRuntime;
+  reactDom: typeof ReactDom;
+  reactDomClient: typeof ReactDomClient;
+  tanstackStore: typeof TanstackStore;
+  tanstackReactStore: typeof TanstackReactStore;
+  webContracts: typeof WebContracts;
+  webComponents: typeof WebComponents;
+  webSecurityBrowser: typeof WebSecurityBrowser;
+  codemirrorState: typeof CodeMirrorState;
+  codemirrorView: typeof CodeMirrorView;
+}
+
+const modules: WebPluginRuntimeModules = Object.freeze({
+  react: React,
+  reactJsxRuntime: ReactJsxRuntime,
+  reactJsxDevRuntime: ReactJsxDevRuntime,
+  reactDom: ReactDom,
+  reactDomClient: ReactDomClient,
+  tanstackStore: TanstackStore,
+  tanstackReactStore: TanstackReactStore,
+  webContracts: WebContracts,
+  webComponents: WebComponents,
+  webSecurityBrowser: WebSecurityBrowser,
+  codemirrorState: CodeMirrorState,
+  codemirrorView: CodeMirrorView,
+});
+
+Object.defineProperty(globalThis, WEB_PLUGIN_RUNTIME_GLOBAL, {
+  configurable: false,
+  enumerable: false,
+  writable: false,
+  value: modules,
+});
+
+interface LoadedSessionComposition {
+  key: string;
+  plugins: readonly WebPluginDefinition[];
+}
+
+const loadedSessions = new Map<string, LoadedSessionComposition>();
+let builtinPlugins: readonly WebPluginDefinition[] = [];
+let runtime: WebPluginRuntime | undefined;
+let activeSession: string | null = null;
+let requestedSession: string | null | undefined;
+let requestedKey: string | undefined;
+let stopActivePlugins: (() => void) | undefined;
+let activeStyles: HTMLLinkElement[] = [];
+let activationEpoch = 0;
+let scriptQueue: Promise<unknown> = Promise.resolve();
+
+function compositionKey(composition: SessionWebComposition): string {
+  return `${composition.id}:${String(composition.revision)}`;
+}
+
+function clearCompositionGlobal(): void {
+  delete (globalThis as unknown as Record<string, unknown>)[WEB_PLUGIN_COMPOSITION_GLOBAL];
+}
+
+async function executeCompositionScript(url: string): Promise<readonly WebPluginDefinition[]> {
+  const execute = async (): Promise<readonly WebPluginDefinition[]> => {
+    clearCompositionGlobal();
+    await new Promise<void>((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = url;
+      script.async = true;
+      script.addEventListener('load', () => resolve(), { once: true });
+      script.addEventListener('error', () => reject(new Error(`The verified plugin script '${url}' failed to load.`)), {
+        once: true,
+      });
+      document.head.append(script);
+      script.addEventListener('load', () => script.remove(), { once: true });
+      script.addEventListener('error', () => script.remove(), { once: true });
+    });
+    const plugins = (globalThis as unknown as Record<string, unknown>)[WEB_PLUGIN_COMPOSITION_GLOBAL];
+    clearCompositionGlobal();
+    if (!Array.isArray(plugins)) throw new Error('The verified plugin composition exported no plugin array.');
+    return plugins as WebPluginDefinition[];
+  };
+  const queued = scriptQueue.then(execute, execute);
+  scriptQueue = queued.catch(() => undefined);
+  return await queued;
+}
+
+function disposeActivePlugins(): void {
+  stopActivePlugins?.();
+  stopActivePlugins = undefined;
+  for (const style of activeStyles) style.remove();
+  activeStyles = [];
+  activeSession = null;
+}
+
+async function prepareStyles(composition: SessionWebComposition): Promise<HTMLLinkElement[]> {
+  const links = composition.stylePaths.map((stylePath) => {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.media = 'not all';
+    link.href = `${composition.verifiedAssetBaseUrl}${stylePath}`;
+    link.dataset.doompiPluginComposition = composition.id;
+    document.head.append(link);
+    return link;
+  });
+  try {
+    await Promise.all(
+      links.map(
+        async (link) =>
+          await new Promise<void>((resolve, reject) => {
+            link.addEventListener('load', () => resolve(), { once: true });
+            link.addEventListener(
+              'error',
+              () => reject(new Error(`The verified plugin style '${link.href}' failed to load.`)),
+              {
+                once: true,
+              },
+            );
+          }),
+      ),
+    );
+    return links;
+  } catch (error) {
+    for (const link of links) link.remove();
+    throw error;
+  }
+}
+
+function reportDiagnostics(): void {
+  for (const diagnostic of webPluginDiagnostics()) {
+    console.warn(`web plugin '${diagnostic.pluginId}' ${diagnostic.kind}: ${diagnostic.message}`);
+  }
+}
+
+/** Focuses, verifies and activates exactly one session's client plugin composition. */
+export async function focusSessionWebPlugins(
+  sessionId: string | null,
+  composition: SessionWebComposition | undefined,
+): Promise<void> {
+  const key = composition === undefined ? 'empty' : compositionKey(composition);
+  if (sessionId === requestedSession && key === requestedKey) return;
+  requestedSession = sessionId;
+  requestedKey = key;
+  const epoch = ++activationEpoch;
+  const replacingActiveSession = sessionId !== null && activeSession === sessionId;
+  if (!replacingActiveSession) {
+    disposeActivePlugins();
+    activateWebPluginSession(sessionId);
+  }
+  if (sessionId === null || runtime === undefined) return;
+
+  const previous = loadedSessions.get(sessionId);
+  let plugins = previous?.key === key ? previous.plugins : undefined;
+  let preparedStyles: HTMLLinkElement[] = [];
+  try {
+    if (composition === undefined) {
+      plugins ??= builtinPlugins;
+    } else {
+      const verified = await activateVerifiedPluginComposition(composition);
+      if (!verified.ok) throw new Error(`The plugin composition was refused (${verified.code}): ${verified.message}`);
+      if (epoch !== activationEpoch) return;
+      plugins ??= await executeCompositionScript(`${composition.verifiedAssetBaseUrl}${composition.entryPath}`);
+      if (epoch !== activationEpoch) return;
+      preparedStyles = await prepareStyles(composition);
+    }
+  } catch (error) {
+    for (const style of preparedStyles) style.remove();
+    if (epoch === activationEpoch) {
+      console.error(error instanceof Error ? error : new Error(String(error)));
+      if (previous === undefined) installSessionWebPlugins(sessionId, []);
+      requestedSession = undefined;
+      requestedKey = undefined;
+    }
+    return;
+  }
+  if (epoch !== activationEpoch || plugins === undefined) {
+    for (const style of preparedStyles) style.remove();
+    return;
+  }
+
+  if (replacingActiveSession) disposeActivePlugins();
+  if (previous === undefined || previous.key !== key) {
+    if (previous !== undefined) removeSessionWebPlugins(sessionId);
+    loadedSessions.set(sessionId, { key, plugins });
+    installSessionWebPlugins(sessionId, plugins);
+  }
+  activateWebPluginSession(sessionId);
+  reportDiagnostics();
+  for (const style of preparedStyles) style.media = 'all';
+  activeStyles = preparedStyles;
+  stopActivePlugins = startPluginDefinitions(plugins, runtime);
+  activeSession = sessionId;
+}
+
+/** Drops one removed session's runtime resources and registry references. */
+export function removeSessionWebPluginRuntime(sessionId: string): void {
+  if (sessionId === activeSession || sessionId === requestedSession) {
+    activationEpoch += 1;
+    disposeActivePlugins();
+    requestedSession = undefined;
+    requestedKey = undefined;
+  }
+  loadedSessions.delete(sessionId);
+  removeSessionWebPlugins(sessionId);
+}
+
+/** Supplies the shell transport and owns all plugin runtime disposal. */
+export function startSessionWebPluginRuntime(hostRuntime: WebPluginRuntime): () => void {
+  runtime = hostRuntime;
+  builtinPlugins = installedWebPlugins();
+  stopActivePlugins = startWebPlugins(hostRuntime);
+  return () => {
+    activationEpoch += 1;
+    disposeActivePlugins();
+    requestedSession = undefined;
+    requestedKey = undefined;
+    for (const sessionId of loadedSessions.keys()) removeSessionWebPlugins(sessionId);
+    loadedSessions.clear();
+    builtinPlugins = [];
+    runtime = undefined;
+    activateWebPluginSession(null);
+  };
+}

--- a/packages/clients/doompi-web/src/web/routes/CockpitPage.tsx
+++ b/packages/clients/doompi-web/src/web/routes/CockpitPage.tsx
@@ -17,10 +17,12 @@ import { TopBar } from '../features/status/TopBar.tsx';
 import { HOST_SLOTS, webTabs } from '../lib/pluginRegistry.ts';
 import { useActiveSession } from '../stores/sessionStore.ts';
 import { sessionsStore, setActiveSession, useNoSessions } from '../stores/sessionsStore.ts';
+import { useWebPluginRegistry } from '../stores/useWebPluginRegistry.ts';
 import { findTransientTab, transientTabsStore } from '../stores/transientTabsStore.ts';
 import { setDockOpen, uiStore } from '../stores/uiStore.ts';
 
 export function CockpitPage() {
+  useWebPluginRegistry();
   const dockOpen = useStore(uiStore, (state) => state.dockOpen);
   const [railOpen, setRailOpen] = useState(false);
   const [mobileActivityOpen, setMobileActivityOpen] = useState(false);

--- a/packages/clients/doompi-web/src/web/routes/SettingsPage.tsx
+++ b/packages/clients/doompi-web/src/web/routes/SettingsPage.tsx
@@ -19,6 +19,7 @@ import {
   settingsSection,
 } from '../lib/settingsSections.ts';
 import { sessionsStore } from '../stores/sessionsStore.ts';
+import { useWebPluginRegistry } from '../stores/useWebPluginRegistry.ts';
 
 /**
  * The settings pages, in the cockpit's frame: the rail stays so a session is
@@ -26,6 +27,7 @@ import { sessionsStore } from '../stores/sessionsStore.ts';
  * An unknown section falls back to the first one.
  */
 export function SettingsPage() {
+  useWebPluginRegistry();
   const { section } = useParams({ strict: false });
   const navigate = useNavigate();
   const activeId = useStore(sessionsStore, (state) => state.activeId);

--- a/packages/clients/doompi-web/src/web/stores/useWebPluginRegistry.ts
+++ b/packages/clients/doompi-web/src/web/stores/useWebPluginRegistry.ts
@@ -1,0 +1,7 @@
+import { useSyncExternalStore } from 'react';
+import { subscribeWebPluginRegistry, webPluginRegistryRevision } from '../lib/pluginRegistry.ts';
+
+/** Re-renders a host surface when the focused session's plugin composition changes. */
+export function useWebPluginRegistry(): void {
+  useSyncExternalStore(subscribeWebPluginRegistry, webPluginRegistryRevision, webPluginRegistryRevision);
+}

--- a/packages/clients/doompi-web/tests/contract/packageShape.test.ts
+++ b/packages/clients/doompi-web/tests/contract/packageShape.test.ts
@@ -79,6 +79,8 @@ describe('doompi-web package contract', () => {
       '@agimon-ai/doompi-web-components',
       '@agimon-ai/doompi-web-contracts',
       '@agimon-ai/doompi-web-security',
+      '@codemirror/state',
+      '@codemirror/view',
       '@earendil-works/pi-client',
       '@earendil-works/pi-coding-agent',
       '@earendil-works/pi-protocol',

--- a/packages/clients/doompi-web/tests/contract/webPluginRegistry.test.ts
+++ b/packages/clients/doompi-web/tests/contract/webPluginRegistry.test.ts
@@ -4,8 +4,13 @@ import * as os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
-import { renderBuiltinWebPluginModules, writeSyncWebPluginModules } from '../../src/adapters/webPluginGenerate.ts';
+import {
+  ensureBuiltinWebPluginModules,
+  renderBuiltinWebPluginModules,
+  writeSyncWebPluginModules,
+} from '../../src/adapters/webPluginGenerate.ts';
 import { scanWebPlugins } from '../../src/adapters/webPluginScan.ts';
+import type { DeclaredWebPlugin } from '../../src/services/webPluginManifest.ts';
 
 const packageRoot = fileURLToPath(new URL('../..', import.meta.url));
 
@@ -16,6 +21,11 @@ describe('the committed builtin web plugin registry', () => {
     for (const [relativePath, content] of renderBuiltinWebPluginModules()) {
       await expect(readFile(path.join(packageRoot, relativePath), 'utf8'), relativePath).resolves.toBe(content);
     }
+  });
+
+  it('accepts the current generated modules with default and check-only options', () => {
+    expect(() => ensureBuiltinWebPluginModules()).not.toThrow();
+    expect(() => ensureBuiltinWebPluginModules({ check: true })).not.toThrow();
   });
 
   it('is empty: every tab and channel is a plugin, never a hardcoded builtin', () => {
@@ -63,18 +73,83 @@ describe('the committed builtin web plugin registry', () => {
       scratch.push(generated);
       const host = fileURLToPath(new URL('../..', import.meta.url));
       const plugins = scanWebPlugins(host, [packageDir], () => undefined);
-      const { cssModulePath } = writeSyncWebPluginModules(plugins, generated);
+      const { compositionModulePath, cssModulePath } = writeSyncWebPluginModules(plugins, generated);
+      const composition = fs.readFileSync(compositionModulePath, 'utf8');
+      expect(composition).toContain("import { webPlugins } from './webPlugins.generated.ts';");
+      expect(composition).toContain('globalThis.DoomPiWebPluginComposition = webPlugins;');
       return fs.readFileSync(cssModulePath, 'utf8');
     }
 
-    it('names src/web when the client is re-exported from src/exports', () => {
+    it('names the shell and plugin src/web roots when the client is re-exported from src/exports', () => {
       const dir = pluginPackage('src/web', path.join('src', 'exports', 'webClient.ts'));
-      expect(cssFor(dir)).toContain(`@source "${path.join(dir, 'src', 'web')}";`);
+      const css = cssFor(dir);
+      expect(css).toContain(`@source "${path.join(packageRoot, 'src', 'web')}";`);
+      expect(css).toContain(`@source "${path.join(dir, 'src', 'web')}";`);
     });
 
     it('falls back to the entry directory for a plugin with no src/web root', () => {
       const dir = pluginPackage('web', path.join('web', 'index.ts'));
       expect(cssFor(dir)).toContain(`@source "${path.join(dir, 'web')}";`);
+    });
+
+    it('names the shell once and excludes host channels from the session registry', () => {
+      const generated = fs.mkdtempSync(path.join(os.tmpdir(), 'doom-web-generated-'));
+      scratch.push(generated);
+      const hostPlugin: DeclaredWebPlugin = {
+        pluginId: 'host-fixture',
+        registrationOrder: 0,
+        channels: ['host-fixture'],
+        packageDir: packageRoot,
+        packageName: '@agimon-ai/doompi-web',
+        isHost: true,
+        client: { entry: './src/web/main.tsx' },
+        hub: { entry: './src/adapters/httpServer.ts' },
+      };
+      const { cssModulePath, serverRegistry } = writeSyncWebPluginModules([hostPlugin], generated);
+      const shellSource = `@source "${path.join(packageRoot, 'src', 'web')}";`;
+      expect(fs.readFileSync(cssModulePath, 'utf8').split(shellSource)).toHaveLength(2);
+      expect(serverRegistry).toBe('[]\n');
+    });
+
+    it('publishes external hub paths with and without a distinct distribution entry', () => {
+      const generated = fs.mkdtempSync(path.join(os.tmpdir(), 'doom-web-generated-'));
+      scratch.push(generated);
+      const externalRoot = path.join(generated, 'external');
+      const externalPlugins: DeclaredWebPlugin[] = [
+        {
+          pluginId: 'external-dist',
+          registrationOrder: 0,
+          channels: ['external-dist'],
+          packageDir: externalRoot,
+          packageName: '@scope/external-dist',
+          isHost: false,
+          client: { entry: './src/web/index.ts' },
+          hub: { entry: './src/hub.ts', dist: './dist/hub.mjs' },
+        },
+        {
+          pluginId: 'external-source',
+          registrationOrder: 1,
+          channels: ['external-source'],
+          packageDir: externalRoot,
+          packageName: '@scope/external-source',
+          isHost: false,
+          client: { entry: './src/web/index.ts' },
+          hub: { entry: './src/hub.ts' },
+        },
+      ];
+      const { serverRegistry } = writeSyncWebPluginModules(externalPlugins, generated);
+      expect(JSON.parse(serverRegistry)).toEqual([
+        {
+          pluginId: 'external-dist',
+          channels: ['external-dist'],
+          hubEntry: path.join(externalRoot, 'dist', 'hub.mjs'),
+        },
+        {
+          pluginId: 'external-source',
+          channels: ['external-source'],
+          hubEntry: path.join(externalRoot, 'src', 'hub.ts'),
+        },
+      ]);
     });
   });
 });

--- a/packages/clients/doompi-web/tests/e2e/files.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/files.spec.ts
@@ -1,9 +1,17 @@
+import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '../support/cockpit.ts';
 
 test.use({ assets: 'synced' });
+
+const writtenTimelines = new Set<string>();
+
+test.afterEach(() => {
+  for (const timelinePath of writtenTimelines) fs.rmSync(timelinePath, { force: true });
+  writtenTimelines.clear();
+});
 
 function hash(value: string): string {
   return createHash('sha256').update(value).digest('hex').slice(0, 16);
@@ -38,10 +46,21 @@ function writeChangedFiles(registryDir: string, agentDir: string): void {
   const hiddenPath = path.join(record.cwd, 'src/HiddenTarget.ts');
   events.push({ version: 2, path: hiddenPath, tool: 'write', at: 1, origin: 'scan', verified: true });
 
-  const timelineDir = path.join(agentDir, 'doom-file-edit');
+  let timelineDir = path.join(agentDir, 'doom-file-edit');
+  try {
+    const gitCommonDir = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+      cwd: record.cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (gitCommonDir !== '') timelineDir = path.join(gitCommonDir, 'doom-file-edit');
+  } catch {
+    // A non-git fixture uses the same agent-directory fallback as FileEditPaths.
+  }
   fs.mkdirSync(timelineDir, { recursive: true });
   const timelinePath = path.join(timelineDir, `${hash(fs.realpathSync(record.cwd))}-${hash('s1')}.jsonl`);
   fs.writeFileSync(timelinePath, `${events.map((event) => JSON.stringify(event)).join('\n')}\n`);
+  writtenTimelines.add(timelinePath);
 }
 
 test('files browser searches and opens the complete changed-file list', async ({ page, cockpit }) => {

--- a/packages/clients/doompi-web/tests/e2e/responsive.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/responsive.spec.ts
@@ -82,13 +82,13 @@ test.describe('responsive repository settings plugins', () => {
     await page.getByTestId('settings-menu-open').click();
     await page.getByTestId('settings-menu-sheet').getByTestId('settings-section-repository-mcp').click();
 
-    await expect(page.getByText('Select a repository to inspect its synced MCP catalog.')).toBeVisible();
+    await expect(page.getByTestId('repository-settings-panel-mcp')).toBeVisible();
     expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(390);
 
     await page.setViewportSize({ width: 800, height: 844 });
     await expect(page.getByTestId('settings-menu')).toBeHidden();
     await expect(page.getByTestId('settings-menu-open')).toBeVisible();
-    await expect(page.getByText('Select a repository to inspect its synced MCP catalog.')).toBeVisible();
+    await expect(page.getByTestId('repository-settings-panel-mcp')).toBeVisible();
     expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(800);
   });
 });

--- a/packages/clients/doompi-web/tests/integration/bridge.test.ts
+++ b/packages/clients/doompi-web/tests/integration/bridge.test.ts
@@ -5,7 +5,7 @@ import { DOOM_NOTIFICATION_ENTRY_TYPE } from '@agimon-ai/doompi-extension-contra
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { serveWeb } from '../../src/adapters/httpServer.ts';
 import type { WebServer } from '../../src/types/bridge.ts';
-import type { SessionSummary } from '../../src/types/hub.ts';
+import { HUB_PROTOCOL_VERSION, type SessionSummary } from '../../src/types/hub.ts';
 import { type FakeSession, startFakeSession } from '../support/fakeSession.ts';
 
 vi.mock('../../src/adapters/syncGuard.ts', () => ({
@@ -108,7 +108,7 @@ describe('the hub bridge', () => {
     const { server } = await bridge();
     const response = await fetch(`${server.url}/api/health`);
     expect(response.ok).toBe(true);
-    expect(await response.json()).toMatchObject({ ok: true, role: 'hub', protocol: 1, sessions: 1 });
+    expect(await response.json()).toMatchObject({ ok: true, role: 'hub', protocol: HUB_PROTOCOL_VERSION, sessions: 1 });
   });
 
   it('validates a create request before it reaches the spawner', async () => {
@@ -203,7 +203,7 @@ describe('the hub bridge', () => {
     await waitFor(() => frames.length >= 2, 'the hello and snapshot');
     // Zero channels: every data source is a plugin, and plugins arrive via a
     // synced bundle's server registry; this server runs on a bare assets dir.
-    expect(frames[0]).toEqual({ type: 'hub_hello', protocol: 1, channels: [] });
+    expect(frames[0]).toEqual({ type: 'hub_hello', protocol: HUB_PROTOCOL_VERSION, channels: [] });
     expect(frames[1].type).toBe('sessions_snapshot');
 
     await session.waitForAttach();

--- a/packages/clients/doompi-web/tests/integration/compositionFailure.test.ts
+++ b/packages/clients/doompi-web/tests/integration/compositionFailure.test.ts
@@ -50,7 +50,7 @@ const start = async (): Promise<WebServer> =>
     onNotice: (message) => notices.push(message),
   });
 
-describe('a cockpit composition that cannot be built', () => {
+describe('the stable cockpit shell', () => {
   it('still binds the hub and answers its health probe', async () => {
     mocks.resolveWebComposition.mockRejectedValue(new Error('vite build failed'));
 
@@ -63,16 +63,16 @@ describe('a cockpit composition that cannot be built', () => {
     expect(response.status).toBe(200);
   });
 
-  it('says why the plugins are missing rather than failing silently', async () => {
+  it('does not rebuild a global plugin union before binding', async () => {
     mocks.resolveWebComposition.mockRejectedValue(new Error('vite build failed'));
 
     server = await start();
 
-    expect(notices.some((message) => message.includes('vite build failed'))).toBe(true);
-    expect(notices.some((message) => message.includes('serving the packaged bundle'))).toBe(true);
+    expect(mocks.resolveWebComposition).not.toHaveBeenCalled();
+    expect(notices.some((message) => message.includes('vite build failed'))).toBe(false);
   });
 
-  it('still serves a composition when one resolves', async () => {
+  it('serves the packaged shell without a synchronized composition', async () => {
     mocks.resolveWebComposition.mockResolvedValue(undefined);
 
     server = await start();

--- a/packages/clients/doompi-web/tests/integration/httpRoutes.test.ts
+++ b/packages/clients/doompi-web/tests/integration/httpRoutes.test.ts
@@ -6,6 +6,7 @@ import { serveWeb } from '../../src/adapters/httpServer.ts';
 import type { WebServer } from '../../src/types/bridge.ts';
 import { type FakeSession, startFakeSession } from '../support/fakeSession.ts';
 
+const { spawned } = vi.hoisted(() => ({ spawned: [] as Array<{ cwd: string; name?: string }> }));
 vi.mock('../../src/adapters/syncGuard.ts', () => ({
   createSyncGuard: () => ({
     ensureSynced: async () => undefined,
@@ -14,6 +15,14 @@ vi.mock('../../src/adapters/syncGuard.ts', () => ({
   }),
 }));
 
+vi.mock('../../src/adapters/serverSpawner.ts', () => ({
+  createServerSpawner: () => ({
+    spawn: async (input: { cwd: string; name?: string }) => {
+      spawned.push(input);
+      return { ok: true as const, sessionId: 'created' };
+    },
+  }),
+}));
 const SESSION = 'routed';
 
 let server: WebServer;
@@ -22,6 +31,7 @@ let registryDir: string;
 let assetsDir: string;
 
 beforeEach(async () => {
+  spawned.length = 0;
   registryDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-web-routes-'));
   assetsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-web-assets-'));
   fs.writeFileSync(path.join(assetsDir, 'index.html'), '<!doctype html><title>cockpit</title>');
@@ -108,6 +118,47 @@ describe('the directory picker', () => {
 });
 
 describe('session lifecycle routes', () => {
+  it.each([
+    ['Doom', (root: string) => fs.mkdirSync(path.join(root, '.doom'))],
+    [
+      'Pi',
+      (root: string) => {
+        fs.mkdirSync(path.join(root, '.pi'));
+        fs.writeFileSync(path.join(root, '.pi', 'settings.json'), '{}');
+      },
+    ],
+    ['Git', (root: string) => fs.mkdirSync(path.join(root, '.git'))],
+  ])('creates a session in the selected directory below a %s-marked ancestor', async (_label, mark) => {
+    const outer = path.join(registryDir, 'outer');
+    const root = path.join(outer, 'project');
+    const selected = path.join(root, 'packages', 'feature');
+    fs.mkdirSync(selected, { recursive: true });
+    fs.mkdirSync(path.join(outer, '.git'));
+    mark(root);
+
+    const response = await fetch(url('/api/sessions'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cwd: selected, name: 'selected' }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(spawned).toEqual([expect.objectContaining({ cwd: selected, name: 'selected' })]);
+  });
+
+  it('creates a session in the selected directory when no marked ancestor exists', async () => {
+    const selected = path.join(registryDir, 'plain', 'nested');
+    fs.mkdirSync(selected, { recursive: true });
+
+    const response = await fetch(url('/api/sessions'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cwd: selected }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(spawned).toEqual([expect.objectContaining({ cwd: selected })]);
+  });
   it('refuses a create with no cwd', async () => {
     const response = await fetch(url('/api/sessions'), {
       method: 'POST',

--- a/packages/clients/doompi-web/tests/integration/hub.test.ts
+++ b/packages/clients/doompi-web/tests/integration/hub.test.ts
@@ -706,6 +706,54 @@ describe('the session hub over a registry', () => {
     expect(lifecycle.at(-1)).toBe('closed');
   });
 
+  it('loads duplicate channel names into isolated session registries and disposes them independently', async () => {
+    const registryDir = freshRegistryDir();
+    const received: string[] = [];
+    const closed: string[] = [];
+    const first = await startRegisteredSession(registryDir, { id: 'first' });
+    const second = await startRegisteredSession(registryDir, { id: 'second' });
+    const harness = startHub(registryDir, undefined, [], undefined, {
+      loadChannels: async (record) => [
+        {
+          frameType: 'shared_data',
+          start: () => ({
+            payloadFor: () => ({ owner: record.id }),
+            close: () => closed.push(record.id),
+          }),
+          receive: (_scope, _payload, connection) => received.push(`${record.id}:${connection.connectionId}`),
+        },
+      ],
+      webComposition: (record, channels) => ({
+        id: (record.id === 'first' ? 'a' : 'b').repeat(64),
+        revision: record.id === 'first' ? 1 : 2,
+        manifestUrl: '/manifest',
+        rawAssetBaseUrl: '/raw',
+        verifiedAssetBaseUrl: '/verified',
+        entryPath: '/composition.js',
+        stylePaths: [],
+        channels: [...channels],
+      }),
+    });
+    await first.waitForAttach();
+    await second.waitForAttach();
+    await waitFor(
+      () =>
+        harness.latest('first')?.webComposition?.channels.includes('shared_data') === true &&
+        harness.latest('second')?.webComposition?.channels.includes('shared_data') === true,
+      'both session channel compositions',
+    );
+
+    expect(harness.hub.channelFrames('first')[0]?.payload).toEqual({ owner: 'first' });
+    expect(harness.hub.channelFrames('second')[0]?.payload).toEqual({ owner: 'second' });
+    harness.hub.receiveChannel('first', 'shared_data', {}, 'page');
+    harness.hub.receiveChannel('second', 'shared_data', {}, 'page');
+    expect(received).toEqual(['first:page', 'second:page']);
+
+    await first.close();
+    await waitFor(() => closed.includes('first'), 'the first channel closing');
+    expect(closed).not.toContain('second');
+  });
+
   it('routes incoming channel payloads by live scope, frame type, and connection', async () => {
     const registryDir = freshRegistryDir();
     const received: unknown[] = [];

--- a/packages/clients/doompi-web/tests/integration/webBundler.test.ts
+++ b/packages/clients/doompi-web/tests/integration/webBundler.test.ts
@@ -8,6 +8,7 @@ import { loadHubChannels } from '../../src/adapters/webHubPluginLoader.ts';
 
 const workflowRoot = fileURLToPath(new URL('../../../../minor/doompi-workflow', import.meta.url));
 const planRoot = fileURLToPath(new URL('../../../../minor/doompi-plan', import.meta.url));
+const voiceRoot = fileURLToPath(new URL('../../../../minor/doompi-voice', import.meta.url));
 const teamRoot = fileURLToPath(new URL('../../../../../layers/team/doompi-team', import.meta.url));
 const securityPackageRoot = fileURLToPath(new URL('../../../../core/doompi-web-security', import.meta.url));
 const securitySingletonFixtureRoot = fileURLToPath(new URL('../fixtures/security-singleton-plugin', import.meta.url));
@@ -19,6 +20,12 @@ function bundledJsHas(assetsDir: string, needle: string): boolean {
     .some((name) => fs.readFileSync(path.join(assetsDir, 'assets', name), 'utf8').includes(needle));
 }
 
+function filesBelow(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    return entry.isDirectory() ? filesBelow(entryPath) : [entryPath];
+  });
+}
 /** The built stylesheet: plugin utility classes prove the plugin dirs were scanned. */
 function bundledCssHas(assetsDir: string, needle: string): boolean {
   return fs
@@ -127,6 +134,19 @@ describe('the sync-time cockpit bundler', () => {
     expect(fs.existsSync(path.join(result.assetsDir, 'index.html'))).toBe(true);
     expect(fs.existsSync(path.join(result.assetsDir, 'webPlugins.server.json'))).toBe(false);
     expect(fs.existsSync(path.join(outDir, 'webPlugins.server.json'))).toBe(true);
+
+    const compositionScript = fs.readFileSync(path.join(result.pluginsDir, 'composition.js'), 'utf8');
+    expect(fs.readFileSync(path.join(result.pluginsDir, 'index.html'), 'utf8')).not.toContain('<script');
+    expect(compositionScript).toContain('DoomPiWebPluginComposition');
+    expect(compositionScript).toContain('DoomPiWebPluginRuntime');
+    expect(compositionScript).not.toContain('__doompi_physical_security_copy__');
+    const clientManifest = JSON.parse(fs.readFileSync(path.join(result.pluginsDir, 'manifest.json'), 'utf8')) as Record<
+      string,
+      { file?: string; isEntry?: boolean }
+    >;
+    expect(Object.values(clientManifest)).toContainEqual(
+      expect.objectContaining({ file: 'composition.js', isEntry: true }),
+    );
     // The roots file beside the bundle is what the dev server reads to serve
     // the same composition with hot reload.
     expect(JSON.parse(fs.readFileSync(path.join(outDir, 'pluginRoots.json'), 'utf8'))).toEqual([
@@ -168,6 +188,29 @@ describe('the sync-time cockpit bundler', () => {
     expect(bundledJsHas(result.assetsDir, '@agimon-ai/doompi-web-security/browser')).toBe(false);
   });
 
+  it('keeps a plugin worker runtime and its emitted assets inside the composition', { timeout: 120_000 }, async () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-web-voice-bundle-'));
+    cleanups.push(() => fs.rmSync(outDir, { recursive: true, force: true }));
+
+    const result = await bundleCockpitWeb({ pluginRoots: [voiceRoot], outDir });
+    const pluginFiles = filesBelow(result.pluginsDir);
+    const bundledJavaScript = pluginFiles
+      .filter((file) => file.endsWith('.js'))
+      .map((file) => fs.readFileSync(file, 'utf8'))
+      .join('\n');
+    const compositionScript = fs.readFileSync(path.join(result.pluginsDir, 'composition.js'), 'utf8');
+
+    expect(result.pluginIds).toEqual(['voice']);
+    expect(bundledJavaScript).toContain('onnxruntime');
+    expect(bundledJavaScript).not.toContain('DoomPiWebPluginRuntime.onnxruntime');
+    expect(pluginFiles.filter((file) => file.endsWith('.js')).length).toBeGreaterThan(1);
+    expect(pluginFiles.some((file) => file.endsWith('.onnx'))).toBe(true);
+    expect(pluginFiles.some((file) => file.endsWith('.css'))).toBe(true);
+    expect(compositionScript).toContain('assets/');
+    expect(compositionScript).toContain('document.currentScript');
+    expect(compositionScript).not.toContain('new URL(`/assets/');
+    expect(compositionScript).not.toContain('../models/silero_vad_v6.2.1.onnx');
+  });
   it('serves zero channels for assets without a registry, since nothing is built in', async () => {
     const channels = await loadHubChannels('/nonexistent-assets', () => undefined);
     expect(channels).toEqual([]);

--- a/packages/clients/doompi-web/tests/support/bundleSetup.ts
+++ b/packages/clients/doompi-web/tests/support/bundleSetup.ts
@@ -1,7 +1,10 @@
+import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { promisify } from 'node:util';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { readSyncRegistration } from '@agimon-ai/doompi/services';
 import {
   type DeclaredPackageApi,
   DOOM_API_SCOPES,
@@ -15,8 +18,12 @@ import { pluginPackageRoots } from './pluginRoots.ts';
 /** A fixture plugin whose tool renderer throws on demand, so the timeline's fallback can be proved. */
 const crashRoot = fileURLToPath(new URL('../fixtures/crash-plugin', import.meta.url));
 
-/** Env var the cockpit fixture reads to serve the synced-style bundle. */
+/** Env vars the cockpit fixture reads for the controlled synchronized composition. */
 export const SYNCED_DIST_ENV = 'DOOMPI_E2E_SYNCED_DIST';
+export const SYNCED_HOME_ENV = 'DOOMPI_E2E_SYNCED_HOME';
+export const SYNCED_WORK_ROOT_ENV = 'DOOMPI_E2E_SYNCED_WORK_ROOT';
+
+const execFileAsync = promisify(execFile);
 
 function importName(basePath: string): string {
   return `${basePath.replace(/-([a-z0-9])/gu, (_, character: string) => character.toUpperCase())}Api`;
@@ -50,28 +57,62 @@ function writeApiRoutes(packageRoots: readonly string[], apiDir: string): void {
 }
 
 /**
- * Playwright global setup: build one synced-style bundle and the package API
- * route modules that the same synced composition publishes. Specs opting into
- * `assets: 'synced'` then exercise both halves of a plugin on a clean machine,
- * without inheriting the developer's ~/.doompi state.
+ * Playwright global setup: publish one real synchronization generation, then
+ * replace its web bundle with the all-plugin test composition. Every test works
+ * below that repository root, so the hub resolves the same valid registration
+ * without sharing the developer's Doom state or rebuilding per test.
  */
 export default async function globalSetup(): Promise<() => void> {
-  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-web-e2e-sync-'));
+  const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-web-e2e-sync-'));
+  const homeDir = path.join(testRoot, 'home');
+  const agentDir = path.join(homeDir, '.pi', 'agent');
+  const workspaceRoot = fileURLToPath(new URL('../../../../../', import.meta.url));
+  const cli = path.join(workspaceRoot, 'packages', 'core', 'doompi', 'dist', 'bin', 'cli.mjs');
+  fs.mkdirSync(agentDir, { recursive: true });
+  const syncEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+    PI_CODING_AGENT_DIR: agentDir,
+    DOOMPI_ROOT: workspaceRoot,
+  };
+  const commandOptions = { cwd: workspaceRoot, env: syncEnv, maxBuffer: 16 * 1024 * 1024 };
+  await execFileAsync(process.execPath, [cli, 'init'], commandOptions);
+  await execFileAsync(process.execPath, [cli, 'sync'], commandOptions);
+
+  const registration = readSyncRegistration(workspaceRoot, homeDir);
+  if (registration?.webDirectory === null || registration?.webDirectory === undefined) {
+    throw new Error('global setup sync did not publish a web bundle');
+  }
+  const outDir = path.dirname(registration.webDirectory);
   const packages = pluginPackageRoots();
   const result = await bundleCockpitWeb({
     pluginRoots: [...packages.map((entry) => entry.root), crashRoot],
     outDir,
   });
-  const apiDir = path.join(outDir, 'api');
+  const apiDir = path.join(testRoot, 'api');
   writeApiRoutes(
     packages.map((entry) => entry.root),
     apiDir,
   );
+  const workRoot = fs.mkdtempSync(path.join(workspaceRoot, 'node_modules', '.doompi-e2e-'));
+  const previousDist = process.env[SYNCED_DIST_ENV];
+  const previousHome = process.env[SYNCED_HOME_ENV];
+  const previousWorkRoot = process.env[SYNCED_WORK_ROOT_ENV];
   const previousApiDir = process.env.DOOMPI_API_DIR;
   process.env[SYNCED_DIST_ENV] = result.assetsDir;
+  process.env[SYNCED_HOME_ENV] = homeDir;
+  process.env[SYNCED_WORK_ROOT_ENV] = workRoot;
   process.env.DOOMPI_API_DIR = apiDir;
   return () => {
-    fs.rmSync(outDir, { recursive: true, force: true });
+    fs.rmSync(testRoot, { recursive: true, force: true });
+    fs.rmSync(workRoot, { recursive: true, force: true });
+    if (previousDist === undefined) delete process.env[SYNCED_DIST_ENV];
+    else process.env[SYNCED_DIST_ENV] = previousDist;
+    if (previousHome === undefined) delete process.env[SYNCED_HOME_ENV];
+    else process.env[SYNCED_HOME_ENV] = previousHome;
+    if (previousWorkRoot === undefined) delete process.env[SYNCED_WORK_ROOT_ENV];
+    else process.env[SYNCED_WORK_ROOT_ENV] = previousWorkRoot;
     if (previousApiDir === undefined) delete process.env.DOOMPI_API_DIR;
     else process.env.DOOMPI_API_DIR = previousApiDir;
   };

--- a/packages/clients/doompi-web/tests/support/cockpit.ts
+++ b/packages/clients/doompi-web/tests/support/cockpit.ts
@@ -40,6 +40,10 @@ process.stderr.write('the agent binary is missing\\n');
 process.exit(3);
 `;
 
+const REFUSING_SYNC = `#!/usr/bin/env node
+process.exit(1);
+`;
+
 async function freePort(): Promise<number> {
   return new Promise((resolve, reject) => {
     const probe = net.createServer();
@@ -133,10 +137,20 @@ export const test = base.extend<CockpitOptions & { cockpit: CockpitFixture }>({
   },
   cockpit: async ({ sessionCount, spawnStub, assets }, use) => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-hub-e2e-'));
+    const syncedDist = process.env.DOOMPI_E2E_SYNCED_DIST;
+    const syncedHome = process.env.DOOMPI_E2E_SYNCED_HOME;
+    const syncedWorkRoot = process.env.DOOMPI_E2E_SYNCED_WORK_ROOT;
+    if (assets === 'synced' && (!syncedDist || !syncedHome || !syncedWorkRoot)) {
+      throw new Error('global setup did not publish the synchronized test composition');
+    }
     const registryDir = path.join(root, 'run');
     const stateDir = path.join(root, 'state');
+    const homeDir = assets === 'synced' ? (syncedHome as string) : path.join(root, 'home');
     const stub = path.join(root, 'fake-doompi-server');
+    const syncStub = path.join(root, 'refuse-doompi-sync');
+    fs.mkdirSync(homeDir, { recursive: true });
     fs.writeFileSync(stub, spawnStub === 'ok' ? REGISTERING_SERVER : FAILING_SERVER, { mode: 0o755 });
+    fs.writeFileSync(syncStub, REFUSING_SYNC, { mode: 0o755 });
 
     // An isolated Pi agent directory: doom-runner keeps its store under it, and
     // runner specs write records there.
@@ -153,7 +167,16 @@ export const test = base.extend<CockpitOptions & { cockpit: CockpitFixture }>({
     for (let index = 0; index < sessionCount; index += 1) {
       const id = `s${index + 1}`;
       const apiSocketPath = path.join(apiSockets, `${id}.sock`);
-      sessions.push(await startFakeSession({ id, name: `session-${index + 1}`, registryDir, apiSocketPath }));
+      const cwd = assets === 'synced' ? fs.mkdtempSync(path.join(syncedWorkRoot as string, `${id}-`)) : undefined;
+      sessions.push(
+        await startFakeSession({
+          id,
+          name: `session-${index + 1}`,
+          registryDir,
+          apiSocketPath,
+          ...(cwd === undefined ? {} : { cwd }),
+        }),
+      );
       sessionApiStops.push(startRunnerApiSocket(runnerStore, id, apiSocketPath));
     }
 
@@ -161,15 +184,21 @@ export const test = base.extend<CockpitOptions & { cockpit: CockpitFixture }>({
     // An isolated workflow home: the hub must never watch the developer's
     // real registry from a test, and workflow specs write runs into this one.
     const workflowHome = path.join(root, 'workflow-mcp');
-    // The hub also resolves provider auth from the environment; the developer's
-    // own keys must not make a throwaway hub look signed in.
-    const env: NodeJS.ProcessEnv = { ...process.env, WORKFLOW_MCP_HOME: workflowHome, PI_CODING_AGENT_DIR: agentDir };
+    // Provider auth and personal Doom configuration are isolated from the
+    // developer. The synchronized suites resolve the one generation global
+    // setup published, while the refusing command prevents accidental rebuilds.
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      WORKFLOW_MCP_HOME: workflowHome,
+      PI_CODING_AGENT_DIR: agentDir,
+      DOOMPI_SYNC_COMMAND: syncStub,
+    };
     for (const key of Object.keys(env)) if (/_API_KEY$|_AUTH_TOKEN$|_OAUTH_TOKEN$/.test(key)) delete env[key];
-    const syncedDist = process.env.DOOMPI_E2E_SYNCED_DIST;
-    if (assets === 'synced' && !syncedDist) throw new Error('global setup did not publish the synced bundle');
     // Assets are always explicit: without this, the server would prefer the
     // developer's machine-wide ~/.doompi/web bundle over the freshly built one.
-    const assetsDir = assets === 'synced' && syncedDist ? syncedDist : path.join(packageRoot, 'dist', 'web');
+    const assetsDir = assets === 'synced' ? (syncedDist as string) : path.join(packageRoot, 'dist', 'web');
     const child: ChildProcess = spawn(
       process.execPath,
       [

--- a/packages/clients/doompi-web/tests/support/fakeSession.ts
+++ b/packages/clients/doompi-web/tests/support/fakeSession.ts
@@ -284,7 +284,9 @@ export async function startFakeSession(options: FakeSessionOptions = {}): Promis
 
   const backlogLimit = options.backlogLimit ?? 512;
   const received: Frame[] = [];
+  const connections = new Set<net.Socket>();
   let client: net.Socket | undefined;
+  let closing = false;
   let backlog: Frame[] = [];
   let dropped = 0;
   const attachWaiters: Array<() => void> = [];
@@ -308,6 +310,11 @@ export async function startFakeSession(options: FakeSessionOptions = {}): Promis
     }),
   });
   const server = net.createServer((connection) => {
+    connections.add(connection);
+    if (closing) {
+      connection.destroy();
+      return;
+    }
     connection.setEncoding('utf8');
     let buffered = '';
     let authenticated = false;
@@ -355,6 +362,7 @@ export async function startFakeSession(options: FakeSessionOptions = {}): Promis
     });
 
     const detach = (): void => {
+      connections.delete(connection);
       if (client === connection) client = undefined;
     };
     connection.on('close', detach);
@@ -445,7 +453,8 @@ export async function startFakeSession(options: FakeSessionOptions = {}): Promis
       return () => rival.destroy();
     },
     async close() {
-      client?.destroy();
+      closing = true;
+      for (const connection of connections) connection.destroy();
       if (recordPath !== undefined) fs.rmSync(recordPath, { force: true });
       await protocolSocket.close();
       await new Promise<void>((resolve) => {

--- a/packages/clients/doompi-web/tests/unit/bundlePublication.test.ts
+++ b/packages/clients/doompi-web/tests/unit/bundlePublication.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { createBundlePublication } from '../../src/adapters/bundlePublication.ts';
+import { createBundlePublication, createPluginBundlePublication } from '../../src/adapters/bundlePublication.ts';
 
 const cleanups: string[] = [];
 
@@ -93,5 +93,88 @@ describe('signed bundle publication', () => {
     fs.symlinkSync(path.join(paths.dir, 'app.js'), path.join(paths.dir, 'linked.js'));
     expect(publication.refresh()).toEqual(before);
     expect(notices.some((message) => message.includes('refused'))).toBe(true);
+  });
+});
+
+describe('signed plugin composition publication', () => {
+  it('retains exact immutable identity and revision pairings', () => {
+    const first = fixture();
+    const second = fixture();
+    const publication = createPluginBundlePublication(first.stateDir);
+
+    const one = publication.publish('a'.repeat(64), first.dir);
+    const two = publication.publish('b'.repeat(64), second.dir);
+    const oneRevision = one?.signed.manifest.revision ?? 0;
+    const twoRevision = two?.signed.manifest.revision ?? 0;
+    const oneSnapshot = publication.get('a'.repeat(64), oneRevision)?.assetsDir;
+    const twoSnapshot = publication.get('b'.repeat(64), twoRevision)?.assetsDir;
+
+    expect(oneRevision).toBeGreaterThan(0);
+    expect(twoRevision).toBe(oneRevision + 1);
+    expect(oneSnapshot).not.toBe(first.dir);
+    expect(twoSnapshot).not.toBe(second.dir);
+    expect(publication.get('a'.repeat(64), twoRevision)).toBeUndefined();
+    fs.writeFileSync(path.join(first.dir, 'app.js'), 'console.log("mutated")');
+    expect(fs.readFileSync(path.join(oneSnapshot ?? '', 'app.js'), 'utf8')).toBe('console.log("one")');
+
+    publication.close();
+    expect(fs.existsSync(oneSnapshot ?? '')).toBe(false);
+    expect(fs.existsSync(twoSnapshot ?? '')).toBe(false);
+  });
+  it('reuses an immutable composition identity and refuses publication after close', () => {
+    const source = fixture();
+    const publication = createPluginBundlePublication(source.stateDir);
+    const compositionId = 'c'.repeat(64);
+    const first = publication.publish(compositionId, source.dir);
+    fs.writeFileSync(path.join(source.dir, 'app.js'), 'console.log("mutated")');
+
+    expect(publication.publish(compositionId, source.dir)).toBe(first);
+    expect(publication.publicKey()).toMatch(/^[A-Za-z0-9_-]+$/u);
+
+    publication.close();
+    expect(publication.publish('d'.repeat(64), source.dir)).toBeUndefined();
+    publication.close();
+  });
+
+  it('reports and refuses a composition whose source directory is unavailable', () => {
+    const source = fixture();
+    const notices: string[] = [];
+    const publication = createPluginBundlePublication(source.stateDir, (message) => notices.push(message));
+
+    expect(publication.publish('e'.repeat(64), path.join(source.dir, 'missing'))).toBeUndefined();
+    expect(notices).toContainEqual(expect.stringContaining('could not be signed'));
+    publication.close();
+  });
+
+  it('refuses an empty composition without retaining its staging directory', () => {
+    const source = fixture();
+    const empty = path.join(path.dirname(source.dir), 'empty');
+    fs.mkdirSync(empty);
+    const notices: string[] = [];
+    const publication = createPluginBundlePublication(source.stateDir, (message) => notices.push(message));
+
+    expect(publication.publish('f'.repeat(64), empty)).toBeUndefined();
+    expect(notices).toContainEqual(expect.stringContaining('empty and cannot be published'));
+    publication.close();
+  });
+
+  it('evicts the oldest immutable composition after reaching the retention limit', () => {
+    const source = fixture();
+    const publication = createPluginBundlePublication(source.stateDir);
+    const published = Array.from({ length: 33 }, (_, index) => {
+      const compositionId = index.toString(16).padStart(64, '0');
+      const bundle = publication.publish(compositionId, source.dir);
+      expect(bundle).toBeDefined();
+      return { compositionId, bundle };
+    });
+    const oldest = published[0];
+    const newest = published.at(-1);
+
+    expect(publication.get(oldest?.compositionId ?? '', oldest?.bundle?.signed.manifest.revision ?? 0)).toBeUndefined();
+    expect(fs.existsSync(oldest?.bundle?.assetsDir ?? '')).toBe(false);
+    expect(publication.get(newest?.compositionId ?? '', newest?.bundle?.signed.manifest.revision ?? 0)).toBe(
+      newest?.bundle,
+    );
+    publication.close();
   });
 });

--- a/packages/clients/doompi-web/tests/unit/pluginRegistry.test.ts
+++ b/packages/clients/doompi-web/tests/unit/pluginRegistry.test.ts
@@ -2,10 +2,12 @@ import { defineSessionChannel, defineSlot, defineWebPlugin } from '@agimon-ai/do
 import { afterEach, describe, expect, it } from 'vitest';
 import { leaderGroup } from '../../src/web/lib/leaderTree.ts';
 import {
+  activateWebPluginSession,
   activityGroupSlot,
   dispatchChannelFrame,
   dropPluginSessionData,
   HOST_SLOTS,
+  installSessionWebPlugins,
   installWebPlugins,
   paletteCommands,
   pluginActivityGroups,
@@ -14,10 +16,13 @@ import {
   pluginRepositorySettingsPanels,
   pluginSelectionAxes,
   pluginToolRenderer,
+  removeSessionWebPlugins,
   resetWebPlugins,
   slotFills,
   startWebPlugins,
+  subscribeWebPluginRegistry,
   webPluginDiagnostics,
+  webPluginRegistryRevision,
   webTabs,
 } from '../../src/web/lib/pluginRegistry.ts';
 import { settingsSections } from '../../src/web/lib/settingsSections.ts';
@@ -537,6 +542,69 @@ describe('the web plugin registry', () => {
     ]);
     dropPluginSessionData('s9');
     expect(log).toEqual(['drop:one:s9', 'drop:two:s9']);
+  });
+
+  it('isolates contributions and channels by session', () => {
+    const log: string[] = [];
+    installSessionWebPlugins('session-a', [
+      defineWebPlugin({
+        id: 'shared-id',
+        tabs: [{ id: 'session-tab', label: 'A', panel: Panel }],
+        channels: [itemsChannel(log, 'shared_channel', 'a')],
+      }),
+    ]);
+    installSessionWebPlugins('session-b', [
+      defineWebPlugin({
+        id: 'shared-id',
+        tabs: [{ id: 'session-tab', label: 'B', panel: Other }],
+        channels: [itemsChannel(log, 'shared_channel', 'b')],
+      }),
+    ]);
+
+    activateWebPluginSession('session-a');
+    expect(webTabs().map((tab) => tab.label)).toEqual(['A']);
+    activateWebPluginSession('session-b');
+    expect(webTabs().map((tab) => tab.label)).toEqual(['B']);
+
+    expect(dispatchChannelFrame({ type: 'shared_channel', sessionId: 'session-a', payload: { items: ['one'] } })).toBe(
+      true,
+    );
+    expect(dispatchChannelFrame({ type: 'shared_channel', sessionId: 'session-b', payload: { items: ['two'] } })).toBe(
+      true,
+    );
+    expect(log).toEqual(['apply:a:session-a:one', 'apply:b:session-b:two']);
+
+    removeSessionWebPlugins('session-a');
+    expect(log.at(-1)).toBe('drop:a:session-a');
+    expect(dispatchChannelFrame({ type: 'shared_channel', sessionId: 'session-a', payload: { items: [] } })).toBe(
+      false,
+    );
+    expect(dispatchChannelFrame({ type: 'shared_channel', sessionId: 'session-b', payload: { items: [] } })).toBe(true);
+  });
+
+  it('replays the latest channel snapshot after an asynchronous session registry install', () => {
+    const log: string[] = [];
+    activateWebPluginSession('late');
+    expect(dispatchChannelFrame({ type: 'late_items', sessionId: 'late', payload: { items: ['first'] } })).toBe(false);
+    expect(dispatchChannelFrame({ type: 'late_items', sessionId: 'late', payload: { items: ['latest'] } })).toBe(false);
+
+    installSessionWebPlugins('late', [defineWebPlugin({ id: 'late', channels: [itemsChannel(log, 'late_items')] })]);
+
+    expect(log).toEqual(['apply:late_items:late:latest']);
+  });
+
+  it('notifies contribution readers when the active session registry changes', () => {
+    const revisions: number[] = [];
+    const unsubscribe = subscribeWebPluginRegistry(() => revisions.push(webPluginRegistryRevision()));
+    installSessionWebPlugins('session-a', [defineWebPlugin({ id: 'a' })]);
+    activateWebPluginSession('session-a');
+    installSessionWebPlugins('session-a', [defineWebPlugin({ id: 'a-next' })]);
+    removeSessionWebPlugins('session-a');
+    unsubscribe();
+
+    expect(revisions).toHaveLength(3);
+    expect(revisions[0]).toBeLessThan(revisions[1] ?? 0);
+    expect(revisions[1]).toBeLessThan(revisions[2] ?? 0);
   });
 
   it('starts runtimes in install order and disposes in reverse', () => {

--- a/packages/clients/doompi-web/tests/unit/pluginRuntime.test.ts
+++ b/packages/clients/doompi-web/tests/unit/pluginRuntime.test.ts
@@ -1,0 +1,342 @@
+import type { WebPluginDefinition, WebPluginRuntime } from '@agimon-ai/doompi-web-contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionWebComposition } from '../../src/types/hub.ts';
+
+const mocks = vi.hoisted(() => ({
+  activateVerifiedPluginComposition: vi.fn(),
+  activateWebPluginSession: vi.fn(),
+  installSessionWebPlugins: vi.fn(),
+  installedWebPlugins: vi.fn(),
+  removeSessionWebPlugins: vi.fn(),
+  startPluginDefinitions: vi.fn(),
+  startWebPlugins: vi.fn(),
+  webPluginDiagnostics: vi.fn(() => []),
+}));
+
+vi.mock('../../src/pwa/workerClient.ts', () => ({
+  activateVerifiedPluginComposition: mocks.activateVerifiedPluginComposition,
+}));
+vi.mock('../../src/web/lib/pluginRegistry.ts', () => ({
+  activateWebPluginSession: mocks.activateWebPluginSession,
+  installSessionWebPlugins: mocks.installSessionWebPlugins,
+  installedWebPlugins: mocks.installedWebPlugins,
+  removeSessionWebPlugins: mocks.removeSessionWebPlugins,
+  startPluginDefinitions: mocks.startPluginDefinitions,
+  startWebPlugins: mocks.startWebPlugins,
+  webPluginDiagnostics: mocks.webPluginDiagnostics,
+}));
+
+import {
+  focusSessionWebPlugins,
+  removeSessionWebPluginRuntime,
+  startSessionWebPluginRuntime,
+} from '../../src/web/lib/pluginRuntime.ts';
+
+interface FakeElement {
+  dataset: Record<string, string>;
+  href: string;
+  media: string;
+  rel: string;
+  removed: boolean;
+  src: string;
+  tag: string;
+  addEventListener(type: string, listener: () => void): void;
+  dispatch(type: string): void;
+  remove(): void;
+}
+
+let appended: FakeElement[];
+let automaticScriptLoad: boolean;
+let automaticStyleLoad: boolean;
+let scriptPlugins: readonly WebPluginDefinition[] | undefined;
+let styleFailure: boolean;
+
+function fakeElement(tag: string): FakeElement {
+  const listeners = new Map<string, Array<() => void>>();
+  return {
+    dataset: {},
+    href: '',
+    media: '',
+    rel: '',
+    removed: false,
+    src: '',
+    tag,
+    addEventListener(type, listener) {
+      const current = listeners.get(type) ?? [];
+      current.push(listener);
+      listeners.set(type, current);
+    },
+    dispatch(type) {
+      for (const listener of listeners.get(type) ?? []) listener();
+      listeners.delete(type);
+    },
+    remove() {
+      this.removed = true;
+    },
+  };
+}
+
+function composition(id: string, revision: number, stylePaths: string[] = []): SessionWebComposition {
+  return {
+    id: id.repeat(64),
+    revision,
+    manifestUrl: `/api/web-plugins/${id.repeat(64)}/${String(revision)}/manifest`,
+    rawAssetBaseUrl: `/api/web-plugins/${id.repeat(64)}/${String(revision)}/assets`,
+    verifiedAssetBaseUrl: `/verified-plugins/${id.repeat(64)}/${String(revision)}`,
+    entryPath: '/composition.js',
+    stylePaths,
+    channels: [],
+  };
+}
+
+beforeEach(() => {
+  appended = [];
+  automaticScriptLoad = true;
+  automaticStyleLoad = true;
+  scriptPlugins = [];
+  styleFailure = false;
+  vi.clearAllMocks();
+  mocks.activateVerifiedPluginComposition.mockResolvedValue({ ok: true, revision: 1 });
+  mocks.installedWebPlugins.mockReturnValue([]);
+  mocks.startPluginDefinitions.mockReturnValue(vi.fn());
+  mocks.startWebPlugins.mockReturnValue(vi.fn());
+  vi.stubGlobal('document', {
+    createElement: (tag: string) => fakeElement(tag),
+    head: {
+      append: (element: FakeElement) => {
+        appended.push(element);
+        queueMicrotask(() => {
+          if (element.tag === 'script') {
+            if (!automaticScriptLoad) return;
+            if (scriptPlugins !== undefined) {
+              (globalThis as unknown as Record<string, unknown>).DoomPiWebPluginComposition = scriptPlugins;
+            }
+            element.dispatch('load');
+          } else if (automaticStyleLoad) {
+            element.dispatch(styleFailure ? 'error' : 'load');
+          }
+        });
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('the focused session plugin runtime', () => {
+  it('uses the captured builtin composition when a session has no synchronized plugins', async () => {
+    const builtin = [{} as WebPluginDefinition];
+    mocks.installedWebPlugins.mockReturnValue(builtin);
+    const stop = startSessionWebPluginRuntime({} as WebPluginRuntime);
+
+    await focusSessionWebPlugins('session-one', undefined);
+
+    expect(mocks.activateVerifiedPluginComposition).not.toHaveBeenCalled();
+    expect(mocks.installSessionWebPlugins).toHaveBeenCalledWith('session-one', builtin);
+    expect(mocks.startPluginDefinitions).toHaveBeenCalledWith(builtin, expect.anything());
+    stop();
+  });
+
+  it('loads verified styles before enabling and starting a synchronized composition', async () => {
+    const dynamic = [{} as WebPluginDefinition];
+    scriptPlugins = dynamic;
+    const stop = startSessionWebPluginRuntime({} as WebPluginRuntime);
+
+    await focusSessionWebPlugins('session-two', composition('a', 2, ['/assets/composition.css']));
+
+    const style = appended.find((element) => element.tag === 'link');
+    expect(style).toEqual(expect.objectContaining({ media: 'all', removed: false }));
+    expect(mocks.installSessionWebPlugins).toHaveBeenCalledWith('session-two', dynamic);
+    expect(mocks.startPluginDefinitions).toHaveBeenCalledWith(dynamic, expect.anything());
+    stop();
+  });
+
+  it('keeps the running composition when its same-session replacement is refused', async () => {
+    const firstPlugins = [{} as WebPluginDefinition];
+    scriptPlugins = firstPlugins;
+    const stopActive = vi.fn();
+    mocks.startPluginDefinitions.mockReturnValue(stopActive);
+    const stop = startSessionWebPluginRuntime({} as WebPluginRuntime);
+    await focusSessionWebPlugins('session-three', composition('b', 1));
+    mocks.installSessionWebPlugins.mockClear();
+    mocks.startPluginDefinitions.mockClear();
+    mocks.activateVerifiedPluginComposition.mockResolvedValueOnce({
+      ok: false,
+      code: 'manifest-fetch',
+      message: 'offline',
+    });
+
+    await focusSessionWebPlugins('session-three', composition('c', 2));
+
+    expect(stopActive).not.toHaveBeenCalled();
+    expect(mocks.installSessionWebPlugins).not.toHaveBeenCalled();
+    expect(mocks.startPluginDefinitions).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('fails closed and removes prepared styles when a first composition style fails', async () => {
+    scriptPlugins = [{} as WebPluginDefinition];
+    styleFailure = true;
+    const stop = startSessionWebPluginRuntime({} as WebPluginRuntime);
+
+    await focusSessionWebPlugins('session-four', composition('d', 1, ['/assets/broken.css']));
+
+    expect(appended.find((element) => element.tag === 'link')?.removed).toBe(true);
+    expect(mocks.installSessionWebPlugins).toHaveBeenCalledWith('session-four', []);
+    expect(mocks.startPluginDefinitions).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('fails closed when a verified script exports no plugin composition', async () => {
+    scriptPlugins = undefined;
+    const stop = startSessionWebPluginRuntime({} as WebPluginRuntime);
+
+    await focusSessionWebPlugins('session-five', composition('e', 1));
+
+    expect(mocks.installSessionWebPlugins).toHaveBeenCalledWith('session-five', []);
+    expect(mocks.startPluginDefinitions).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('atomically replaces an active composition and ignores its repeated key', async () => {
+    const firstPlugins = [{} as WebPluginDefinition];
+    const secondPlugins = [{ id: 'replacement' } as WebPluginDefinition];
+    const firstStop = vi.fn();
+    const secondStop = vi.fn();
+    mocks.startPluginDefinitions.mockReturnValueOnce(firstStop).mockReturnValueOnce(secondStop);
+    scriptPlugins = firstPlugins;
+    const stop = startSessionWebPluginRuntime({} as WebPluginRuntime);
+    await focusSessionWebPlugins('session-six', composition('f', 1));
+    scriptPlugins = secondPlugins;
+
+    const replacement = composition('g', 2, ['/assets/replacement.css']);
+    await focusSessionWebPlugins('session-six', replacement);
+    await focusSessionWebPlugins('session-six', replacement);
+
+    expect(firstStop).toHaveBeenCalledOnce();
+    expect(mocks.removeSessionWebPlugins).toHaveBeenCalledWith('session-six');
+    expect(mocks.installSessionWebPlugins).toHaveBeenLastCalledWith('session-six', secondPlugins);
+    expect(mocks.activateVerifiedPluginComposition).toHaveBeenCalledTimes(2);
+
+    removeSessionWebPluginRuntime('session-six');
+    expect(secondStop).toHaveBeenCalledOnce();
+    stop();
+  });
+
+  it('reuses a verified cached composition when focus returns to its session', async () => {
+    const cachedPlugins = [{ id: 'cached' } as WebPluginDefinition];
+    scriptPlugins = cachedPlugins;
+    const stop = startSessionWebPluginRuntime({} as WebPluginRuntime);
+    const cachedComposition = composition('i', 3);
+    await focusSessionWebPlugins('session-eight', cachedComposition);
+    await focusSessionWebPlugins('other-session', undefined);
+    const scriptCount = appended.filter((element) => element.tag === 'script').length;
+    mocks.installSessionWebPlugins.mockClear();
+
+    await focusSessionWebPlugins('session-eight', cachedComposition);
+
+    expect(appended.filter((element) => element.tag === 'script')).toHaveLength(scriptCount);
+    expect(mocks.installSessionWebPlugins).not.toHaveBeenCalledWith('session-eight', expect.anything());
+    expect(mocks.startPluginDefinitions).toHaveBeenLastCalledWith(cachedPlugins, expect.anything());
+    stop();
+  });
+
+  it('cancels stale composition work after script and style loading', async () => {
+    scriptPlugins = [{ id: 'stale-script' } as WebPluginDefinition];
+    automaticScriptLoad = false;
+    const stop = startSessionWebPluginRuntime({} as WebPluginRuntime);
+    const pendingScript = focusSessionWebPlugins('session-nine', composition('j', 1));
+    await vi.waitFor(() => expect(appended.some((element) => element.tag === 'script')).toBe(true));
+    await focusSessionWebPlugins('fallback-one', undefined);
+    const script = appended.find((element) => element.tag === 'script');
+    (globalThis as unknown as Record<string, unknown>).DoomPiWebPluginComposition = scriptPlugins;
+    script?.dispatch('load');
+    await pendingScript;
+    expect(mocks.installSessionWebPlugins).not.toHaveBeenCalledWith('session-nine', expect.anything());
+
+    appended = [];
+    automaticScriptLoad = true;
+    automaticStyleLoad = false;
+    scriptPlugins = [{ id: 'stale-style' } as WebPluginDefinition];
+    const pendingStyle = focusSessionWebPlugins('session-ten', composition('k', 1, ['/assets/stale.css']));
+    await vi.waitFor(() => expect(appended.some((element) => element.tag === 'link')).toBe(true));
+    await focusSessionWebPlugins('fallback-two', undefined);
+    const style = appended.find((element) => element.tag === 'link');
+    style?.dispatch('load');
+    await pendingStyle;
+
+    expect(style?.removed).toBe(true);
+    expect(mocks.installSessionWebPlugins).not.toHaveBeenCalledWith('session-ten', expect.anything());
+    stop();
+  });
+
+  it('reports non-Error verification failures as Error instances', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mocks.activateVerifiedPluginComposition.mockRejectedValueOnce('offline');
+    const stop = startSessionWebPluginRuntime({} as WebPluginRuntime);
+
+    await focusSessionWebPlugins('session-eleven', composition('l', 1));
+
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ message: 'offline' }));
+    stop();
+  });
+
+  it('ignores a verification rejection after its session is removed', async () => {
+    let rejectVerification: ((reason: Error) => void) | undefined;
+    mocks.activateVerifiedPluginComposition.mockImplementationOnce(
+      async () =>
+        await new Promise<never>((_resolve, reject) => {
+          rejectVerification = reject;
+        }),
+    );
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const stop = startSessionWebPluginRuntime({} as WebPluginRuntime);
+    const pending = focusSessionWebPlugins('session-twelve', composition('m', 1));
+    await vi.waitFor(() => expect(rejectVerification).toBeTypeOf('function'));
+    removeSessionWebPluginRuntime('session-twelve');
+    rejectVerification?.(new Error('obsolete'));
+    await pending;
+
+    expect(error).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('cancels a pending composition when its session is removed', async () => {
+    let resolveVerification: ((result: { ok: true; revision: number }) => void) | undefined;
+    mocks.activateVerifiedPluginComposition.mockImplementationOnce(
+      async () =>
+        await new Promise<{ ok: true; revision: number }>((resolve) => {
+          resolveVerification = resolve;
+        }),
+    );
+    scriptPlugins = [{} as WebPluginDefinition];
+    const stop = startSessionWebPluginRuntime({} as WebPluginRuntime);
+
+    const pending = focusSessionWebPlugins('session-seven', composition('h', 1));
+    await vi.waitFor(() => expect(resolveVerification).toBeTypeOf('function'));
+    removeSessionWebPluginRuntime('session-seven');
+    resolveVerification?.({ ok: true, revision: 1 });
+    await pending;
+
+    expect(appended.filter((element) => element.tag === 'script')).toHaveLength(0);
+    expect(mocks.installSessionWebPlugins).not.toHaveBeenCalled();
+    expect(mocks.removeSessionWebPlugins).toHaveBeenCalledWith('session-seven');
+
+    mocks.removeSessionWebPlugins.mockClear();
+    removeSessionWebPluginRuntime('unknown-session');
+    expect(mocks.removeSessionWebPlugins).toHaveBeenCalledWith('unknown-session');
+    stop();
+  });
+
+  it('does not activate plugins without a focused session or host runtime', async () => {
+    await focusSessionWebPlugins(null, undefined);
+    await focusSessionWebPlugins('session-without-runtime', undefined);
+
+    expect(mocks.startPluginDefinitions).not.toHaveBeenCalled();
+    expect(mocks.activateWebPluginSession).toHaveBeenCalledWith(null);
+    expect(mocks.activateWebPluginSession).toHaveBeenCalledWith('session-without-runtime');
+    removeSessionWebPluginRuntime('session-without-runtime');
+  });
+});

--- a/packages/clients/doompi-web/tests/unit/sessionWebComposition.test.ts
+++ b/packages/clients/doompi-web/tests/unit/sessionWebComposition.test.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ readSyncRegistration: vi.fn() }));
+
+vi.mock('@agimon-ai/doompi/services', () => ({ readSyncRegistration: mocks.readSyncRegistration }));
+
+import { resolveSessionWebArtifacts } from '../../src/adapters/sessionWebComposition.ts';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  vi.clearAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe('session web composition artifacts', () => {
+  it('includes standalone CSS manifest entries not attached to the JavaScript entry', () => {
+    const generation = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-session-web-composition-'));
+    temporaryDirectories.push(generation);
+    const webDirectory = path.join(generation, 'web');
+    const pluginsDirectory = path.join(generation, 'plugins');
+    fs.mkdirSync(webDirectory);
+    fs.mkdirSync(path.join(pluginsDirectory, 'assets'), { recursive: true });
+    fs.writeFileSync(path.join(pluginsDirectory, 'composition.js'), 'globalThis.DoomPiWebPluginComposition = [];');
+    fs.writeFileSync(
+      path.join(pluginsDirectory, 'manifest.json'),
+      JSON.stringify({
+        'composition.ts': { file: 'composition.js', isEntry: true },
+        'style.css': { file: 'assets/composition.css', src: 'style.css' },
+      }),
+    );
+    mocks.readSyncRegistration.mockReturnValue({
+      root: '/repo',
+      generation: 'generation-one',
+      stateSha256: 'state-one',
+      webDirectory,
+    });
+
+    expect(resolveSessionWebArtifacts('/repo')).toEqual(
+      expect.objectContaining({
+        pluginsDir: pluginsDirectory,
+        entryPath: '/composition.js',
+        stylePaths: ['/assets/composition.css'],
+      }),
+    );
+  });
+});

--- a/packages/clients/doompi-web/tests/unit/syncGuard.test.ts
+++ b/packages/clients/doompi-web/tests/unit/syncGuard.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createSyncGuard } from '../../src/adapters/syncGuard.ts';
 
 vi.mock('node:child_process', async (importOriginal) => ({
@@ -11,6 +11,10 @@ vi.mock('node:child_process', async (importOriginal) => ({
 const REPO = '/workspace/repo';
 const drifted = { fresh: false, reasons: ['configuration-changed'] as const };
 const fresh = { fresh: true, reasons: [] as const };
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 function guard(readDrift: () => { fresh: boolean; reasons: readonly string[] }, runSync = vi.fn(async () => {})) {
   return {
@@ -58,7 +62,19 @@ describe('cwd sync guard', () => {
     await subject.ensureSynced();
 
     expect(findRoot).toHaveBeenCalledWith('/workspace/repo/packages/web');
-    expect(readDrift).toHaveBeenCalledWith(REPO);
+    expect(readDrift).toHaveBeenCalledWith(REPO, undefined);
+    subject.close();
+  });
+
+  it('checks the selected repository against the launcher-staged Doom entry', async () => {
+    const stagedEntry = '/runtime/doompi/dist/src/extensions/entries/doom.mjs';
+    vi.stubEnv('DOOMPI_BOOTSTRAP_ENTRY', stagedEntry);
+    const readDrift = vi.fn((_repoRoot: string, _expectedBootstrapEntry?: string) => fresh);
+    const subject = createSyncGuard({ repoRoot: REPO, readDrift });
+
+    await subject.ensureSynced();
+
+    expect(readDrift).toHaveBeenCalledWith(REPO, stagedEntry);
     subject.close();
   });
 });
@@ -137,7 +153,7 @@ describe('sync guard', () => {
     expect(spawn).toHaveBeenCalledWith(
       process.execPath,
       [expect.stringMatching(/cli\.mjs$/), 'sync'],
-      expect.objectContaining({ cwd: REPO }),
+      expect.objectContaining({ cwd: REPO, env: expect.objectContaining({ DOOMPI_ROOT: REPO }) }),
     );
     subject.close();
   });

--- a/packages/clients/doompi-web/tests/unit/webPluginVite.test.ts
+++ b/packages/clients/doompi-web/tests/unit/webPluginVite.test.ts
@@ -1,13 +1,19 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({ readSyncRegistration: vi.fn() }));
 
 vi.mock('@agimon-ai/doompi/services', () => ({ readSyncRegistration: mocks.readSyncRegistration }));
 
-import { readDevPluginRoots } from '../../src/adapters/webPluginVite.ts';
+import {
+  WEB_PLUGIN_RUNTIME_SPECIFIERS,
+  readDevPluginRoots,
+  webPluginRuntimeAliases,
+  webPluginRuntimeGlobal,
+} from '../../src/adapters/webPluginVite.ts';
 
 const temporaryDirectories: string[] = [];
 
@@ -22,6 +28,42 @@ afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
 });
 
+describe('the standalone plugin runtime facade', () => {
+  it('externalizes the complete shared singleton set by exact specifier', () => {
+    expect(WEB_PLUGIN_RUNTIME_SPECIFIERS).toEqual([
+      'react',
+      'react/jsx-runtime',
+      'react/jsx-dev-runtime',
+      'react-dom',
+      'react-dom/client',
+      '@tanstack/store',
+      '@tanstack/react-store',
+      '@agimon-ai/doompi-web-contracts',
+      '@agimon-ai/doompi-web-components',
+      '@agimon-ai/doompi-web-security/browser',
+      '@codemirror/state',
+      '@codemirror/view',
+    ]);
+    expect(webPluginRuntimeGlobal('react/jsx-runtime')).toBe('globalThis.DoomPiWebPluginRuntime.reactJsxRuntime');
+    expect(webPluginRuntimeGlobal('react/jsx-dev-runtime')).toBe(
+      'globalThis.DoomPiWebPluginRuntime.reactJsxDevRuntime',
+    );
+    expect(webPluginRuntimeGlobal('@codemirror/view')).toBe('globalThis.DoomPiWebPluginRuntime.codemirrorView');
+  });
+
+  it('resolves transformed plugin imports from the host runtime dependency tree', () => {
+    const clientRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../src/web');
+    const alias = webPluginRuntimeAliases(clientRoot).find(
+      ({ find }) => find instanceof RegExp && find.test('react/jsx-dev-runtime'),
+    );
+
+    if (alias === undefined || !(alias.find instanceof RegExp)) {
+      throw new Error('The host runtime did not resolve the React JSX development runtime.');
+    }
+    expect(alias.find.test('react/jsx-dev-runtime/extra')).toBe(false);
+    expect(fs.existsSync(alias.replacement)).toBe(true);
+  });
+});
 describe('readDevPluginRoots', () => {
   it('prefers an explicit roots list without reading a registration', () => {
     expect(readDevPluginRoots({ DOOMPI_WEB_PLUGIN_ROOTS: ['/one', '/two'].join(path.delimiter) }, '/home')).toEqual([

--- a/packages/core/doompi/src/adapters/bootstrapLocator.ts
+++ b/packages/core/doompi/src/adapters/bootstrapLocator.ts
@@ -8,6 +8,8 @@ import { readSyncRegistration } from './syncRegistration.ts';
 import { readSyncState } from './syncState.ts';
 import { BUNDLED_PRECOMPILE_STRATEGY, PRECOMPILE_STATE_VERSION } from './syncStateContract.ts';
 
+const BOOTSTRAP_ENTRY_ENV = 'DOOMPI_BOOTSTRAP_ENTRY';
+
 /**
  * One recorded build input: the stat pair for speed, the digest for truth.
  *
@@ -167,6 +169,8 @@ function isInside(directory: string, target: string): boolean {
 }
 
 function packagedDoomEntry(moduleUrl: string = import.meta.url): string {
+  const configuredEntry = process.env[BOOTSTRAP_ENTRY_ENV];
+  if (configuredEntry) return configuredEntry;
   const extension = moduleUrl.endsWith('.ts') ? 'ts' : 'mjs';
   const sourceRoot = path.dirname(path.dirname(fileURLToPath(moduleUrl)));
   return path.join(sourceRoot, 'extensions', 'entries', `doom.${extension}`);

--- a/packages/core/doompi/src/adapters/syncDrift.ts
+++ b/packages/core/doompi/src/adapters/syncDrift.ts
@@ -24,6 +24,8 @@ export interface SyncDrift {
 
 export interface ReadSyncDriftOptions {
   repoRoot: string;
+  /** Launcher-owned Doom entry used to build this repository's generated bootstrap. */
+  expectedBootstrapEntry?: string;
   homeDirectory?: string;
 }
 
@@ -78,13 +80,20 @@ export function readSyncDrift(options: ReadSyncDriftOptions): SyncDrift {
   // The same question the `--check` path asks, so the cockpit and the CLI
   // cannot disagree about whether one repository is synced.
   try {
-    if (!readBootstrapStatus(options.repoRoot, undefined, homeDirectory).fresh) reasons.push('runtime-stale');
+    if (!readBootstrapStatus(options.repoRoot, options.expectedBootstrapEntry, homeDirectory).fresh) {
+      reasons.push('runtime-stale');
+    }
   } catch {
     // An unreadable bootstrap record is exactly as unusable as a stale one, and
     // syncing is what reports the underlying cause.
     reasons.push('runtime-stale');
   }
-  if (registration.webDirectory !== null && !fs.existsSync(path.join(registration.webDirectory, 'index.html'))) {
+  if (
+    registration.webDirectory !== null &&
+    (!fs.existsSync(path.join(registration.webDirectory, 'index.html')) ||
+      !fs.existsSync(path.join(path.dirname(registration.webDirectory), 'plugins', 'composition.js')) ||
+      !fs.existsSync(path.join(path.dirname(registration.webDirectory), 'plugins', 'manifest.json')))
+  ) {
     reasons.push('cockpit-bundle-missing');
   }
   if (!fs.existsSync(registration.apiDirectory)) reasons.push('package-apis-missing');

--- a/packages/core/doompi/tests/services/bootstrapLocator.test.ts
+++ b/packages/core/doompi/tests/services/bootstrapLocator.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   readBootstrapPointer,
   readBootstrapStatus,
@@ -111,6 +111,7 @@ function stateWith(overrides: Record<string, unknown>): string {
 
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  vi.unstubAllEnvs();
 });
 
 describe('readBootstrapState contract', () => {
@@ -210,6 +211,18 @@ describe('readBootstrapStatus freshness', () => {
     const { bootstrap } = bundledState(root);
 
     expect(readBootstrapStatus(root, entry, homeFor(root))).toEqual({ bootstrap, fresh: true });
+  });
+
+  it('loads the generated bootstrap built from a launcher-staged Doom entry', () => {
+    const root = temporaryRoot();
+    const stagedEntry = path.join(root, 'runtime', 'doompi', 'dist', 'src', 'extensions', 'entries', 'doom.mjs');
+    fs.mkdirSync(path.dirname(stagedEntry), { recursive: true });
+    fs.writeFileSync(stagedEntry, 'export default () => undefined;\n');
+    const { bootstrap, bootstrapManifest } = bundledState(root, { bootstrapEntry: stagedEntry });
+    fs.writeFileSync(bootstrapManifest, JSON.stringify(compilerManifest(bootstrap, [stagedEntry])));
+    vi.stubEnv('DOOMPI_BOOTSTRAP_ENTRY', stagedEntry);
+
+    expect(readBootstrapStatus(root, undefined, homeFor(root))).toEqual({ bootstrap, fresh: true });
   });
 
   it('rejects output built for a different package entry or precompile contract', () => {

--- a/packages/minor/doompi-voice/src/web/browserMediaDevice.ts
+++ b/packages/minor/doompi-voice/src/web/browserMediaDevice.ts
@@ -497,7 +497,7 @@ export class BrowserVoiceMediaDevice implements VoiceMediaDevice {
         this.capabilities.captureActivity = false;
         this.capabilities.autonomousOrchestration = false;
       });
-      await detector.initialize(new URL('../models/silero_vad_v6.2.1.onnx', import.meta.url).href);
+      await detector.initialize(new URL('../../models/silero_vad_v6.2.1.onnx', import.meta.url).href);
       this.speechDetector = detector;
       this.capabilities.captureActivity = true;
       this.capabilities.autonomousOrchestration = this.rebindProtocolSupported;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,6 +439,12 @@ importers:
       '@agimon-ai/doompi-web-security':
         specifier: workspace:*
         version: link:../../core/doompi-web-security
+      '@codemirror/state':
+        specifier: 6.7.1
+        version: 6.7.1
+      '@codemirror/view':
+        specifier: 6.43.9
+        version: 6.43.9
       '@earendil-works/pi-client':
         specifier: 0.84.4
         version: 0.84.4


### PR DESCRIPTION
## What this changes

Keeps the packaged DoomPi web client as a stable shell while synchronizing immutable, verified plugin artifacts per repository and activating them only for the focused session. It also preserves each session's requested working directory, disposes inactive browser runtimes and styles, and makes the packaged desktop runtime resolve the same synchronized composition correctly.

## Why

The packaged desktop and web path could replace the stable cockpit with repository-specific output, resolve synchronization from the wrong root, or retain plugin resources after focus changed. Those failures could hide plugin-backed activity data, lose nested session cwd, or leak one repository's browser composition into another session.

## Checks

- [x] `pnpm lint:vibe --preflight-only`
- [x] Affected Nx targets pass: `lint`, `typecheck`, `build`, `test`
- [x] `pnpm fmt:check`
- [x] Packed-install system tests, if this is a release change: `pnpm nx run-many -t test-system`
- [x] DoomPi web E2E: 159 passed
- [x] Exact `Dockerfile.ci` build and run completed locally with Node 22.22.1 and pnpm 11.1.3

## Scope

- [x] Package boundaries are respected (`packages/core`, `packages/default`, `packages/minor`, `packages/clients`, `layers/`, `packages/tooling`)
- [x] Doom-to-Doom dependencies stay `workspace:*`
- [x] Package exports, Pi entries, resources, runtime ordering, and RMUX LFS payloads are preserved
- [x] No unrelated changes bundled in

## Risk

This changes the synchronized web-plugin publication and browser activation boundary. Publication now stages and verifies immutable plugin artifacts before replacement, the stable shell verifies compositions before importing them, and tests cover signature rejection, failed publication, focus changes, disposal, cwd preservation, and repository isolation. The web client also declares the CodeMirror packages used by synchronized tool renderers as direct dependencies so generated plugin modules resolve consistently.
