### PR TITLE
feat: improve MCP session authorization

### DIFF
--- a/packages/clients/doompi-web/src/web/features/activity/ContextPanel.tsx
+++ b/packages/clients/doompi-web/src/web/features/activity/ContextPanel.tsx
@@ -47,6 +47,20 @@ function tokens(value: number | null): string {
  * because a package is what you add or remove. It reads only; switching stays
  * with the composer chips that already own it.
  */
+function withoutMcpInventory(groups: readonly ContextGroup[]): ContextGroup[] {
+  return groups.map((group) => {
+    const mcp = group.items.filter((item) => item.source === 'mcp');
+    const activeMcpTokens = mcp.reduce((sum, item) => sum + (item.active ? (item.tokens ?? 0) : 0), 0);
+    const inactiveMcpTokens = mcp.reduce((sum, item) => sum + (item.active ? 0 : (item.tokens ?? 0)), 0);
+    return {
+      ...group,
+      items: group.items.filter((item) => item.source !== 'mcp'),
+      tokens: group.tokens === null ? null : Math.max(0, group.tokens - activeMcpTokens),
+      inactiveTokens: Math.max(0, group.inactiveTokens - inactiveMcpTokens),
+    };
+  });
+}
+
 export function ContextPanel() {
   const statuses = useActiveSession((state) => state.statuses);
   const widgets = useActiveSession((state) => state.widgets);
@@ -59,7 +73,7 @@ export function ContextPanel() {
   const groups = context ? projectedGroups(context) : contextGroups(statuses, widgets, projection);
   const total = totalTokens(groups);
   const idle = inactiveTotal(groups);
-
+  const visibleGroups = withoutMcpInventory(groups);
   return (
     <div data-testid="context-panel" className="flex min-h-0 flex-1 flex-col">
       <div data-testid="context-scroll" className="min-h-0 flex-1 overflow-y-auto">
@@ -73,7 +87,7 @@ export function ContextPanel() {
           />
         ) : (
           <div className="flex flex-col">
-            {groups.map((group) => (
+            {visibleGroups.map((group) => (
               <ContextGroupView key={`${group.kind}:${group.id}`} group={group} onSelect={setTarget} />
             ))}
           </div>

--- a/packages/clients/doompi-web/src/web/features/session/Timeline.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/Timeline.tsx
@@ -339,16 +339,15 @@ const Entry = memo(function Entry({ entry, sessionId }: { entry: TimelineEntry; 
       <p
         className={`min-w-0 flex-1 whitespace-pre-wrap break-words text-[12px] ${isError ? 'text-doom-red' : 'text-doom-dim'}`}
       >
-        {entry.text.split('\n').map((line, index) => {
-          const href = noticeHref(line);
+        {entry.text.split(/(\s+)/u).map((part, index) => {
+          const href = noticeHref(part);
           return (
             <Fragment key={index}>
-              {index > 0 ? '\n' : null}
               {href === null ? (
-                line
+                part
               ) : (
                 <a href={href} target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
-                  {line}
+                  {part}
                 </a>
               )}
             </Fragment>

--- a/packages/clients/doompi-web/src/web/lib/pluginSlotProps.ts
+++ b/packages/clients/doompi-web/src/web/lib/pluginSlotProps.ts
@@ -5,6 +5,7 @@ import type {
   TransientTab,
   WebPluginContextItem,
   WebPluginSlotProps,
+  WebPluginContextInventoryItem,
 } from '@agimon-ai/doompi-web-contracts';
 import { createElement, type ReactNode } from 'react';
 import { fileTabForPath } from './composition.ts';
@@ -31,6 +32,7 @@ export function pluginSlotProps(
   appendComposerDraft: (text: string) => void,
   attachComposerContext: (item: WebPluginContextItem) => void,
   attachComposerCapture: (capture: ComposerCapture) => void = () => undefined,
+  contextInventory: readonly WebPluginContextInventoryItem[] = [],
 ): WebPluginSlotProps {
   const props: WebPluginSlotProps = {
     sessionId,
@@ -66,6 +68,7 @@ export function pluginSlotProps(
     },
     sendSessionFrame: sendFrame,
     statuses,
+    contextInventory,
     renderThread(threadId, options): ReactNode {
       return sessionId === null ? null : renderThread(sessionId, threadId, options);
     },

--- a/packages/clients/doompi-web/src/web/lib/sessionModel.ts
+++ b/packages/clients/doompi-web/src/web/lib/sessionModel.ts
@@ -6,6 +6,7 @@ import {
   MINOR_MODE_ENTRY_TYPE,
   type MinorModeProjection,
 } from '../../types/hub.ts';
+import { parseDoomNotificationEntry } from '../../types/notification.ts';
 import { BUILTIN_COMMANDS } from './commands.ts';
 
 export type EntryKind = 'user' | 'assistant' | 'tool' | 'notice';
@@ -782,11 +783,21 @@ export function reduceSession(state: SessionState, frame: Frame, options: Reduce
     case DIALOG_ANSWERED_TYPE:
       return state.dialog && state.dialog.id === asString(frame.id) ? { ...state, dialog: null } : state;
 
-    // The runtime journals its minor-mode catalog as a custom entry; every
-    // other custom entry belongs to some extension's own bookkeeping.
+    // Journaled composition and notifications apply independently of protocol-owned messages.
     case 'entry_appended': {
       const entry = isRecord(frame.entry) ? frame.entry : undefined;
       if (!entry) return state;
+      const notification = parseDoomNotificationEntry(frame);
+      if (notification) {
+        if (state.restoredIds.includes(notification.entryId)) return state;
+        const next = withEntry(state, {
+          kind: 'notice',
+          id: `n${state.nextId}`,
+          text: notification.data.body,
+          tone: notification.data.level === 'error' ? 'error' : 'info',
+        });
+        return { ...next, restoredIds: [...next.restoredIds, notification.entryId] };
+      }
       if (entry.type === 'custom' && entry.customType === MINOR_MODE_ENTRY_TYPE) {
         const data = isRecord(entry.data) ? entry.data : undefined;
         if (!data || !Array.isArray(data.modes)) return state;

--- a/packages/clients/doompi-web/src/web/stores/usePluginSlotProps.ts
+++ b/packages/clients/doompi-web/src/web/stores/usePluginSlotProps.ts
@@ -12,6 +12,10 @@ export function usePluginSlotProps(sessionId: string | null, onOpen?: () => void
   const statuses = useStore(sessionStoreFor(sessionId), (state) => state.statuses);
   const catalog = useStore(sessionStoreFor(sessionId), (state) => state.minorModes);
   const widgets = useStore(sessionStoreFor(sessionId), (state) => state.widgets);
+  const contextInventory = useStore(
+    sessionStoreFor(sessionId),
+    (state) => state.context?.groups.flatMap((group) => group.items) ?? [],
+  );
   const openTab = useOpenTab();
   const props = pluginSlotProps(
     sessionId,
@@ -34,6 +38,7 @@ export function usePluginSlotProps(sessionId: string | null, onOpen?: () => void
     (text) => appendComposerDraft(sessionId, text),
     (item) => attachComposerContext(sessionId, item),
     (capture) => attachComposerCapture(sessionId, capture),
+    contextInventory,
   );
   props.activeMinorModes = minorModes(statuses, widgets, catalog)
     .filter((mode) => mode.availability === 'on')

--- a/packages/clients/doompi-web/tests/e2e/context.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/context.spec.ts
@@ -75,7 +75,7 @@ test.describe('with the synced MCP context contribution', () => {
     await expect(page.getByTestId('context-empty')).toBeVisible();
     const auth = page.getByTestId('context-mcp-auth');
     await expect(auth).toBeVisible();
-    const serverList = auth.getByRole('list', { name: 'MCP servers needing authorization' });
+    const serverList = auth.getByRole('list', { name: 'MCP servers', exact: true });
     const serverRow = serverList.getByRole('listitem').filter({ hasText: serverName });
     await expect(serverRow).toHaveCount(1);
 
@@ -91,12 +91,117 @@ test.describe('with the synced MCP context contribution', () => {
 
     cockpit.session.emit(status('doom-mcp-session-auth', ''));
     await expect(auth).toBeHidden();
-
+    await page.getByTestId('mcp-authorization-dialog').getByRole('button', { name: 'close', exact: true }).click();
     cockpit.session.emit(status('doom-mcp-session-auth', JSON.stringify([{ name: 'linear', state: 'needs-auth' }])));
     await expect(auth).toBeVisible();
     await expect(serverList.getByRole('listitem')).toHaveCount(1);
     await expect(serverList).toContainText('linear');
     await expect(serverList).not.toContainText(serverName);
+  });
+  test('opens OAuth in a new tab and keeps a copyable manual link in the dialog', async ({ page, cockpit }) => {
+    await page.context().route('https://auth.example.test/**', (route) => route.fulfill({ body: 'Provider sign-in' }));
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {
+          writeText: async (value: string) => {
+            localStorage.setItem('copied-oauth-link', value);
+          },
+        },
+      });
+    });
+    await page.goto(cockpit.url);
+    await cockpit.session.waitForAttach();
+    cockpit.session.emit(status('doom-mcp-session-auth', JSON.stringify([{ name: 'agiflow-mcp', state: 'failed' }])));
+    await page.getByTestId('dock-tab-context').click();
+    const popupPromise = page.waitForEvent('popup');
+    await page.getByRole('button', { name: 'Authorize agiflow-mcp', exact: true }).click();
+    const popup = await popupPromise;
+    const dialog = page.getByTestId('mcp-authorization-dialog');
+    await expect(dialog).toBeVisible();
+    await expect
+      .poll(() => cockpit.session.received.filter((frame) => frame.type === 'prompt'))
+      .toEqual([{ type: 'prompt', message: '/mcp auth agiflow-mcp' }]);
+    const authorizationUrl = 'https://auth.example.test/oauth?state=example&code_challenge=test';
+    cockpit.session.emit(
+      status('doom-mcp-session-auth', JSON.stringify([{ name: 'agiflow-mcp', state: 'needs-auth', authorizationUrl }])),
+    );
+    await expect(popup).toHaveURL(authorizationUrl);
+    expect(await popup.evaluate(() => window.opener)).toBeNull();
+    await expect(dialog.getByRole('textbox', { name: 'OAuth authorization URL' })).toHaveValue(authorizationUrl);
+    await expect(dialog.getByRole('link', { name: 'open authorization page' })).toHaveAttribute(
+      'href',
+      authorizationUrl,
+    );
+    await dialog.getByRole('button', { name: 'copy link' }).click();
+    await expect(dialog).toContainText('Link copied.');
+    expect(await page.evaluate(() => localStorage.getItem('copied-oauth-link'))).toBe(authorizationUrl);
+    cockpit.session.emit(
+      status('doom-mcp-session-auth', JSON.stringify([{ name: 'agiflow-mcp', state: 'connected' }])),
+    );
+    await expect(dialog).toContainText('Authorization complete.');
+    await expect(dialog.getByRole('textbox')).toHaveCount(0);
+    await dialog.getByRole('button', { name: 'close', exact: true }).click();
+    expect(popup.isClosed()).toBe(false);
+    const serverList = page.getByRole('list', { name: 'MCP servers', exact: true });
+    await expect(serverList).toContainText('agiflow-mcp');
+    await expect(serverList).toContainText('connected');
+    const pageCount = page.context().pages().length;
+    await serverList.getByRole('button', { name: 'Manage agiflow-mcp', exact: true }).click();
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'reauthorize', exact: true })).toBeVisible();
+    expect(page.context().pages()).toHaveLength(pageCount);
+    expect(cockpit.session.received.filter((frame) => frame.type === 'prompt')).toHaveLength(1);
+    await dialog.getByRole('button', { name: 'disconnect', exact: true }).click();
+    await expect
+      .poll(() => cockpit.session.received.filter((frame) => frame.type === 'prompt'))
+      .toEqual([
+        { type: 'prompt', message: '/mcp auth agiflow-mcp' },
+        { type: 'prompt', message: '/mcp disconnect agiflow-mcp' },
+      ]);
+    expect(page.context().pages()).toHaveLength(pageCount);
+    cockpit.session.emit(status('doom-mcp-session-auth', JSON.stringify([{ name: 'agiflow-mcp', state: 'closed' }])));
+    await expect(dialog).toContainText('Disconnected from this session. Saved credentials were kept.');
+    await expect(dialog.getByRole('button', { name: 'disconnect', exact: true })).toHaveCount(0);
+    await expect(page.getByTestId('context-mcp-auth')).toContainText('closed');
+    const retryPopupPromise = page.waitForEvent('popup');
+    await dialog.getByRole('button', { name: 'reauthorize', exact: true }).click();
+    const retryPopup = await retryPopupPromise;
+    await expect.poll(() => cockpit.session.received.filter((frame) => frame.type === 'prompt')).toHaveLength(3);
+    expect(cockpit.session.received.filter((frame) => frame.type === 'prompt').at(-1)).toEqual({
+      type: 'prompt',
+      message: '/mcp auth agiflow-mcp',
+    });
+    await dialog.getByRole('button', { name: 'close', exact: true }).click();
+    await expect.poll(() => retryPopup.isClosed()).toBe(true);
+    await popup.close();
+  });
+
+  test('keeps manual authorization usable when popups and clipboard are blocked', async ({ page, cockpit }) => {
+    await page.addInitScript(() => {
+      window.open = () => null;
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {
+          writeText: async () => {
+            throw new Error('permission denied');
+          },
+        },
+      });
+    });
+    await page.goto(cockpit.url);
+    await cockpit.session.waitForAttach();
+    const authorizationUrl = 'https://auth.example.test/oauth?state=manual';
+    cockpit.session.emit(
+      status('doom-mcp-session-auth', JSON.stringify([{ name: 'agiflow-mcp', state: 'connecting', authorizationUrl }])),
+    );
+    await page.getByTestId('dock-tab-context').click();
+    await page.getByRole('button', { name: 'Authorize agiflow-mcp', exact: true }).click();
+    const dialog = page.getByTestId('mcp-authorization-dialog');
+    await expect(dialog).toContainText('browser blocked the new tab');
+    await expect(dialog.getByRole('link')).toHaveAttribute('href', authorizationUrl);
+    await dialog.getByRole('button', { name: 'copy link' }).click();
+    await expect(dialog).toContainText('copy it manually');
+    await expect(dialog.getByRole('textbox')).toHaveValue(authorizationUrl);
+    expect(cockpit.session.received.filter((frame) => frame.type === 'prompt')).toEqual([]);
   });
 });
 test('reports the estimate as an estimate', async ({ page, cockpit }) => {

--- a/packages/clients/doompi-web/tests/e2e/states.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/states.spec.ts
@@ -151,7 +151,10 @@ test('an informational notice reads as an aside, an error shouts', async ({ page
   await expect(notices.nth(1)).toHaveAttribute('data-tone', 'error');
 });
 
-test('links only safe standalone URLs in notices and preserves their lines', async ({ page, cockpit }) => {
+test('links safe URLs in notices, including normalized inline OAuth links, and preserves whitespace', async ({
+  page,
+  cockpit,
+}) => {
   await page.goto(cockpit.url);
   await cockpit.session.waitForAttach();
   await expect(page).toHaveURL(/\/session\/[^/]+$/);
@@ -159,7 +162,7 @@ test('links only safe standalone URLs in notices and preserves their lines', asy
   const message = [
     'Open this URL:',
     'https://auth.example.com/oauth?client=doom&state=a%26b',
-    'Embedded https://example.com stays plain text.',
+    'Authorize agiflow-mcp by opening: https://example.com',
     'https://user:secret@example.com/private',
     '<b>not markup</b>',
   ].join('\n');
@@ -174,13 +177,41 @@ test('links only safe standalone URLs in notices and preserves their lines', asy
   const notice = page.getByTestId('entry-notice');
   await expect(notice).toBeVisible();
   expect(await notice.locator('p').innerText()).toBe(message);
-  await expect(notice.locator('a')).toHaveCount(1);
-  await expect(notice.locator('a')).toHaveText('https://auth.example.com/oauth?client=doom&state=a%26b');
-  await expect(notice.locator('a')).toHaveAttribute('href', 'https://auth.example.com/oauth?client=doom&state=a%26b');
-  await expect(notice.locator('a')).toHaveAttribute('target', '_blank');
-  await expect(notice.locator('a')).toHaveAttribute('rel', 'noopener noreferrer');
+  await expect(notice.locator('a')).toHaveCount(2);
+  const authorizationLink = notice.locator('a').first();
+  await expect(authorizationLink).toHaveText('https://auth.example.com/oauth?client=doom&state=a%26b');
+  await expect(authorizationLink).toHaveAttribute('href', 'https://auth.example.com/oauth?client=doom&state=a%26b');
+  await expect(authorizationLink).toHaveAttribute('target', '_blank');
+  await expect(authorizationLink).toHaveAttribute('rel', 'noopener noreferrer');
+  await expect(notice.locator('a').nth(1)).toHaveAttribute('href', 'https://example.com/');
   await expect(notice.locator('b')).toHaveCount(0);
   expect(page.url()).toBe(currentUrl);
+});
+
+test('shows journaled MCP authorization feedback and its link once', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForAttach();
+  const frame = {
+    type: 'entry_appended',
+    entry: {
+      type: 'custom',
+      id: 'mcp-auth-feedback',
+      customType: 'doom-notification',
+      data: {
+        version: 1,
+        title: 'Pi',
+        subtitle: 'doompi',
+        body: 'Authorize agiflow-mcp by opening: https://auth.example.com/oauth?state=test',
+        level: 'info',
+      },
+    },
+  };
+  cockpit.session.emit(frame);
+  cockpit.session.emit(frame);
+  const notice = page.getByTestId('entry-notice');
+  await expect(notice).toHaveCount(1);
+  await expect(notice).toContainText('Authorize agiflow-mcp');
+  await expect(notice.locator('a')).toHaveAttribute('href', 'https://auth.example.com/oauth?state=test');
 });
 
 test('the activity dock stays hidden across a route change and a reload', async ({ page, cockpit }) => {

--- a/packages/clients/doompi-web/tests/unit/sessionModel.test.ts
+++ b/packages/clients/doompi-web/tests/unit/sessionModel.test.ts
@@ -61,6 +61,33 @@ describe('summariseArgs', () => {
 });
 
 describe('reduceSession', () => {
+  it.each([false, true])('shows journaled OAuth feedback once with protocol ownership %s', (transcriptFromProtocol) => {
+    const frame = {
+      type: 'entry_appended',
+      entry: {
+        type: 'custom',
+        id: 'mcp-authorization-notice',
+        customType: 'doom-notification',
+        data: {
+          version: 1,
+          title: 'Pi',
+          subtitle: 'doompi',
+          body: 'Could not authorize agiflow-mcp: Connection timeout after 30000ms',
+          level: 'warning',
+        },
+      },
+    };
+    const state = reduceSession(initialSessionState, frame, { transcriptFromProtocol });
+    expect(state.entries).toEqual([expect.objectContaining({ kind: 'notice', text: frame.entry.data.body })]);
+    expect(reduceSession(state, frame, { transcriptFromProtocol }).entries).toHaveLength(1);
+    expect(
+      reduceSession(initialSessionState, {
+        ...frame,
+        entry: { ...frame.entry, data: { ...frame.entry.data, body: '' } },
+      }).entries,
+    ).toEqual([]);
+  });
+
   it('ignores frames it does not model', () => {
     expect(reduceSession(initialSessionState, { type: 'something_new' })).toBe(initialSessionState);
   });

--- a/packages/core/doompi-extension-contracts/src/schemas/mcpStatus.ts
+++ b/packages/core/doompi-extension-contracts/src/schemas/mcpStatus.ts
@@ -51,13 +51,10 @@ export const McpStatusSnapshotSchema = Type.Object(
 export type McpStatusSnapshot = Static<typeof McpStatusSnapshotSchema>;
 
 /**
- * The current MCP picture, on request.
+ * The current MCP picture, with optional live change notifications.
  *
- * Pulled rather than pushed. Servers connect long after install and a notification
- * only reaches subscribers that were already listening, so a surface would have to
- * win a race against the provider's own startup to see the first snapshot. Asking
- * when the answer is needed removes the ordering question, and every consumer so
- * far reads this when a panel opens rather than continuously.
+ * Consumers subscribe before reading the snapshot so startup ordering cannot
+ * lose a change. Older providers remain readable through getSnapshot alone.
  *
  * No provider means MCP is not loaded for this session (`--no-mcp`), which times
  * out and is not an error.
@@ -66,6 +63,8 @@ export interface DoomMcpStatusService {
   /** Fences consumers against a replaced MCP session. */
   readonly generation: string;
   getSnapshot(): McpStatusSnapshot;
+  /** Notifies after tool registration and status updates; returns listener cleanup. */
+  onChange?(listener: () => void): () => void;
 }
 
 declare module '@deepseek-ai/cordis' {

--- a/packages/core/doompi-web-contracts/src/exports/index.ts
+++ b/packages/core/doompi-web-contracts/src/exports/index.ts
@@ -68,6 +68,7 @@ export type {
   ToolRendererContribution,
   ToolResultView,
   TransientTab,
+  WebPluginContextInventoryItem,
   WebPluginContextItem,
   WebPluginDefinition,
   WebPluginRuntime,

--- a/packages/core/doompi-web-contracts/src/services/testing/slotProps.ts
+++ b/packages/core/doompi-web-contracts/src/services/testing/slotProps.ts
@@ -55,6 +55,7 @@ export interface SlotPropsFixture {
 export interface SlotPropsOptions {
   sessionId?: string | null;
   statuses?: Readonly<Record<string, string>>;
+  contextInventory?: WebPluginSlotProps['contextInventory'];
   /** Component fills this slot owner should see; keyed by slot name. */
   slotContent?: Readonly<Record<string, ReactNode>>;
   /** Data fills this slot owner should read back, keyed by slot name. */
@@ -74,6 +75,7 @@ export function slotPropsFixture(options: SlotPropsOptions = {}): SlotPropsFixtu
   const props: WebPluginSlotProps = {
     sessionId: options.sessionId === undefined ? DEFAULT_SESSION_ID : options.sessionId,
     statuses: options.statuses ?? {},
+    contextInventory: options.contextInventory ?? [],
     openTab: (tabId) => {
       actions.push({ action: 'openTab', target: tabId });
     },

--- a/packages/core/doompi-web-contracts/src/types/webPlugin.ts
+++ b/packages/core/doompi-web-contracts/src/types/webPlugin.ts
@@ -143,6 +143,16 @@ export interface ContextAction {
   run(): void;
 }
 
+/** Compact live inventory row exposed to Context slot components. */
+export interface WebPluginContextInventoryItem {
+  name: string;
+  itemKind: 'tool' | 'skill';
+  source: 'extension' | 'mcp' | 'plugin' | 'core';
+  owner: string;
+  tokens: number | null;
+  active: boolean;
+}
+
 /** Every slot component receives the focused session; null while nothing is focused. */
 export interface WebPluginSlotProps {
   sessionId: string | null;
@@ -185,6 +195,8 @@ export interface WebPluginSlotProps {
    * own surface needs the same facts the host folds into the selection bar.
    */
   statuses: Readonly<Record<string, string>>;
+  /** Runtime inventory used by Context section owners to place their own rows. */
+  contextInventory?: readonly WebPluginContextInventoryItem[];
   /** Names of minor modes currently active in the session catalog. */
   activeMinorModes?: readonly string[];
 }

--- a/packages/core/doompi/src/extensions/entries/modeCatalog.ts
+++ b/packages/core/doompi/src/extensions/entries/modeCatalog.ts
@@ -1,3 +1,4 @@
+import { DOOM_MCP_STATUS_SERVICE, readDoomMcpStatus } from '@agimon-ai/doompi-extension-contracts/mcp-status';
 import {
   DOOM_MINOR_MODE_CATALOG_SERVICE,
   DOOM_MINOR_MODE_ENTRY_TYPE,
@@ -104,11 +105,8 @@ export async function modeCatalogExtension(pi: ExtensionAPI): Promise<void> {
       void contextBinding.publisher?.publish();
     }, BOOT_PUBLISH_DELAY_MS);
   });
-  // MCP status is pull-only and servers connect long after startup, so the
-  // boot read above cannot see them. A turn is the moment the composition is
-  // actually sent, which makes it both the freshest and the most meaningful
-  // time to price. Identical compositions are skipped, so a quiet session
-  // journals nothing extra.
+  // Turns still refresh active-tool costs, including for older pull-only MCP providers.
+  // Identical compositions are skipped rather than journaled again.
   pi.on('turn_start', () => {
     void contextBinding.publisher?.publish();
   });
@@ -119,6 +117,13 @@ export async function modeCatalogExtension(pi: ExtensionAPI): Promise<void> {
       readSessionId: () => activeCatalog.sessionId,
       writeDetail: (sessionId, revision, items) => void writeContextDetail(sessionId, revision, items),
       removeDetail: removeContextDetail,
+    });
+    cordis.inject([DOOM_MCP_STATUS_SERVICE], (mcpContext) => {
+      const publish = () => void contextBinding.publisher?.publish();
+      const unsubscribe = readDoomMcpStatus(mcpContext)?.onChange?.(publish);
+      // Subscribe first, then read: discovery may already have finished before binding.
+      publish();
+      return unsubscribe;
     });
     modeCatalogPlugin(cordis, pi, activeCatalog, () => void contextBinding.publisher?.publish());
     return () => {

--- a/packages/core/doompi/tests/extensions/modeCatalog.test.ts
+++ b/packages/core/doompi/tests/extensions/modeCatalog.test.ts
@@ -1,3 +1,5 @@
+import { DOOM_MCP_STATUS_SERVICE } from '@agimon-ai/doompi-extension-contracts/mcp-status';
+import * as contextCatalog from '../../src/services/contextCatalog.ts';
 import { connectDoomCordisHost } from '@agimon-ai/doompi-extension-contracts/cordis-host';
 import { createDoomHelpService, DOOM_HELP_SERVICE } from '@agimon-ai/doompi-extension-contracts/help';
 import { DOOM_MINOR_MODE_ENTRY_TYPE, readMinorModeCatalog } from '@agimon-ai/doompi-extension-contracts/mode';
@@ -61,6 +63,45 @@ async function setup() {
 }
 
 describe('mode catalog extension', () => {
+  it('refreshes context on late MCP changes without a turn and unsubscribes on removal', async () => {
+    const publish = vi.fn(async () => undefined);
+    const spy = vi.spyOn(contextCatalog, 'createContextPublisher').mockReturnValue({ publish, dispose: vi.fn() });
+    const { binding, connection, dispatch } = await setup();
+    try {
+      await dispatch('session_start', { reason: 'startup' });
+      const listeners = new Set<() => void>();
+      const provider = connection.root.plugin((root) => {
+        root.provide(DOOM_MCP_STATUS_SERVICE, {
+          generation: 'mcp-test',
+          getSnapshot: () => ({ servers: [] }),
+          onChange: (listener: () => void) => {
+            listeners.add(listener);
+            return () => {
+              listeners.delete(listener);
+            };
+          },
+        });
+      });
+      await provider;
+      await connection.root.fiber.await();
+      expect(listeners.size).toBe(1);
+      expect(publish).toHaveBeenCalled();
+      publish.mockClear();
+      for (const listener of listeners) listener();
+      expect(publish).toHaveBeenCalledOnce();
+      await provider.dispose();
+      expect(listeners.size).toBe(0);
+      publish.mockClear();
+      for (const listener of listeners) listener();
+      expect(publish).not.toHaveBeenCalled();
+    } finally {
+      await dispatch('session_shutdown');
+      binding.dispose();
+      await connection.dispose();
+      spy.mockRestore();
+    }
+  });
+
   it('publishes the session service without registering a Pi tool', async () => {
     const { binding, connection, dispatch, registerTool } = await setup();
     await dispatch('session_start', { reason: 'startup' });

--- a/packages/default/doompi-mcp/package.json
+++ b/packages/default/doompi-mcp/package.json
@@ -74,7 +74,7 @@
     "@agimon-ai/doompi-ui": "workspace:*",
     "@agimon-ai/doompi-web-components": "workspace:*",
     "@agimon-ai/doompi-web-contracts": "workspace:*",
-    "@agimon-ai/mcp-proxy": "0.31.19",
+    "@agimon-ai/mcp-proxy": "0.31.20",
     "@deepseek-ai/cordis": "4.0.1",
     "@modelcontextprotocol/sdk": "1.30.0",
     "@napi-rs/keyring": "1.3.0",

--- a/packages/default/doompi-mcp/src/adapters/pi/extension.ts
+++ b/packages/default/doompi-mcp/src/adapters/pi/extension.ts
@@ -144,7 +144,7 @@ function mcpPlugin(cordis: Context, { pi, mode }: McpPluginOptions): void {
       const names = servers.map((server) => server.name).join(',');
       context.ui?.setStatus(MCP_STATUS_KEY, names);
       if (context.mode !== 'tui') {
-        context.ui?.setStatus(MCP_SESSION_AUTH_STATUS_KEY, formatMcpSessionAuthStatus(servers));
+        context.ui?.setStatus(MCP_SESSION_AUTH_STATUS_KEY, formatMcpSessionAuthStatus(session.getServers()));
       }
     };
     const stopPublishing = session.onChange(publishServerStatus);
@@ -176,6 +176,7 @@ function mcpPlugin(cordis: Context, { pi, mode }: McpPluginOptions): void {
     const status: DoomMcpStatusService = Object.freeze({
       generation: `${hostSession.generation}:mcp-status`,
       getSnapshot: () => session.getSnapshot(),
+      onChange: (listener: () => void) => session.onChange(listener),
     });
     const toolResolver: DoomMcpToolResolverService = Object.freeze({
       generation: `${hostSession.generation}:mcp-tool-resolver`,

--- a/packages/default/doompi-mcp/src/adapters/pi/mcpSession.ts
+++ b/packages/default/doompi-mcp/src/adapters/pi/mcpSession.ts
@@ -37,8 +37,8 @@ export function mcpConfigurationFingerprint(configuration: McpSessionConfig): st
     pluginConfigPaths: configuration.pluginConfigPaths ?? [],
     sources: configuration.sources ?? [],
     allowlist: {
-      servers: [...(configuration.allowlist?.servers ?? [])].sort(),
-      proxy: [...(configuration.allowlist?.proxy ?? [])].sort(),
+      servers: [...(configuration.allowlist?.servers ?? [])].sort((left, right) => left.localeCompare(right)),
+      proxy: [...(configuration.allowlist?.proxy ?? [])].sort((left, right) => left.localeCompare(right)),
     },
   });
 }
@@ -87,6 +87,8 @@ export class McpSession {
   private readonly authorizationUrls = new Map<string, string>();
   /** Servers whose explicit auth action should launch the browser when its URL arrives. */
   private readonly browserAuthorizationRequests = new Set<string>();
+  /** Explicit session disconnects fence late discovery and stale tool invocations. */
+  private readonly disconnectedServers = new Set<string>();
   /** Invalidates deferred startup work when a session reloads or shuts down. */
   private lifecycleGeneration = 0;
   private configurationFingerprint: string | undefined;
@@ -156,6 +158,7 @@ export class McpSession {
   private bindConfiguration(configuration: McpSessionConfig): void {
     this.configurationFingerprint = mcpConfigurationFingerprint(configuration);
     this.groups = buildMcpConfigGroups(configuration);
+    this.disconnectedServers.clear();
     this.catalog = this.createCatalog();
     // Doom embeds the client runtime, so upstreams referenced by a proxy wrapper
     // remain individual servers in the catalog rather than collapsing into it.
@@ -192,7 +195,8 @@ export class McpSession {
   }
 
   private isToolAvailable(registeredTool: CatalogTool): boolean {
-    if (this.incompatibleNames.has(registeredTool.piName)) return false;
+    if (this.disconnectedServers.has(registeredTool.serverName) || this.incompatibleNames.has(registeredTool.piName))
+      return false;
     const current = this.catalog.findTool(registeredTool.piName);
     return (
       current !== undefined && toolRegistrationFingerprint(current) === toolRegistrationFingerprint(registeredTool)
@@ -200,7 +204,11 @@ export class McpSession {
   }
 
   private applyActiveTools(): void {
-    applyActiveTools(this.pi, this.catalog, this.historicallyOwnedNames, this.incompatibleNames);
+    const unavailable = new Set(this.incompatibleNames);
+    for (const tool of this.catalog.allTools()) {
+      if (this.disconnectedServers.has(tool.serverName)) unavailable.add(tool.piName);
+    }
+    applyActiveTools(this.pi, this.catalog, this.historicallyOwnedNames, unavailable);
   }
 
   private startDetached(): void {
@@ -220,6 +228,7 @@ export class McpSession {
    */
   async start(): Promise<void> {
     const generation = ++this.lifecycleGeneration;
+    this.disconnectedServers.clear();
     // Explicit disabled and empty Doom projections must not instantiate any
     // runtime collaborator, including the keyring-backed token store.
     if (this.configuredServerNames().length === 0) return;
@@ -255,7 +264,7 @@ export class McpSession {
    * callback; the overlay retains a clickable fallback and a retry action.
    */
   private onAuthorizationUrl(url: URL, serverName: string, generation: number): void {
-    if (generation !== this.lifecycleGeneration) return;
+    if (generation !== this.lifecycleGeneration || this.disconnectedServers.has(serverName)) return;
     this.authorizationUrls.set(serverName, url.toString());
     this.emitChange();
     const openBrowser = this.browserAuthorizationRequests.has(serverName);
@@ -278,6 +287,28 @@ export class McpSession {
     return [...new Set([...this.groups.sessionLocal.serverNames, ...this.groups.shared.serverNames])];
   }
 
+  /** Closes only this session's connection. Saved OAuth credentials are untouched. */
+  async disconnect(serverName: string): Promise<void> {
+    if (!this.configuredServerNames().includes(serverName)) throw new Error(`Unknown MCP server: ${serverName}`);
+    const clientManager = this.clientManager();
+    if (!clientManager) throw new Error(RUNTIME_NOT_STARTED);
+    const generation = this.lifecycleGeneration;
+    this.disconnectedServers.add(serverName);
+    try {
+      await clientManager.disconnectServer(serverName);
+    } catch (error) {
+      if (generation === this.lifecycleGeneration) this.disconnectedServers.delete(serverName);
+      throw error;
+    }
+    if (generation !== this.lifecycleGeneration) return;
+    this.resourceCache.delete(serverName);
+    this.authorizationUrls.delete(serverName);
+    this.browserAuthorizationRequests.delete(serverName);
+    this.catalog.applyStateChange({ serverName, state: 'closed' }, []);
+    this.applyActiveTools();
+    this.emitChange();
+  }
+
   /**
    * Reconnects one server, running its OAuth flow when it demands one.
    *
@@ -287,8 +318,10 @@ export class McpSession {
   async reauthorize(serverName: string): Promise<void> {
     const clientManager = this.clientManager();
     if (!clientManager) throw new Error(RUNTIME_NOT_STARTED);
+    this.disconnectedServers.delete(serverName);
     // What this server offers is exactly what the reconnect is about to settle.
     this.resourceCache.delete(serverName);
+    if (this.authorizationUrls.delete(serverName)) this.emitChange();
     this.browserAuthorizationRequests.add(serverName);
     try {
       await clientManager.disconnectServer(serverName);
@@ -349,6 +382,7 @@ export class McpSession {
    * the next request rather than remembered as empty.
    */
   async listResources(serverName: string, options: { refresh?: boolean } = {}): Promise<readonly McpResourceView[]> {
+    if (this.disconnectedServers.has(serverName)) throw new Error(`MCP server is disconnected: ${serverName}`);
     if (!options.refresh) {
       const cached = this.resourceCache.get(serverName);
       if (cached) return cached;
@@ -424,10 +458,12 @@ export class McpSession {
    * This handler runs detached from the connect, so awaiting it cannot deadlock.
    */
   private onServerStateChange(change: McpServerStateChange, generation: number): void {
-    if (generation !== this.lifecycleGeneration) return;
+    if (generation !== this.lifecycleGeneration || this.disconnectedServers.has(change.serverName)) return;
     // The flow this URL belonged to is over, one way or the other: a server that
     // reached a terminal state is not still waiting on a redirect.
-    if (change.state !== 'connecting') this.authorizationUrls.delete(change.serverName);
+    if (change.state !== 'connecting' && change.state !== 'needs-auth') {
+      this.authorizationUrls.delete(change.serverName);
+    }
     const runtime = this.runtime;
     const services = runtime?.getServices();
     const tools =
@@ -437,7 +473,12 @@ export class McpSession {
     void tools
       .catch(() => [])
       .then((tools) => {
-        if (generation !== this.lifecycleGeneration || !runtime?.isCurrent(services)) return;
+        if (
+          generation !== this.lifecycleGeneration ||
+          !runtime?.isCurrent(services) ||
+          this.disconnectedServers.has(change.serverName)
+        )
+          return;
         const added = this.catalog.applyStateChange(change, tools);
         this.registerTools(added);
         this.applyActiveTools();

--- a/packages/default/doompi-mcp/src/commands/mcpCommand.ts
+++ b/packages/default/doompi-mcp/src/commands/mcpCommand.ts
@@ -10,7 +10,7 @@ const COMMAND_DESCRIPTION = 'Browse this session MCP servers: authorize, enable,
 const INFO = 'info';
 const WARNING = 'warning';
 
-const SUBCOMMAND = { status: 'status', auth: 'auth', reload: 'reload' } as const;
+const SUBCOMMAND = { status: 'status', auth: 'auth', disconnect: 'disconnect', reload: 'reload' } as const;
 const SUBCOMMANDS = Object.values(SUBCOMMAND).join(', ');
 
 /** `/mcp <subcommand> [argument]`, with the bare command showing status. */
@@ -63,6 +63,22 @@ export function registerCommand(pi: ExtensionAPI, session: McpCommandTarget, dep
       const { subcommand, argument } = parseArguments(raw);
       if (subcommand === SUBCOMMAND.auth) {
         await runAuth(session, argument, ctx);
+        return;
+      }
+      if (subcommand === SUBCOMMAND.disconnect) {
+        if (!argument) {
+          ctx.ui.notify('Name the server to disconnect, for example /mcp disconnect boomlink.', WARNING);
+          return;
+        }
+        try {
+          await session.disconnect(argument);
+          ctx.ui.notify(`${argument} is disconnected from this session. Saved credentials were kept.`, INFO);
+        } catch (error) {
+          ctx.ui.notify(
+            `Could not disconnect ${argument}: ${error instanceof Error ? error.message : 'unknown error'}`,
+            WARNING,
+          );
+        }
         return;
       }
       if (subcommand === SUBCOMMAND.reload) {

--- a/packages/default/doompi-mcp/src/types/mcp.ts
+++ b/packages/default/doompi-mcp/src/types/mcp.ts
@@ -11,6 +11,8 @@ export interface McpCommandTarget {
   getDiagnostics(): readonly string[];
   /** Reconnects a server, running its OAuth flow when it demands one. */
   reauthorize(serverName: string): Promise<void>;
+  /** Closes this session's connection without deleting saved credentials. */
+  disconnect(serverName: string): Promise<void>;
   /** Rebuilds the runtime and reconnects everything. */
   start(): Promise<void>;
 }

--- a/packages/default/doompi-mcp/src/types/webMcp.ts
+++ b/packages/default/doompi-mcp/src/types/webMcp.ts
@@ -22,23 +22,48 @@ export const MCP_SESSION_AUTH_STATUS_KEY = 'doom-mcp-session-auth';
 
 const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, 'gu');
 const MAX_SESSION_AUTH_SERVERS = 128;
+const MAX_AUTHORIZATION_URL_LENGTH = 8192;
+const SESSION_AUTH_STATES = [
+  'not-connected',
+  'connecting',
+  'connected',
+  'degraded',
+  'needs-auth',
+  'failed',
+  'closed',
+  'disabled',
+] as const;
+export type McpSessionAuthState = (typeof SESSION_AUTH_STATES)[number];
+
+function isSessionAuthState(value: unknown): value is McpSessionAuthState {
+  return SESSION_AUTH_STATES.some((state) => state === value);
+}
 
 export interface McpSessionAuthStatusItem {
   readonly name: string;
-  readonly state: 'needs-auth';
+  readonly state: McpSessionAuthState;
+  readonly authorizationUrl?: string;
 }
 
 interface McpSessionServerStatusSource {
   readonly name: string;
   readonly state: string;
-  readonly [key: string]: unknown;
+  readonly authorizationUrl?: unknown;
 }
 
-/** Projects only the browser's compact authorization needs, excluding runtime diagnostics and credentials. */
-export function formatMcpSessionAuthStatus(servers: readonly McpSessionServerStatusSource[]): string | undefined {
-  const items: McpSessionAuthStatusItem[] = servers
-    .filter((server) => server.state === 'needs-auth')
-    .map((server) => ({ name: server.name, state: 'needs-auth' }));
+/** Keeps servers visible before discovery and after failures, without diagnostics or credentials. */
+export function formatMcpSessionAuthStatus<T extends McpSessionServerStatusSource>(
+  servers: readonly T[],
+): string | undefined {
+  const items: McpSessionAuthStatusItem[] = servers.flatMap((server) => {
+    if (!isSessionAuthState(server.state)) return [];
+    const item: McpSessionAuthStatusItem = {
+      name: server.name,
+      state: server.state,
+      ...(isAuthorizationUrl(server.authorizationUrl) ? { authorizationUrl: server.authorizationUrl } : {}),
+    };
+    return [item];
+  });
   return items.length === 0 ? undefined : JSON.stringify(items);
 }
 
@@ -63,20 +88,33 @@ export function parseMcpSessionAuthStatus(raw: string | undefined): McpSessionAu
 function hasControlCharacter(value: string): boolean {
   for (const character of value) {
     const codePoint = character.codePointAt(0);
-    if (codePoint !== undefined && (codePoint < 32 || codePoint === 127)) return true;
+    if (codePoint !== undefined && (codePoint < 32 || (codePoint >= 127 && codePoint <= 159))) return true;
   }
   return false;
+}
+
+function isAuthorizationUrl(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length > MAX_AUTHORIZATION_URL_LENGTH || hasControlCharacter(value)) {
+    return false;
+  }
+  try {
+    const url = new URL(value);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && url.username === '' && url.password === '';
+  } catch {
+    return false;
+  }
 }
 
 function isSessionAuthStatusItem(value: unknown): value is McpSessionAuthStatusItem {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const record = value as Record<string, unknown>;
   return (
-    Object.keys(record).length === 2 &&
+    Object.keys(record).every((key) => key === 'name' || key === 'state' || key === 'authorizationUrl') &&
+    (!('authorizationUrl' in record) || isAuthorizationUrl(record.authorizationUrl)) &&
     typeof record.name === 'string' &&
     record.name.trim() !== '' &&
     !hasControlCharacter(record.name) &&
-    record.state === 'needs-auth'
+    isSessionAuthState(record.state)
   );
 }
 

--- a/packages/default/doompi-mcp/src/web/McpSessionAuthSection.tsx
+++ b/packages/default/doompi-mcp/src/web/McpSessionAuthSection.tsx
@@ -1,8 +1,19 @@
-import { Button } from '@agimon-ai/doompi-web-components';
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+} from '@agimon-ai/doompi-web-components';
 import type { SessionFrameSender, WebPluginSlotProps } from '@agimon-ai/doompi-web-contracts';
+import { useEffect, useRef, useState } from 'react';
 import { MCP_SESSION_AUTH_STATUS_KEY, parseMcpSessionAuthStatus } from '../types/webMcp.ts';
 
-/** Requests authorization through Pi's command frame, never through a browser shell or URL opener. */
+/** Requests authorization through Pi's command frame, never through a shell. */
 export function requestMcpSessionAuthorization(
   sendSessionFrame: SessionFrameSender,
   sessionId: string,
@@ -11,39 +22,247 @@ export function requestMcpSessionAuthorization(
   sendSessionFrame(sessionId, { type: 'prompt', message: `/mcp auth ${serverName}` });
 }
 
-/** Live MCP servers waiting for authorization in the focused session. */
-export function McpSessionAuthSection({ sessionId, statuses, sendSessionFrame }: WebPluginSlotProps) {
-  const servers = parseMcpSessionAuthStatus(statuses[MCP_SESSION_AUTH_STATUS_KEY]);
-  if (!servers) return null;
+function tokenEstimate(value: number | null): string {
+  return value === null ? '—' : `~${value.toLocaleString()}`;
+}
+
+/** Keep configured servers actionable even before they have discovered any tools. */
+export function McpSessionAuthSection({
+  sessionId,
+  statuses,
+  sendSessionFrame,
+  contextInventory = [],
+}: WebPluginSlotProps) {
+  const servers = parseMcpSessionAuthStatus(statuses[MCP_SESSION_AUTH_STATUS_KEY]) ?? [];
+  const [target, setTarget] = useState<{ sessionId: string; name: string } | null>(null);
+  const [copyFeedback, setCopyFeedback] = useState('');
+  const [popupBlocked, setPopupBlocked] = useState(false);
+  // Only retain a tab while it is our blank placeholder. Never close the provider's page.
+  const pendingTab = useRef<Window | null>(null);
+  const selected = target?.sessionId === sessionId ? target : null;
+  const server = servers.find((item) => item.name === selected?.name);
+  const authorizationUrl = server?.authorizationUrl;
+
+  const closePendingTab = () => {
+    pendingTab.current?.close();
+    pendingTab.current = null;
+  };
+
+  useEffect(() => {
+    const tab = pendingTab.current;
+    if (!selected || !authorizationUrl || !tab || tab.closed) return;
+    tab.location.replace(authorizationUrl);
+    pendingTab.current = null;
+  }, [selected, authorizationUrl]);
+
+  useEffect(
+    () => () => {
+      pendingTab.current?.close();
+      pendingTab.current = null;
+    },
+    [sessionId],
+  );
+
+  const authorize = (name: string) => {
+    if (sessionId === null) return;
+    const current = servers.find((item) => item.name === name);
+    closePendingTab();
+    setTarget({ sessionId, name });
+    setCopyFeedback('');
+    // Reserve the tab during the click. Opening it after asynchronous discovery is blocked by browsers.
+    const tab = window.open('about:blank', '_blank');
+    setPopupBlocked(tab === null);
+    if (tab) {
+      tab.opener = null;
+      if (current?.authorizationUrl) {
+        tab.location.replace(current.authorizationUrl);
+      } else {
+        tab.document.title = 'MCP authorization';
+        tab.document.body.textContent = 'Preparing authorization. Return to DoomPi for progress or manual sign-in.';
+        pendingTab.current = tab;
+      }
+    }
+    if (!current?.authorizationUrl && current?.state !== 'connecting') {
+      requestMcpSessionAuthorization(sendSessionFrame, sessionId, name);
+    }
+  };
+
+  const copyLink = async () => {
+    if (!authorizationUrl) return;
+    try {
+      await navigator.clipboard.writeText(authorizationUrl);
+      setCopyFeedback('Link copied.');
+    } catch {
+      setCopyFeedback('Clipboard unavailable. Select the link above and copy it manually.');
+    }
+  };
 
   return (
-    <section data-testid="context-mcp-auth" className="flex flex-col gap-2 border-b border-doom-border px-3 py-3">
-      <div className="flex flex-col gap-0.5">
-        <p className="text-[9px] font-bold uppercase tracking-wide text-doom-faint">MCP authorization</p>
-        <p className="text-[9px] leading-relaxed text-doom-muted">
-          Authorization links appear in the session transcript.
-        </p>
-      </div>
-      <ul aria-label="MCP servers needing authorization" className="flex flex-col gap-1">
-        {servers.map((server) => (
-          <li key={server.name} className="flex min-w-0 items-center gap-2 px-1 py-0.5">
-            <span className="min-w-0 flex-1 truncate text-[10px] text-doom-hi">{server.name}</span>
+    <>
+      {servers.length === 0 ? null : (
+        <section data-testid="context-mcp-auth" className="flex flex-col gap-2 border-b border-doom-border px-3 py-3">
+          <div className="flex flex-col gap-0.5">
+            <p className="text-[9px] font-bold uppercase tracking-wide text-doom-faint">MCP servers</p>
+            <p className="text-[9px] leading-relaxed text-doom-muted">
+              Open sign-in in a new tab, or copy the link from the authorization dialog.
+            </p>
+          </div>
+          <ul aria-label="MCP servers" className="flex flex-col gap-2">
+            {servers.map((item) => {
+              const tools = contextInventory.filter(
+                (inventoryItem) => inventoryItem.source === 'mcp' && inventoryItem.owner === item.name,
+              );
+              return (
+                <li key={item.name} className="flex min-w-0 flex-col gap-1 px-1 py-0.5">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="min-w-0 flex-1 truncate text-[10px] text-doom-hi">{item.name}</span>
+                    <span className="text-[9px] text-doom-muted">{item.state.replace(/-/g, ' ')}</span>
+                    <Button
+                      variant="subtle"
+                      size="xs"
+                      data-testid={`context-mcp-auth-${item.name}`}
+                      aria-label={`${item.state === 'connected' ? 'Manage' : 'Authorize'} ${item.name}`}
+                      disabled={sessionId === null || item.state === 'disabled'}
+                      onClick={() => {
+                        if (item.state !== 'connected') {
+                          authorize(item.name);
+                        } else if (sessionId !== null) {
+                          closePendingTab();
+                          setCopyFeedback('');
+                          setPopupBlocked(false);
+                          setTarget({ sessionId, name: item.name });
+                        }
+                      }}
+                      className="shrink-0 text-[8px] font-bold"
+                    >
+                      {item.state === 'connected' ? 'manage' : 'authorize'}
+                    </Button>
+                  </div>
+                  {tools.length === 0 ? (
+                    <p className="pl-3 text-[9px] text-doom-faint">no tools reported</p>
+                  ) : (
+                    <ul aria-label={`${item.name} tools`} className="flex flex-col">
+                      {tools.map((tool) => (
+                        <li key={tool.name} className="flex min-w-0 items-center gap-2 py-px pl-3">
+                          <span
+                            className={`min-w-0 flex-1 truncate text-[9px] ${tool.active ? 'text-doom-muted' : 'text-doom-faint'}`}
+                          >
+                            {tool.name}
+                          </span>
+                          <span className="w-14 shrink-0 text-right text-[9px] text-doom-faint">
+                            {tool.active ? tokenEstimate(tool.tokens) : `(${tokenEstimate(tool.tokens)})`}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+      <Dialog
+        open={selected !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            closePendingTab();
+            setTarget(null);
+          }
+        }}
+      >
+        <DialogContent data-testid="mcp-authorization-dialog">
+          <DialogHeader className="items-start px-4 py-4 sm:px-5">
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <DialogTitle className="break-words text-[14px] leading-snug">
+                {server?.state === 'connected' ? 'Manage' : 'Authorize'} {selected?.name}
+              </DialogTitle>
+              <DialogDescription className="max-w-2xl">
+                {server?.state === 'connected'
+                  ? 'Disconnect this session without deleting saved credentials, or reauthorize to sign in again.'
+                  : "Complete sign-in in the provider's tab. You can also open or copy the link below."}
+              </DialogDescription>
+            </div>
+          </DialogHeader>
+          <DialogBody className="px-4 py-4 sm:px-5 sm:py-5">
+            <p role="status" className="text-[11px] text-doom-muted">
+              {server?.state === 'connected'
+                ? 'Authorization complete. This server is connected.'
+                : server?.state === 'closed'
+                  ? 'Disconnected from this session. Saved credentials were kept.'
+                  : authorizationUrl
+                    ? 'Waiting for you to complete authorization.'
+                    : server?.state === 'failed'
+                      ? 'Connection failed. Retry authorization; details are in the session transcript.'
+                      : server
+                        ? 'Preparing the authorization link...'
+                        : 'This server is no longer available in the session.'}
+            </p>
+            {popupBlocked ? (
+              <p className="text-[10px] text-doom-muted">
+                The browser blocked the new tab. Open the link below when it is ready.
+              </p>
+            ) : null}
+            {authorizationUrl ? (
+              <div className="flex flex-col gap-2">
+                <Input
+                  aria-label="OAuth authorization URL"
+                  readOnly
+                  value={authorizationUrl}
+                  onFocus={(event) => event.currentTarget.select()}
+                />
+                <a
+                  href={authorizationUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[11px] text-doom-accent underline underline-offset-2"
+                >
+                  open authorization page
+                </a>
+                <Button variant="outline" size="xs" onClick={() => void copyLink()}>
+                  copy link
+                </Button>
+              </div>
+            ) : null}
+            {copyFeedback ? (
+              <p role="status" className="text-[10px] text-doom-muted">
+                {copyFeedback}
+              </p>
+            ) : null}
+          </DialogBody>
+          <DialogFooter className="flex-wrap justify-end border-t border-doom-border-soft px-4 py-3 sm:px-5">
+            {server?.state === 'connected' && selected ? (
+              <Button
+                variant="outline"
+                size="md"
+                onClick={() => {
+                  closePendingTab();
+                  setCopyFeedback('');
+                  setPopupBlocked(false);
+                  sendSessionFrame(selected.sessionId, { type: 'prompt', message: `/mcp disconnect ${selected.name}` });
+                }}
+              >
+                disconnect
+              </Button>
+            ) : null}
+            {(server?.state === 'failed' || server?.state === 'connected' || server?.state === 'closed') && selected ? (
+              <Button size="md" onClick={() => authorize(selected.name)}>
+                {server.state === 'failed' ? 'retry authorization' : 'reauthorize'}
+              </Button>
+            ) : null}
             <Button
-              variant="subtle"
-              size="xs"
-              data-testid={`context-mcp-auth-${server.name}`}
-              aria-label={`Authorize ${server.name}`}
-              disabled={sessionId === null}
+              variant="ghost"
+              size="md"
               onClick={() => {
-                if (sessionId !== null) requestMcpSessionAuthorization(sendSessionFrame, sessionId, server.name);
+                closePendingTab();
+                setTarget(null);
               }}
-              className="shrink-0 text-[8px] font-bold"
             >
-              authorize
+              close
             </Button>
-          </li>
-        ))}
-      </ul>
-    </section>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/packages/default/doompi-mcp/tests/extension.test.ts
+++ b/packages/default/doompi-mcp/tests/extension.test.ts
@@ -465,6 +465,27 @@ describe('doom mcp extension', () => {
     expect(createProxyContainer).not.toHaveBeenCalled();
   });
 
+  it('disconnects through the command and reports closed status without clearing credentials', async () => {
+    const extension = registerExtension();
+    await extension.startSession();
+    await vi.waitFor(() => expect(createProxyContainer).toHaveBeenCalledOnce());
+    await extension.runCommand('disconnect pencil', false);
+    expect(disconnectServer).toHaveBeenCalledWith('pencil');
+    expect(setStatus).toHaveBeenCalledWith(
+      'doom-mcp-session-auth',
+      JSON.stringify([{ name: 'pencil', state: 'closed' }]),
+    );
+  });
+
+  it('does not disconnect an unnamed or unknown server', async () => {
+    const extension = registerExtension();
+    await extension.startSession();
+    await vi.waitFor(() => expect(createProxyContainer).toHaveBeenCalledOnce());
+    await extension.runCommand('disconnect', false);
+    await extension.runCommand('disconnect missing', false);
+    expect(disconnectServer).not.toHaveBeenCalled();
+  });
+
   // Reported before anything has connected, so the panel is never blank while the
   // session is still dialling out.
   it('publishes configured servers through the session status service', async () => {
@@ -481,6 +502,42 @@ describe('doom mcp extension', () => {
     });
   });
 
+  it('notifies status subscribers after changes and supports unsubscribe', async () => {
+    ensureConnected.mockResolvedValue({
+      listTools: async () => [{ name: 'get_screenshot', inputSchema: { type: 'object' } }],
+    });
+    const extension = registerExtension({
+      host: { service: projectionService(nativeProjection(path.join(repoRoot, '.mcp.json'))) },
+    });
+    await extension.startSession();
+    await vi.waitFor(() => expect(createProxyContainer).toHaveBeenCalledOnce());
+    const root = extension.hostRoot();
+    if (!root) throw new Error('Expected a composed Cordis test host.');
+    const status = readDoomMcpStatus(root);
+    const snapshots: unknown[] = [];
+    const unsubscribe = status?.onChange?.(() =>
+      snapshots.push({
+        status: status.getSnapshot(),
+        registered: [...extension.registeredTools],
+      }),
+    );
+    expect(unsubscribe).toBeTypeOf('function');
+    emitServerState?.({ serverName: 'pencil', state: 'connected' });
+    await vi.waitFor(() =>
+      expect(snapshots.at(-1)).toEqual({
+        status: {
+          servers: [expect.objectContaining({ name: 'pencil', state: 'connected', tools: ['pencil_get_screenshot'] })],
+        },
+        registered: ['pencil_get_screenshot'],
+      }),
+    );
+    unsubscribe?.();
+    const count = snapshots.length;
+    emitServerState?.({ serverName: 'pencil', state: 'failed' });
+    await vi.waitFor(() => expect(status?.getSnapshot().servers[0]?.state).toBe('failed'));
+    expect(snapshots).toHaveLength(count);
+  });
+
   // The cockpit recognises `<server>_<tool>` calls by these names, and a
   // browser session never sees the catalog any other way.
   it('publishes the server names as the doom-mcp footer status and clears it on shutdown', async () => {
@@ -494,7 +551,7 @@ describe('doom mcp extension', () => {
     expect(setStatus).toHaveBeenCalledWith('doom-mcp', undefined);
   });
 
-  it('publishes only compact needs-auth rows and clears that browser status on shutdown', async () => {
+  it('publishes live authorization URLs and connected completion, then clears on shutdown', async () => {
     const extension = registerExtension();
     await extension.startSession();
     await vi.waitFor(() => expect(createProxyContainer).toHaveBeenCalledOnce());
@@ -508,9 +565,28 @@ describe('doom mcp extension', () => {
     const authPayload = JSON.stringify([{ name: 'pencil', state: 'needs-auth' }]);
     await vi.waitFor(() => expect(setStatus).toHaveBeenCalledWith('doom-mcp-session-auth', authPayload));
     expect(setStatus.mock.calls.flatMap((call) => call.slice(1)).join('\n')).not.toContain('private');
+    const authorizationUrl = new URL('https://auth.example.test/authorize?state=waiting');
+    const onAuthorizationUrl = createProxyContainer.mock.calls[0]?.[0]?.auth?.onAuthorizationUrl;
+    await onAuthorizationUrl(authorizationUrl, 'pencil');
+    expect(setStatus).toHaveBeenLastCalledWith(
+      'doom-mcp-session-auth',
+      JSON.stringify([{ name: 'pencil', state: 'needs-auth', authorizationUrl: authorizationUrl.toString() }]),
+    );
 
+    emitServerState?.({ serverName: 'pencil', state: 'failed' });
+    await vi.waitFor(() =>
+      expect(setStatus).toHaveBeenLastCalledWith(
+        'doom-mcp-session-auth',
+        JSON.stringify([{ name: 'pencil', state: 'failed' }]),
+      ),
+    );
     emitServerState?.({ serverName: 'pencil', state: 'connected' });
-    await vi.waitFor(() => expect(setStatus).toHaveBeenCalledWith('doom-mcp-session-auth', undefined));
+    await vi.waitFor(() =>
+      expect(setStatus).toHaveBeenLastCalledWith(
+        'doom-mcp-session-auth',
+        JSON.stringify([{ name: 'pencil', state: 'connected' }]),
+      ),
+    );
 
     await extension.shutdownSession();
     expect(setStatus).toHaveBeenLastCalledWith('doom-mcp-session-auth', undefined);

--- a/packages/default/doompi-mcp/tests/mcpOverlay.test.ts
+++ b/packages/default/doompi-mcp/tests/mcpOverlay.test.ts
@@ -28,6 +28,7 @@ function createOverlay(servers: readonly McpServerView[] = [server()]) {
     getSnapshot: vi.fn(() => ({ servers: [] })),
     getDiagnostics: vi.fn(() => []),
     reauthorize: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
     openAuthorizationPage: vi.fn().mockResolvedValue(undefined),
     start: vi.fn().mockResolvedValue(undefined),
     getServers: vi.fn(() => current),

--- a/packages/default/doompi-mcp/tests/mcpSession.test.ts
+++ b/packages/default/doompi-mcp/tests/mcpSession.test.ts
@@ -169,6 +169,68 @@ describe('McpSession', () => {
     );
   });
 
+  describe('session-only disconnect', () => {
+    it('closes the connection, deactivates tools, keeps credentials and allows reauthorization', async () => {
+      const { pi, activeTools, definitions } = fakePi();
+      const active = session(pi);
+      active.install();
+      await active.start();
+      emitState({ serverName: 'pencil', state: 'connected' });
+      await vi.waitFor(() => expect(activeTools()).toContain('pencil_get_screenshot'));
+      await active.disconnect('pencil');
+      expect(disconnectServer).toHaveBeenCalledWith('pencil');
+      expect(active.getSnapshot().servers[0]?.state).toBe('closed');
+      expect(activeTools()).toEqual(['read']);
+      const store = createProxyContainer.mock.calls[0]?.[0]?.auth.tokenStore;
+      expect(store.clear).not.toHaveBeenCalled();
+      expect(store.write).not.toHaveBeenCalled();
+      ensureConnected.mockClear();
+      await expect(active.listResources('pencil')).rejects.toThrow('disconnected');
+      await expect(definitions.get('pencil_get_screenshot')?.execute?.('stale-call', {})).rejects.toThrow(
+        'not available',
+      );
+      expect(ensureConnected).not.toHaveBeenCalled();
+      await active.reauthorize('pencil');
+      emitState({ serverName: 'pencil', state: 'connected' });
+      await vi.waitFor(() => expect(activeTools()).toContain('pencil_get_screenshot'));
+    });
+
+    it('ignores late tool discovery and connection events after disconnect', async () => {
+      const { pi, activeTools } = fakePi();
+      const active = session(pi);
+      active.install();
+      await active.start();
+      let finishDiscovery: (tools: never[]) => void = () => undefined;
+      const discovery = new Promise<never[]>((resolve) => {
+        finishDiscovery = resolve;
+      });
+      listTools.mockReturnValue(discovery);
+      emitState({ serverName: 'pencil', state: 'connected' });
+      await vi.waitFor(() => expect(listTools).toHaveBeenCalledOnce());
+      await active.disconnect('pencil');
+      finishDiscovery([]);
+      await discovery;
+      await Promise.resolve();
+      emitState({ serverName: 'pencil', state: 'connected' });
+      expect(active.getSnapshot().servers[0]?.state).toBe('closed');
+      expect(activeTools()).toEqual(['read']);
+      expect(listTools).toHaveBeenCalledOnce();
+    });
+
+    it('reports disconnect failures without marking the server closed', async () => {
+      const { pi } = fakePi();
+      const active = session(pi);
+      active.install();
+      await expect(active.disconnect('missing')).rejects.toThrow('Unknown MCP server');
+      await expect(active.disconnect('pencil')).rejects.toThrow();
+      await active.start();
+      disconnectServer.mockRejectedValueOnce(new Error('close failed'));
+      await expect(active.disconnect('pencil')).rejects.toThrow('close failed');
+      emitState({ serverName: 'pencil', state: 'connected' });
+      await vi.waitFor(() => expect(active.getSnapshot().servers[0]?.state).toBe('connected'));
+    });
+  });
+
   describe('folding in a server as it connects', () => {
     it('registers and activates its tools', async () => {
       const { pi, registered, activeTools } = fakePi();
@@ -344,6 +406,46 @@ describe('McpSession', () => {
       expect(disconnectServer).toHaveBeenCalledWith('boomlink');
       expect(ensureConnected).toHaveBeenCalledWith('boomlink');
     });
+
+    it('clears the previous URL before retry even when disconnect rejects without a state event', async () => {
+      const active = session(fakePi().pi);
+      active.install();
+      await active.start();
+      const authorize = createProxyContainer.mock.calls[0]?.[0]?.auth?.onAuthorizationUrl;
+      authorize(new URL('https://auth.example.test/old'), 'pencil');
+      const listener = vi.fn();
+      active.onChange(listener);
+      disconnectServer.mockImplementation(async () => {
+        expect(active.getServers()[0].authorizationUrl).toBeUndefined();
+        throw new Error('disconnect failed');
+      });
+      await expect(active.reauthorize('pencil')).rejects.toThrow('disconnect failed');
+      expect(listener).toHaveBeenCalledOnce();
+    });
+
+    it.each(['connected', 'failed', 'closed', 'degraded'] as const)(
+      'retains URLs while needs-auth is waiting and clears them on %s',
+      async (state) => {
+        const hostCallback = vi.fn().mockRejectedValue(new Error('browser unavailable'));
+        const active = new McpSession({
+          pi: fakePi().pi,
+          onAuthorizationUrl: hostCallback,
+          tokenStore: { read: vi.fn(), write: vi.fn(), clear: vi.fn() },
+        });
+        active.install(configuration());
+        await active.start();
+        const authorize = createProxyContainer.mock.calls[0]?.[0]?.auth?.onAuthorizationUrl;
+        const url = new URL('https://auth.example.test/waiting');
+        authorize(url, 'pencil');
+        emitState({ serverName: 'pencil', state: 'needs-auth' });
+        await vi.waitFor(() => expect(active.getServers()[0].state).toBe('needs-auth'));
+        await vi.waitFor(() => expect(active.getDiagnostics().join()).toContain('browser unavailable'));
+        expect(active.getServers()[0].authorizationUrl).toBe(url.toString());
+        emitState({ serverName: 'pencil', state });
+        await vi.waitFor(() => expect(active.getServers()[0].state).toBe(state));
+        expect(active.getServers()[0].authorizationUrl).toBeUndefined();
+      },
+    );
 
     it('says so when the runtime has not started', async () => {
       const { pi } = fakePi();

--- a/packages/default/doompi-mcp/tests/repositoryConfig.test.ts
+++ b/packages/default/doompi-mcp/tests/repositoryConfig.test.ts
@@ -20,7 +20,7 @@ describe('package MCP configuration', () => {
       ...manifest.peerDependencies,
     };
 
-    expect(dependencies).toHaveProperty('@agimon-ai/mcp-proxy', '0.31.19');
+    expect(dependencies).toHaveProperty('@agimon-ai/mcp-proxy', '0.31.20');
     expect(dependencies).not.toHaveProperty('@agiflowai/architect-mcp');
     expect(dependencies).not.toHaveProperty('@agimon-ai/vibe-lint');
   });

--- a/packages/default/doompi-mcp/tests/web/mcpSessionAuth.test.ts
+++ b/packages/default/doompi-mcp/tests/web/mcpSessionAuth.test.ts
@@ -8,16 +8,54 @@ import {
 import { McpSessionAuthSection, requestMcpSessionAuthorization } from '../../src/web/McpSessionAuthSection.tsx';
 
 describe('MCP live-session authorization status', () => {
-  it('serializes only server names that need authorization', () => {
+  it('serializes connected completion and safe authorization URLs without diagnostics', () => {
+    const authorizationUrl = 'https://auth.example.test/authorize?state=waiting';
     const status = formatMcpSessionAuthStatus([
       { name: 'ready', state: 'connected', error: 'not part of the wire contract' },
-      { name: 'github', state: 'needs-auth', error: 'token=secret' },
+      { name: 'github', state: 'needs-auth', authorizationUrl, error: 'token=secret' },
     ]);
 
-    expect(status).toBe(JSON.stringify([{ name: 'github', state: 'needs-auth' }]));
+    expect(parseMcpSessionAuthStatus(status)).toEqual([
+      { name: 'ready', state: 'connected' },
+      { name: 'github', state: 'needs-auth', authorizationUrl },
+    ]);
     expect(status).not.toContain('secret');
-    expect(status).not.toContain('ready');
-    expect(formatMcpSessionAuthStatus([{ name: 'ready', state: 'connected' }])).toBeUndefined();
+    expect(formatMcpSessionAuthStatus([])).toBeUndefined();
+  });
+
+  it.each([
+    'javascript:alert(1)',
+    'file:///tmp/secret',
+    'https://user:password@auth.example.test/',
+    'https://user@auth.example.test/',
+    'https://auth.example.test/\nredirect',
+    `https://auth.example.test/${String.fromCharCode(127)}`,
+    `https://auth.example.test/${'a'.repeat(8192)}`,
+    '/relative',
+    123,
+    null,
+  ])('rejects unsafe authorization URL %s', (authorizationUrl) => {
+    const row = { name: 'github', state: 'needs-auth', authorizationUrl };
+    expect(parseMcpSessionAuthStatus(JSON.stringify([row]))).toBeUndefined();
+    expect(parseMcpSessionAuthStatus(formatMcpSessionAuthStatus([row]))).toEqual([
+      { name: 'github', state: 'needs-auth' },
+    ]);
+  });
+
+  it('accepts HTTP callback authorization pages', () => {
+    const rows = [{ name: 'local', state: 'connecting', authorizationUrl: 'http://localhost:8080/authorize' }];
+    expect(parseMcpSessionAuthStatus(formatMcpSessionAuthStatus(rows))).toEqual(rows);
+  });
+
+  it('keeps undiscovered and failed servers visible without exposing diagnostics', () => {
+    const servers = [
+      { name: 'agiflow-mcp', state: 'not-connected', tools: [] },
+      { name: 'boomlink-mcp', state: 'failed', tools: [], error: 'token=secret' },
+      { name: 'pending', state: 'connecting', tools: [] },
+    ];
+    const status = formatMcpSessionAuthStatus(servers);
+    expect(parseMcpSessionAuthStatus(status)).toEqual(servers.map(({ name, state }) => ({ name, state })));
+    expect(status).not.toContain('secret');
   });
 
   it('treats absent and browser-cleared statuses as absent and rejects malformed rows', () => {
@@ -25,7 +63,7 @@ describe('MCP live-session authorization status', () => {
     expect(parseMcpSessionAuthStatus('')).toBeUndefined();
     expect(parseMcpSessionAuthStatus('   ')).toBeUndefined();
     expect(parseMcpSessionAuthStatus('not json')).toBeUndefined();
-    expect(parseMcpSessionAuthStatus(JSON.stringify([{ name: 'github', state: 'connected' }]))).toBeUndefined();
+    expect(parseMcpSessionAuthStatus(JSON.stringify([{ name: 'github', state: 'unknown' }]))).toBeUndefined();
     expect(
       parseMcpSessionAuthStatus(JSON.stringify([{ name: 'github', state: 'needs-auth', error: 'secret' }])),
     ).toBeUndefined();
@@ -43,6 +81,24 @@ describe('MCP live-session authorization status', () => {
         JSON.stringify(Array.from({ length: 129 }, (_, index) => ({ name: `server-${index}`, state: 'needs-auth' }))),
       ),
     ).toBeUndefined();
+  });
+
+  it.each([{}, [], [null], [42], [[]], [{ state: 'connected' }], [{ name: ' ', state: 'connected' }]])(
+    'rejects malformed connected-server status %j',
+    (value) => {
+      expect(parseMcpSessionAuthStatus(JSON.stringify(value))).toBeUndefined();
+    },
+  );
+
+  it('retains connected servers when an unrecognized runtime state is omitted', () => {
+    expect(
+      parseMcpSessionAuthStatus(
+        formatMcpSessionAuthStatus([
+          { name: 'ready', state: 'connected' },
+          { name: 'unsupported', state: 'unknown' },
+        ]),
+      ),
+    ).toEqual([{ name: 'ready', state: 'connected' }]);
   });
 
   it('accepts terminal ANSI decoration around a valid status', () => {
@@ -67,12 +123,78 @@ describe('MCP session authorization Context section', () => {
     );
 
     expect(rendered.error).toBeUndefined();
-    expect(rendered.includes('MCP authorization')).toBe(true);
-    expect(rendered.includes('Authorization links appear in the session transcript.')).toBe(true);
+    expect(rendered.includes('MCP servers')).toBe(true);
+    expect(rendered.includes('copy the link from the authorization dialog')).toBe(true);
     expect(rendered.includes('github')).toBe(true);
     expect(rendered.includes('linear')).toBe(true);
     expect(rendered.html.match(/>authorize<\/button>/gu)).toHaveLength(2);
     expect(rendered.html).toContain('aria-label="Authorize github"');
+  });
+
+  it('offers authorization before discovery and after a failed connection', () => {
+    const status = formatMcpSessionAuthStatus([
+      { name: 'agiflow-mcp', state: 'not-connected', tools: [] },
+      { name: 'boomlink-mcp', state: 'failed', tools: [] },
+    ]);
+    const rendered = renderPlugin(
+      McpSessionAuthSection,
+      slotPropsFixture({ statuses: { [MCP_SESSION_AUTH_STATUS_KEY]: status! } }).props,
+    );
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.html).toContain('aria-label="Authorize agiflow-mcp"');
+    expect(rendered.html).toContain('aria-label="Authorize boomlink-mcp"');
+    expect(rendered.includes('not connected')).toBe(true);
+    expect(rendered.includes('failed')).toBe(true);
+  });
+
+  it('nests each MCP tool beneath its owning server and reports empty discovery', () => {
+    const status = formatMcpSessionAuthStatus([
+      { name: 'pencil', state: 'connected' },
+      { name: 'agiflow-mcp', state: 'connected' },
+    ]);
+    const rendered = renderPlugin(
+      McpSessionAuthSection,
+      slotPropsFixture({
+        statuses: { [MCP_SESSION_AUTH_STATUS_KEY]: status! },
+        contextInventory: [
+          { name: 'pencil_execute', itemKind: 'tool', source: 'mcp', owner: 'pencil', tokens: 320, active: true },
+          { name: 'read', itemKind: 'tool', source: 'extension', owner: 'doompi-read', tokens: 100, active: true },
+        ],
+      }).props,
+    );
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.html).toContain('aria-label="pencil tools"');
+    expect(rendered.includes('pencil_execute')).toBe(true);
+    expect(rendered.includes('~320')).toBe(true);
+    expect(rendered.includes('read')).toBe(false);
+    expect(rendered.includes('no tools reported')).toBe(true);
+  });
+
+  it('keeps a connected zero-tool server visible and offers management', () => {
+    const status = formatMcpSessionAuthStatus([{ name: 'agiflow-mcp', state: 'connected', tools: [] }]);
+    const rendered = renderPlugin(
+      McpSessionAuthSection,
+      slotPropsFixture({ statuses: { [MCP_SESSION_AUTH_STATUS_KEY]: status! } }).props,
+    );
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.includes('agiflow-mcp')).toBe(true);
+    expect(rendered.includes('connected')).toBe(true);
+    expect(rendered.html).toContain('aria-label="Manage agiflow-mcp"');
+    expect(rendered.html).not.toContain('aria-label="Authorize agiflow-mcp"');
+  });
+
+  it.each([
+    { sessionId: null, state: 'connected' },
+    { sessionId: 'session-1', state: 'disabled' },
+  ])('keeps the server visible but disables unsafe actions for %j', ({ sessionId, state }) => {
+    const status = formatMcpSessionAuthStatus([{ name: 'agiflow-mcp', state }]);
+    const rendered = renderPlugin(
+      McpSessionAuthSection,
+      slotPropsFixture({ sessionId, statuses: { [MCP_SESSION_AUTH_STATUS_KEY]: status! } }).props,
+    );
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.includes('agiflow-mcp')).toBe(true);
+    expect(rendered.html).toMatch(/<button[^>]*disabled/);
   });
 
   it('renders nothing for an absent or browser-cleared status', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1618,8 +1618,8 @@ importers:
         specifier: workspace:*
         version: link:../../core/doompi-web-contracts
       '@agimon-ai/mcp-proxy':
-        specifier: 0.31.19
-        version: 0.31.19(@earendil-works/pi-coding-agent@0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)
+        specifier: 0.31.20
+        version: 0.31.20(@earendil-works/pi-coding-agent@0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)
       '@deepseek-ai/cordis':
         specifier: 4.0.1
         version: 4.0.1
@@ -2451,14 +2451,31 @@ packages:
     peerDependencies:
       zod: ^4.4.3
 
+  '@agimon-ai/foundation-port-registry@0.29.20':
+    resolution: {integrity: sha512-sVffXtU8JRObzwNnk8JtQ+pgRSr9TuLmfj/tspJ043LrIfxPlflTAaOb+jdl3XWdjY4fKxGDuS8CoWJ5sA9W8Q==}
+    hasBin: true
+    peerDependencies:
+      zod: ^4.4.3
+
   '@agimon-ai/foundation-process-registry@0.29.19':
     resolution: {integrity: sha512-GS+T2TWkjlxifVwUUmhOqHbMg3BRHECdlivOqvnqT1N5L7nrvezX1F+gvMjTKQ3A5YfdMEXVGeomCWh56U6YaA==}
     hasBin: true
     peerDependencies:
       zod: ^4.4.3
 
+  '@agimon-ai/foundation-process-registry@0.29.20':
+    resolution: {integrity: sha512-zQg5JD7Y3589g5vWewrgTFub+Kz4RtVFGIjBXjjSQtIYK8TlcPUsFNTD2a11G/9qig+3wRj/6K6ctbWQlFhf3Q==}
+    hasBin: true
+    peerDependencies:
+      zod: ^4.4.3
+
   '@agimon-ai/foundation-validator@0.26.19':
     resolution: {integrity: sha512-TthyaScN6OZNnpaWWOxQfwRdttSOir0qcUJSIyG6nU5d5JFzE8npGlWnBlzB0uyKkc+vAxjOSWrHWEMxycvC5g==}
+    peerDependencies:
+      zod: ^4.4.3
+
+  '@agimon-ai/foundation-validator@0.26.20':
+    resolution: {integrity: sha512-7LTNktd+h2irZ6J129+Lqx5/+rEQBeaCkQWy16OSJcKazUduW3MLOmKAH0B6msMiHavEObzGkn7eSr+xpF4MRQ==}
     peerDependencies:
       zod: ^4.4.3
 
@@ -2472,8 +2489,18 @@ packages:
       '@earendil-works/pi-coding-agent':
         optional: true
 
-  '@agimon-ai/mcp-proxy@0.31.19':
-    resolution: {integrity: sha512-8G5n4kvWw6RUbQ/ejau7Y6tgVEikGrHvDytL/pvIrfJ4GCSm4ylafA6ZLyjer7L+vUooiO+8pJlHzcjWn/vrQg==}
+  '@agimon-ai/log-sink-mcp@0.29.20':
+    resolution: {integrity: sha512-IGB5aj4L79vX60l+vNXD8PMNSKRyhJsZ2+RQDkEyLCwCwuZM2cb0iOGpFjXLOTsldqetwjUNuLnPsygEkyNCHQ==}
+    hasBin: true
+    peerDependencies:
+      '@earendil-works/pi-coding-agent': '*'
+      zod: ^4.4.3
+    peerDependenciesMeta:
+      '@earendil-works/pi-coding-agent':
+        optional: true
+
+  '@agimon-ai/mcp-proxy@0.31.20':
+    resolution: {integrity: sha512-9DU5D90NUH0uxVoazmdsJZeyNgHMSVt8070pacpSnt6JZ5SwiyRNr55yjue15VonUMpSFvjKDI1BCM4I3+WQWg==}
     hasBin: true
     peerDependencies:
       zod: ^4.4.3
@@ -9163,13 +9190,28 @@ snapshots:
       '@tursodatabase/database': 0.7.2
       zod: 4.4.3
 
+  '@agimon-ai/foundation-port-registry@0.29.20(zod@4.4.3)':
+    dependencies:
+      '@tursodatabase/database': 0.7.2
+      zod: 4.4.3
+
   '@agimon-ai/foundation-process-registry@0.29.19(zod@4.4.3)':
     dependencies:
       '@agimon-ai/foundation-port-registry': 0.29.19(zod@4.4.3)
       '@tursodatabase/database': 0.7.2
       zod: 4.4.3
 
+  '@agimon-ai/foundation-process-registry@0.29.20(zod@4.4.3)':
+    dependencies:
+      '@agimon-ai/foundation-port-registry': 0.29.20(zod@4.4.3)
+      '@tursodatabase/database': 0.7.2
+      zod: 4.4.3
+
   '@agimon-ai/foundation-validator@0.26.19(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+
+  '@agimon-ai/foundation-validator@0.26.20(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
 
@@ -9236,12 +9278,75 @@ snapshots:
       - supports-color
       - unstorage
 
-  '@agimon-ai/mcp-proxy@0.31.19(@earendil-works/pi-coding-agent@0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)':
+  '@agimon-ai/log-sink-mcp@0.29.20(@earendil-works/pi-coding-agent@0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@agimon-ai/foundation-port-registry': 0.29.19(zod@4.4.3)
-      '@agimon-ai/foundation-process-registry': 0.29.19(zod@4.4.3)
-      '@agimon-ai/foundation-validator': 0.26.19(zod@4.4.3)
-      '@agimon-ai/log-sink-mcp': 0.29.19(@earendil-works/pi-coding-agent@0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)
+      '@agimon-ai/foundation-port-registry': 0.29.20(zod@4.4.3)
+      '@agimon-ai/foundation-process-registry': 0.29.20(zod@4.4.3)
+      '@agimon-ai/foundation-validator': 0.26.20(zod@4.4.3)
+      '@hono/node-server': 2.0.10(hono@4.12.34)
+      '@hono/zod-validator': 0.7.6(hono@4.12.34)(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.219.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.8.0(@opentelemetry/api@1.9.1)
+      chalk: 5.6.2
+      commander: 14.0.3
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)
+      hono: 4.12.34
+      hono-rate-limiter: 0.5.3(hono@4.12.34)
+      inversify: 8.1.0(reflect-metadata@0.2.2)
+      reflect-metadata: 0.2.2
+      ruvector-onnx-embeddings-wasm: 0.1.2
+      sqlite-vec: 0.1.9
+      ulidx: 2.4.1
+      yaml: 2.8.3
+      zod: 4.4.3
+    optionalDependencies:
+      '@earendil-works/pi-coding-agent': 0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cfworker/json-schema'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+      - supports-color
+      - unstorage
+
+  '@agimon-ai/mcp-proxy@0.31.20(@earendil-works/pi-coding-agent@0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@agimon-ai/foundation-port-registry': 0.29.20(zod@4.4.3)
+      '@agimon-ai/foundation-process-registry': 0.29.20(zod@4.4.3)
+      '@agimon-ai/foundation-validator': 0.26.20(zod@4.4.3)
+      '@agimon-ai/log-sink-mcp': 0.29.20(@earendil-works/pi-coding-agent@0.85.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)
       '@hono/node-server': 2.0.10(hono@4.12.34)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       chalk: 5.6.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,11 +44,11 @@ onlyBuiltDependencies:
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
   - "@agimon-ai/foundation-exec@0.26.16||0.26.19"
-  - "@agimon-ai/foundation-port-registry@0.29.16||0.29.19"
-  - "@agimon-ai/foundation-process-registry@0.29.16||0.29.19"
-  - "@agimon-ai/foundation-validator@0.26.16||0.26.19"
-  - "@agimon-ai/log-sink-mcp@0.29.16||0.29.19"
-  - "@agimon-ai/mcp-proxy@0.31.16||0.31.19"
+  - "@agimon-ai/foundation-port-registry@0.29.16||0.29.19||0.29.20"
+  - "@agimon-ai/foundation-process-registry@0.29.16||0.29.19||0.29.20"
+  - "@agimon-ai/foundation-validator@0.26.16||0.26.19||0.26.20"
+  - "@agimon-ai/log-sink-mcp@0.29.16||0.29.19||0.29.20"
+  - "@agimon-ai/mcp-proxy@0.31.16||0.31.19||0.31.20"
   - "@agimon-ai/vibe-lint@0.0.1-alpha.26||0.0.1-alpha.29"
   - "@agimon-ai/workflow-mcp@0.23.16||0.23.19"
   - "@earendil-works/chord@0.85.0"


### PR DESCRIPTION
## Summary
- add explicit MCP session authorization state and browser-safe OAuth handling
- surface runtime tool and skill inventory through the web plugin context panel
- update MCP configuration, contracts, and focused coverage for the new flow

## Verification
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm lint:vibe --preflight-only