### PR TITLE
Fix per-session web extension sync without forced generations

### DIFF
--- a/packages/clients/doompi-web/src/adapters/syncGuard.ts
+++ b/packages/clients/doompi-web/src/adapters/syncGuard.ts
@@ -1,15 +1,17 @@
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { describeSyncDrift, readSyncDrift } from '@agimon-ai/doompi/services';
+import { describeSyncDrift, readSyncDrift, readSyncRegistration } from '@agimon-ai/doompi/services';
 import { findRepositoryRoot } from '@agimon-ai/doompi/utils';
 import { repositoryDoomPiCli } from './bundledServer.ts';
+import { webHostPackageRoot } from './webPluginGenerate.ts';
 
 const DOOMPI_PACKAGE = '@agimon-ai/doompi';
 const AGENT_COMMAND_ENV = 'DOOMPI_AGENT_COMMAND';
 const SYNC_COMMAND_ENV = 'DOOMPI_SYNC_COMMAND';
 const BOOTSTRAP_ENTRY_ENV = 'DOOMPI_BOOTSTRAP_ENTRY';
 const HARNESS_ROOT_ENV = 'DOOMPI_ROOT';
+const WEB_PACKAGE_ROOT_ENV = 'DOOMPI_WEB_PACKAGE_ROOT';
 const CLI_SEGMENTS = ['dist', 'bin', 'cli.mjs'];
 const SYNC_ARGS = ['sync'];
 /** How often the watcher re-reads the drift inputs. */
@@ -79,7 +81,11 @@ function spawnSync(repoRoot: string): Promise<SyncRunOutcome> {
   return new Promise((resolve) => {
     const child = spawn(process.execPath, [cli, ...SYNC_ARGS], {
       cwd: repoRoot,
-      env: { ...process.env, [HARNESS_ROOT_ENV]: repoRoot },
+      env: {
+        ...process.env,
+        [HARNESS_ROOT_ENV]: repoRoot,
+        [WEB_PACKAGE_ROOT_ENV]: process.env[WEB_PACKAGE_ROOT_ENV] || webHostPackageRoot(),
+      },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     const tail: string[] = [];
@@ -122,7 +128,14 @@ export function createSyncGuard(options: SyncGuardOptions): SyncGuard {
   const expectedBootstrapEntry = process.env[BOOTSTRAP_ENTRY_ENV];
   const readDrift =
     options.readDrift ??
-    ((root: string, entry?: string) => readSyncDrift({ repoRoot: root, expectedBootstrapEntry: entry }));
+    ((root: string, entry?: string) => {
+      const drift = readSyncDrift({ repoRoot: root, expectedBootstrapEntry: entry });
+      // A CLI-only sync is valid for the terminal, but cannot supply session UI.
+      if (drift.fresh && readSyncRegistration(root)?.webDirectory == null) {
+        return { fresh: false, reasons: ['cockpit-bundle-missing'] };
+      }
+      return drift;
+    });
   const baseInterval = options.intervalMs ?? WATCH_INTERVAL_MS;
   let inFlight: Promise<{ ready: boolean; rebuilt: boolean; error?: string }> | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;

--- a/packages/clients/doompi-web/tests/unit/syncGuard.test.ts
+++ b/packages/clients/doompi-web/tests/unit/syncGuard.test.ts
@@ -1,13 +1,20 @@
 import { spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
+import { readSyncDrift, readSyncRegistration } from '@agimon-ai/doompi/services';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createSyncGuard } from '../../src/adapters/syncGuard.ts';
+import { webHostPackageRoot } from '../../src/adapters/webPluginGenerate.ts';
 
 vi.mock('node:child_process', async (importOriginal) => ({
   ...(await importOriginal<typeof import('node:child_process')>()),
   spawn: vi.fn(),
 }));
 
+vi.mock('@agimon-ai/doompi/services', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agimon-ai/doompi/services')>()),
+  readSyncDrift: vi.fn(),
+  readSyncRegistration: vi.fn(),
+}));
 const REPO = '/workspace/repo';
 const drifted = { fresh: false, reasons: ['configuration-changed'] as const };
 const fresh = { fresh: true, reasons: [] as const };
@@ -89,6 +96,28 @@ describe('cwd sync guard', () => {
 });
 
 describe('sync guard', () => {
+  it('rebuilds a CLI-only sync before serving web extensions', async () => {
+    vi.mocked(readSyncDrift).mockReturnValue({ fresh: true, reasons: [] });
+    vi.mocked(readSyncRegistration).mockReturnValue({ webDirectory: null } as ReturnType<typeof readSyncRegistration>);
+    const runSync = vi.fn(async () => {
+      vi.mocked(readSyncRegistration).mockReturnValue({ webDirectory: '/synced/web' } as ReturnType<
+        typeof readSyncRegistration
+      >);
+    });
+    const subject = createSyncGuard({ repoRoot: REPO, runSync });
+    await subject.ensureSynced();
+    expect(runSync).toHaveBeenCalledExactlyOnceWith(REPO);
+    subject.close();
+  });
+
+  it('rejects a sync that still has no web composition', async () => {
+    vi.mocked(readSyncDrift).mockReturnValue({ fresh: true, reasons: [] });
+    vi.mocked(readSyncRegistration).mockReturnValue({ webDirectory: null } as ReturnType<typeof readSyncRegistration>);
+    const subject = createSyncGuard({ repoRoot: REPO, runSync: async () => {} });
+    await expect(subject.ensureSynced()).rejects.toThrow('cockpit bundle is missing');
+    subject.close();
+  });
+
   it('leaves a synced repository alone', async () => {
     const { guard: subject, runSync } = guard(() => fresh);
 
@@ -150,6 +179,7 @@ describe('sync guard', () => {
   });
 
   it('runs the packaged sync command when no runner is injected', async () => {
+    vi.stubEnv('DOOMPI_WEB_PACKAGE_ROOT', '');
     const child = fakeChild();
     const subject = createSyncGuard({ repoRoot: REPO, readDrift: driftOnce() });
 
@@ -160,12 +190,16 @@ describe('sync guard', () => {
     expect(spawn).toHaveBeenCalledWith(
       process.execPath,
       [expect.stringMatching(/cli\.mjs$/), 'sync'],
-      expect.objectContaining({ cwd: REPO, env: expect.objectContaining({ DOOMPI_ROOT: REPO }) }),
+      expect.objectContaining({
+        cwd: REPO,
+        env: expect.objectContaining({ DOOMPI_ROOT: REPO, DOOMPI_WEB_PACKAGE_ROOT: webHostPackageRoot() }),
+      }),
     );
     subject.close();
   });
 
   it('uses the configured bundled agent when the repository has no pinned CLI', async () => {
+    vi.stubEnv('DOOMPI_WEB_PACKAGE_ROOT', '/runtime/doompi-web');
     vi.stubEnv('DOOMPI_AGENT_COMMAND', '/runtime/doompi/dist/bin/cli.mjs');
     const child = fakeChild();
     const subject = createSyncGuard({ repoRoot: REPO, readDrift: driftOnce() });
@@ -177,7 +211,10 @@ describe('sync guard', () => {
     expect(spawn).toHaveBeenCalledWith(
       process.execPath,
       ['/runtime/doompi/dist/bin/cli.mjs', 'sync'],
-      expect.objectContaining({ cwd: REPO }),
+      expect.objectContaining({
+        cwd: REPO,
+        env: expect.objectContaining({ DOOMPI_WEB_PACKAGE_ROOT: '/runtime/doompi-web' }),
+      }),
     );
     subject.close();
     vi.unstubAllEnvs();

--- a/packages/core/doompi/src/adapters/syncDrift.ts
+++ b/packages/core/doompi/src/adapters/syncDrift.ts
@@ -27,6 +27,8 @@ export interface ReadSyncDriftOptions {
   /** Launcher-owned Doom entry used to build this repository's generated bootstrap. */
   expectedBootstrapEntry?: string;
   homeDirectory?: string;
+  /** Web hosts cannot reuse a CLI-only generation without plugin artifacts. */
+  requireWebBundle?: boolean;
 }
 
 /**
@@ -89,10 +91,11 @@ export function readSyncDrift(options: ReadSyncDriftOptions): SyncDrift {
     reasons.push('runtime-stale');
   }
   if (
-    registration.webDirectory !== null &&
-    (!fs.existsSync(path.join(registration.webDirectory, 'index.html')) ||
-      !fs.existsSync(path.join(path.dirname(registration.webDirectory), 'plugins', 'composition.js')) ||
-      !fs.existsSync(path.join(path.dirname(registration.webDirectory), 'plugins', 'manifest.json')))
+    (registration.webDirectory === null && options.requireWebBundle) ||
+    (registration.webDirectory !== null &&
+      (!fs.existsSync(path.join(registration.webDirectory, 'index.html')) ||
+        !fs.existsSync(path.join(path.dirname(registration.webDirectory), 'plugins', 'composition.js')) ||
+        !fs.existsSync(path.join(path.dirname(registration.webDirectory), 'plugins', 'manifest.json'))))
   ) {
     reasons.push('cockpit-bundle-missing');
   }

--- a/packages/core/doompi/src/commands/syncCommand.ts
+++ b/packages/core/doompi/src/commands/syncCommand.ts
@@ -499,7 +499,12 @@ export class SyncCommand {
     // Publishing an identical generation is not a no-op: it moves the
     // registration, so every attached cockpit reloads and the previous
     // generation becomes garbage. Same inputs, same published result.
-    if (!force && readSyncDrift({ repoRoot, homeDirectory }).fresh) {
+    const driftOptions = {
+      repoRoot,
+      homeDirectory,
+      requireWebBundle: Boolean(environment.DOOMPI_WEB_PACKAGE_ROOT),
+    };
+    if (!force && readSyncDrift(driftOptions).fresh) {
       output.write('doompi sync is already up to date\n');
       return 0;
     }
@@ -512,7 +517,7 @@ export class SyncCommand {
     try {
       // A concurrent publisher may have resolved the drift while this command
       // waited for the lock. Avoid moving the registration for no change.
-      if (!force && readSyncDrift({ repoRoot, homeDirectory }).fresh) {
+      if (!force && readSyncDrift(driftOptions).fresh) {
         output.write('doompi sync is already up to date\n');
         return 0;
       }

--- a/packages/core/doompi/tests/commands/syncCommand.test.ts
+++ b/packages/core/doompi/tests/commands/syncCommand.test.ts
@@ -657,6 +657,52 @@ describe('doompi sync', { timeout: 30_000 }, () => {
     expect(text()).toContain('already up to date');
   });
 
+  it('builds missing web artifacts once for concurrent sessions and reuses their generation', async () => {
+    const root = makeRepository();
+    const homeDirectory = homeFor(root);
+    await new SyncCommand().execute(
+      ['sync'],
+      environmentFor(root, { DOOMPI_WEB_PACKAGE_ROOT: path.join(root, 'unavailable-web-host') }),
+      root,
+      capture().output,
+    );
+    const cliOnly = readSyncRegistration(root, homeDirectory);
+    expect(cliOnly?.webDirectory).toBeNull();
+
+    const webRoot = path.join(root, 'web-host');
+    fs.mkdirSync(path.join(webRoot, 'dist'), { recursive: true });
+    fs.writeFileSync(
+      path.join(webRoot, 'dist', 'bundler.mjs'),
+      `import fs from 'node:fs';
+import path from 'node:path';
+export async function bundleCockpitWeb({ outDir }) {
+  const assetsDir = path.join(outDir, 'web');
+  fs.mkdirSync(assetsDir, { recursive: true });
+  fs.writeFileSync(path.join(assetsDir, 'index.html'), '<html></html>');
+  const plugins = path.join(outDir, 'plugins');
+  fs.mkdirSync(plugins, { recursive: true });
+  fs.writeFileSync(path.join(plugins, 'composition.js'), 'export {};');
+  fs.writeFileSync(path.join(plugins, 'manifest.json'), '{}');
+  return { assetsDir, pluginIds: [] };
+}
+`,
+    );
+    const environment = { ...environmentFor(root), DOOMPI_WEB_PACKAGE_ROOT: webRoot };
+    const buildsBefore = mocks.buildSyncedRuntime.mock.calls.length;
+    await Promise.all([
+      new SyncCommand().execute(['sync'], environment, root, capture().output),
+      new SyncCommand().execute(['sync'], environment, root, capture().output),
+    ]);
+    const web = readSyncRegistration(root, homeDirectory);
+    expect(web?.webDirectory).not.toBeNull();
+    expect(web?.generation).not.toBe(cliOnly?.generation);
+    expect(mocks.buildSyncedRuntime.mock.calls.length - buildsBefore).toBe(1);
+
+    await new SyncCommand().execute(['sync'], environment, root, capture().output);
+    expect(readSyncRegistration(root, homeDirectory)?.generation).toBe(web?.generation);
+    expect(mocks.buildSyncedRuntime.mock.calls.length - buildsBefore).toBe(1);
+  });
+
   it('prunes generations the published one replaced', async () => {
     const root = makeRepository();
     const homeDirectory = homeFor(root);


### PR DESCRIPTION
## Summary
- Pass the running web host's bundler path to per-folder sync subprocesses, preserving explicit overrides.
- Treat missing web artifacts as drift for web-required syncs, while retaining CLI-only sync behavior.
- Keep normal lock-protected syncs so concurrent sessions reuse the published generation rather than forcing replacements.

## Verification
- Added coverage for missing web bundles, bundler propagation, and concurrent same-repository generation reuse.
- Passed affected DoomPi and doompi-web Nx lint, typecheck, build, and test targets.
- Passed repository vibe-lint preflight with five existing PWA coverage warnings.
- Regenerated local global and agirepo web bundles successfully. Rendered UI remains unverified.
