### PR TITLE
fix(doompi-voice): bind external narration to session

### DIFF
--- a/packages/minor/doompi-voice/docs/ARCHITECTURE.md
+++ b/packages/minor/doompi-voice/docs/ARCHITECTURE.md
@@ -420,11 +420,15 @@ flowchart TB
 | Direction | Service                           | Site                                              |
 | --------- | --------------------------------- | ------------------------------------------------- |
 | provides  | `DOOM_VOICE_TOOLS_SERVICE`        | `voice.ts`                                        |
-| provides  | `DOOM_NARRATION_SERVICE`          | `voice.ts`                                        |
+| provides  | `DOOM_NARRATION_SERVICE`          | `voice.ts`, inside the Cordis session fiber       |
 | injects   | `DOOM_HELP_SERVICE`               | `extension.ts`                                    |
 | injects   | `DOOM_UI_HUB_SERVICE`             | `extension.ts`                                    |
 | injects   | `DOOM_MINOR_MODE_CATALOG_SERVICE` | `voice.ts`                                        |
 | listens   | `DOOM_ASK_USER_BLOCKED_EVENT`     | `voice.ts`, blocks delivery while a modal is open |
+
+`DOOM_NARRATION_SERVICE` is a session capability rather than a runtime-root service. Each request is checked against the exact-active narration tool runtime for the Cordis session that provided it. Disposing that session invalidates retained service references and aborts its in-flight external narration.
+
+Browser media ownership remains page-global so an enabled background Voice session stays connected across route changes. That continuity does not authorize narration from another session: an inactive or mismatched session cannot borrow the active session's controller.
 
 ### Worker protocol
 

--- a/packages/minor/doompi-voice/src/adapters/pi/voice.ts
+++ b/packages/minor/doompi-voice/src/adapters/pi/voice.ts
@@ -10,6 +10,10 @@ import {
 } from '@agimon-ai/doompi-config/config';
 import { type DoomConfig, type IDoomConfigLoader, type ResolvedVoiceConfig } from '@agimon-ai/doompi-config/types';
 import { DOOM_ASK_USER_BLOCKED_EVENT } from '@agimon-ai/doompi-extension-contracts/ask-user';
+import {
+  DOOM_CORDIS_SESSION_SERVICE,
+  type DoomCordisSessionService,
+} from '@agimon-ai/doompi-extension-contracts/cordis-host';
 import type { LeaderBinding } from '@agimon-ai/doompi-extension-contracts/leader';
 import {
   DOOM_MINOR_MODE_CATALOG_SERVICE,
@@ -384,17 +388,49 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+export interface VoiceNarrationServiceBinding {
+  readonly generation: string;
+  readonly signal: AbortSignal;
+  isCurrentSession(): boolean;
+}
+
 export function createVoiceNarrationService(
   controller: Pick<VoiceWorkerAutoCaptureController, 'narrateExternal'>,
+  binding: VoiceNarrationServiceBinding,
 ): DoomNarrationService {
   const service: DoomNarrationService = {
-    generation: `${VOICE_SOURCE}:narration:${crypto.randomUUID()}`,
+    generation: binding.generation,
     async request(request) {
       if (!isNarrationRequest(request)) throw new Error('Invalid narration request.');
-      await controller.narrateExternal(request.text);
+      if (binding.signal.aborted || !binding.isCurrentSession()) return;
+      await controller.narrateExternal(request.text, binding.signal);
     },
   };
   return Object.freeze(service);
+}
+
+export function registerSessionVoiceNarrationService(
+  cordis: Context,
+  controller: Pick<VoiceWorkerAutoCaptureController, 'narrateExternal'>,
+  runtimeProvider: () => NarrationToolRuntime | undefined,
+): void {
+  cordis.inject([DOOM_CORDIS_SESSION_SERVICE], (sessionContext) => {
+    const session = sessionContext.get(DOOM_CORDIS_SESSION_SERVICE) as DoomCordisSessionService;
+    const sessionAbort = new AbortController();
+    let mounted = true;
+    sessionContext.provide(
+      DOOM_NARRATION_SERVICE,
+      createVoiceNarrationService(controller, {
+        generation: `${session.generation}:voice-narration`,
+        signal: sessionAbort.signal,
+        isCurrentSession: () => mounted && isNarrationRuntimeActive(runtimeProvider(), session.context),
+      }),
+    );
+    return () => {
+      mounted = false;
+      sessionAbort.abort();
+    };
+  });
 }
 
 export function registerAutoCaptureCordisEventHandlers(
@@ -1033,7 +1069,7 @@ export function installVoiceRuntime(cordis: Context, pi: ExtensionAPI, options: 
       }, VOICE_OWNERSHIP_COMMAND_TIMEOUT_MS);
     };
 
-    cordis.provide(DOOM_NARRATION_SERVICE, createVoiceNarrationService(autoController));
+    registerSessionVoiceNarrationService(cordis, autoController, () => narrationToolRuntime);
     if (typeof pi.registerTool === 'function') {
       registerNarrationTool(pi, () => narrationToolRuntime, options.waitUntilConfigured);
     }

--- a/packages/minor/doompi-voice/tests/voiceExtension.test.ts
+++ b/packages/minor/doompi-voice/tests/voiceExtension.test.ts
@@ -1,6 +1,10 @@
 import { DOOM_ASK_USER_BLOCKED_EVENT } from '@agimon-ai/doompi-extension-contracts/ask-user';
-import { createNarrationRequest } from '@agimon-ai/doompi-extension-contracts/narration';
-import { VOICE_MODE_TOOL_NAMES } from '@agimon-ai/doompi-extension-contracts/voice-tools';
+import {
+  DOOM_CORDIS_SESSION_SERVICE,
+  type DoomCordisSessionService,
+} from '@agimon-ai/doompi-extension-contracts/cordis-host';
+import { createNarrationRequest, readDoomNarrationService } from '@agimon-ai/doompi-extension-contracts/narration';
+import { createDoomVoiceToolsService, VOICE_MODE_TOOL_NAMES } from '@agimon-ai/doompi-extension-contracts/voice-tools';
 import { Context } from '@deepseek-ai/cordis';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { describe, expect, it, vi } from 'vitest';
@@ -10,9 +14,11 @@ import {
   extractTerminalAssistantText,
   reconcileVoiceModeTools,
   registerAutoCaptureCordisEventHandlers,
+  registerSessionVoiceNarrationService,
   registerVoiceTurnFallback,
   type VoiceTurnFallbackRuntime,
 } from '../src/exports';
+import type { NarrationToolRuntime } from '../src/adapters/pi/narrationTool.ts';
 import { deliverAutoCaptureInput } from '../src/adapters/pi/voice.ts';
 describe('autonomous prompt delivery', () => {
   it('queues composed prompts as follow-ups without changing ordinary idle or steer delivery', () => {
@@ -67,24 +73,177 @@ describe('Voice-owned tool reconciliation', () => {
 });
 
 describe('Doom Voice Cordis wiring', () => {
+  function narrationContext(sessionId: string): ExtensionContext {
+    return {
+      hasUI: true,
+      sessionManager: { getSessionId: () => sessionId },
+      signal: undefined,
+    } as unknown as ExtensionContext;
+  }
+
+  function runtimeFixture(sessionId: string, context: ExtensionContext, active = true) {
+    const voiceTools = createDoomVoiceToolsService<ExtensionContext>(`voice-narration-test:${sessionId}`);
+    const session = voiceTools.bindSession(sessionId, context);
+    session.setActive(active);
+    const runtime: NarrationToolRuntime = {
+      context,
+      session,
+      controller: { state: active ? 'active' : 'disabled', narrateAgent: vi.fn(async () => 'completed' as const) },
+    };
+    return { runtime, dispose: () => voiceTools.dispose() };
+  }
+
+  function mountSession(cordis: Context, sessionId: string, generation: string, context: ExtensionContext) {
+    const service: DoomCordisSessionService = Object.freeze({
+      sessionId,
+      generation,
+      reason: 'startup',
+      context,
+    });
+    return cordis.plugin((sessionContext) => sessionContext.provide(DOOM_CORDIS_SESSION_SERVICE, service));
+  }
+
+  function request(text: string) {
+    const value = createNarrationRequest(text);
+    if (!value) throw new Error('Expected a narration request.');
+    return value;
+  }
+
   it('publishes a direct narration service for caller-owned speech', async () => {
     const controller = { narrateExternal: vi.fn(async () => 'completed' as const) };
-    const service = createVoiceNarrationService(controller);
-    const request = createNarrationRequest('Caller-owned narration.');
-    if (!request) throw new Error('Expected a narration request.');
-    await service.request(request);
+    const sessionAbort = new AbortController();
+    const service = createVoiceNarrationService(controller, {
+      generation: 'voice-session:narration',
+      signal: sessionAbort.signal,
+      isCurrentSession: () => true,
+    });
+    await service.request(request('Caller-owned narration.'));
 
+    expect(service.generation).toBe('voice-session:narration');
     expect(controller.narrateExternal).toHaveBeenCalledOnce();
-    expect(controller.narrateExternal).toHaveBeenCalledWith('Caller-owned narration.');
+    expect(controller.narrateExternal).toHaveBeenCalledWith('Caller-owned narration.', sessionAbort.signal);
   });
 
   it('reports rejected external playback to the direct caller', async () => {
     const controller = { narrateExternal: vi.fn(async () => Promise.reject(new Error('speaker unavailable'))) };
-    const service = createVoiceNarrationService(controller);
-    const request = createNarrationRequest('Status.');
-    if (!request) throw new Error('Expected a narration request.');
-    await expect(service.request(request)).rejects.toThrow('speaker unavailable');
+    const sessionAbort = new AbortController();
+    const service = createVoiceNarrationService(controller, {
+      generation: 'voice-session:narration',
+      signal: sessionAbort.signal,
+      isCurrentSession: () => true,
+    });
+    await expect(service.request(request('Status.'))).rejects.toThrow('speaker unavailable');
     expect(controller.narrateExternal).toHaveBeenCalledOnce();
+  });
+
+  it('provides external narration only for the exact active Cordis session', async () => {
+    const cordis = new Context();
+    const controller = {
+      narrateExternal: vi.fn(async (_text: string, _signal?: AbortSignal) => 'completed' as const),
+    };
+    let runtime: NarrationToolRuntime | undefined;
+    registerSessionVoiceNarrationService(cordis, controller, () => runtime);
+    expect(readDoomNarrationService(cordis)).toBeUndefined();
+
+    const contextA = narrationContext('session-a');
+    const activeA = runtimeFixture('session-a', contextA);
+    runtime = activeA.runtime;
+    const sessionA = mountSession(cordis, 'session-a', 'cordis-session-a', contextA);
+    await sessionA.await();
+    const serviceA = readDoomNarrationService(cordis);
+    if (!serviceA) throw new Error('Expected session A narration service.');
+    expect(serviceA.generation).toBe('cordis-session-a:voice-narration');
+    await serviceA.request(request('Session A update.'));
+    expect(controller.narrateExternal).toHaveBeenCalledOnce();
+    const signalA = controller.narrateExternal.mock.calls[0]?.[1];
+
+    await sessionA.dispose();
+    expect(readDoomNarrationService(cordis)).toBeUndefined();
+    await serviceA.request(request('Stale session A update.'));
+    expect(controller.narrateExternal).toHaveBeenCalledOnce();
+    expect(signalA?.aborted).toBe(true);
+
+    const contextB = narrationContext('session-b');
+    const sessionB = mountSession(cordis, 'session-b', 'cordis-session-b', contextB);
+    await sessionB.await();
+    const serviceB = readDoomNarrationService(cordis);
+    if (!serviceB) throw new Error('Expected session B narration service.');
+    await serviceB.request(request('Mismatched session B update.'));
+    expect(controller.narrateExternal).toHaveBeenCalledOnce();
+
+    const activeB = runtimeFixture('session-b', contextB);
+    runtime = activeB.runtime;
+    await serviceB.request(request('Session B update.'));
+    expect(controller.narrateExternal).toHaveBeenCalledTimes(2);
+    const signalB = controller.narrateExternal.mock.calls[1]?.[1];
+    expect(signalB).not.toBe(signalA);
+
+    await sessionB.dispose();
+    activeA.dispose();
+    activeB.dispose();
+    await cordis.fiber.dispose();
+  });
+
+  it('aborts in-flight external narration when its Cordis session is disposed', async () => {
+    const cordis = new Context();
+    let narrationSignal: AbortSignal | undefined;
+    const controller = {
+      narrateExternal: vi.fn(
+        async (_text: string, signal?: AbortSignal) =>
+          new Promise<'interrupted'>((resolve) => {
+            narrationSignal = signal;
+            signal?.addEventListener('abort', () => resolve('interrupted'), { once: true });
+          }),
+      ),
+    };
+    let runtime: NarrationToolRuntime | undefined;
+    registerSessionVoiceNarrationService(cordis, controller, () => runtime);
+    const context = narrationContext('session-active');
+    const active = runtimeFixture('session-active', context);
+    runtime = active.runtime;
+    const session = mountSession(cordis, 'session-active', 'cordis-session-active', context);
+    await session.await();
+    const service = readDoomNarrationService(cordis);
+    if (!service) throw new Error('Expected active narration service.');
+
+    const pending = service.request(request('In-flight update.'));
+    await vi.waitFor(() => expect(narrationSignal).toBeDefined());
+    await session.dispose();
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(narrationSignal?.aborted).toBe(true);
+    active.dispose();
+    await cordis.fiber.dispose();
+  });
+
+  it('keeps an active background root independent from an inactive root', async () => {
+    const rootA = new Context();
+    const rootB = new Context();
+    const controllerA = { narrateExternal: vi.fn(async () => 'completed' as const) };
+    const controllerB = { narrateExternal: vi.fn(async () => 'completed' as const) };
+    const contextA = narrationContext('background-a');
+    const contextB = narrationContext('inactive-b');
+    const activeA = runtimeFixture('background-a', contextA);
+    const inactiveB = runtimeFixture('inactive-b', contextB, false);
+    registerSessionVoiceNarrationService(rootA, controllerA, () => activeA.runtime);
+    registerSessionVoiceNarrationService(rootB, controllerB, () => inactiveB.runtime);
+    const sessionA = mountSession(rootA, 'background-a', 'cordis-background-a', contextA);
+    const sessionB = mountSession(rootB, 'inactive-b', 'cordis-inactive-b', contextB);
+    await Promise.all([sessionA.await(), sessionB.await()]);
+    const serviceA = readDoomNarrationService(rootA);
+    const serviceB = readDoomNarrationService(rootB);
+    if (!serviceA || !serviceB) throw new Error('Expected both session narration services.');
+
+    await serviceA.request(request('Background A update.'));
+    await serviceB.request(request('Inactive B update.'));
+    await serviceA.request(request('Background A continues.'));
+
+    expect(controllerA.narrateExternal).toHaveBeenCalledTimes(2);
+    expect(controllerB.narrateExternal).not.toHaveBeenCalled();
+    await Promise.all([sessionA.dispose(), sessionB.dispose()]);
+    activeA.dispose();
+    inactiveB.dispose();
+    await Promise.all([rootA.fiber.dispose(), rootB.fiber.dispose()]);
   });
 
   it('subscribes only while the Cordis event consumer is live', async () => {


### PR DESCRIPTION
## What this changes

Scopes `DOOM_NARRATION_SERVICE` to the Cordis session fiber and validates each external narration request against that session's exact-active Voice runtime. Session disposal now invalidates retained service references and aborts in-flight external narration while preserving page-global browser media ownership.

## Why

External narration previously used the runtime-root provider and could borrow an active Voice controller from another session. Voice activation is session-local, so inactive and mismatched sessions must fail closed.

## Checks

- [x] `pnpm lint:vibe --preflight-only`
- [x] Affected Nx targets pass: `lint`, `typecheck`, `build`, `test`
- [x] `pnpm fmt:check`
- [x] Packed-install system tests are not applicable because this is not a release change

Additional consumer tests passed for task, user feedback, plan, and workflow.

## Scope

- [x] Package boundaries are respected (`packages/core`, `packages/default`, `packages/minor`, `packages/clients`, `layers/`, `packages/tooling`)
- [x] Doom-to-Doom dependencies stay `workspace:*`
- [x] Package exports, Pi entries, resources, runtime ordering, and RMUX LFS payloads are preserved
- [x] No unrelated changes bundled in

## Risk

The authorization boundary for external narration moves from the runtime root to the Cordis session lifecycle. Regression coverage includes mismatched sessions, inactive sessions, retained stale references, in-flight disposal, and independent Cordis roots.
