### PR TITLE
fix(doompi-web): load remote activity plugins securely

### DIFF
--- a/packages/clients/doompi-web/src/pwa/serviceWorker.ts
+++ b/packages/clients/doompi-web/src/pwa/serviceWorker.ts
@@ -51,6 +51,7 @@ interface ActivatePluginCompositionMessage {
   manifestUrl: string;
   rawAssetBaseUrl: string;
   verifiedAssetBaseUrl: string;
+  relayThroughClient: boolean;
 }
 
 interface ResetBundleMessage {
@@ -95,6 +96,18 @@ function parsePluginFetchResult(value: unknown, requestId: number): PluginFetchR
   return value as PluginFetchResult;
 }
 
+async function fetchPluginDirect(path: string): Promise<Response> {
+  const response = await fetch(path, {
+    credentials: 'include',
+    cache: 'no-store',
+    redirect: 'error',
+  });
+  if (response.redirected || new URL(response.url).origin !== worker.location.origin) {
+    throw new Error('The plugin asset request left the trusted origin.');
+  }
+  return response;
+}
+
 async function fetchThroughClient(port: MessagePort, path: string): Promise<Response> {
   const requestId = ++pluginFetchRequestId;
   return await new Promise((resolve, reject) => {
@@ -133,7 +146,8 @@ function parseWorkerRequest(value: unknown): WorkerRequest | undefined {
       Number(value.revision) < 1 ||
       typeof value.manifestUrl !== 'string' ||
       typeof value.rawAssetBaseUrl !== 'string' ||
-      typeof value.verifiedAssetBaseUrl !== 'string'
+      typeof value.verifiedAssetBaseUrl !== 'string' ||
+      typeof value.relayThroughClient !== 'boolean'
     ) {
       return undefined;
     }
@@ -154,6 +168,7 @@ function parseWorkerRequest(value: unknown): WorkerRequest | undefined {
       manifestUrl: value.manifestUrl,
       rawAssetBaseUrl: value.rawAssetBaseUrl,
       verifiedAssetBaseUrl: value.verifiedAssetBaseUrl,
+      relayThroughClient: value.relayThroughClient,
     };
   }
   if (
@@ -443,7 +458,10 @@ async function handleMessage(request: WorkerRequest, port: MessagePort): Promise
     return await activateBundle(request.publicKey, request.minimumRevision);
   }
   if (request.type === ACTIVATE_PLUGIN_MESSAGE) {
-    return await queuePluginActivation(request, (path) => fetchThroughClient(port, path));
+    const fetchPlugin = request.relayThroughClient
+      ? (path: string) => fetchThroughClient(port, path)
+      : fetchPluginDirect;
+    return await queuePluginActivation(request, fetchPlugin);
   }
   const current = await readActiveBundle();
   if (current === undefined) return { ok: false, code: 'no-pin', message: 'No host signing key is pinned.' };

--- a/packages/clients/doompi-web/src/pwa/serviceWorker.ts
+++ b/packages/clients/doompi-web/src/pwa/serviceWorker.ts
@@ -30,6 +30,9 @@ const ACTIVATE_MESSAGE = 'doompi:activate-bundle';
 const ACTIVATE_PLUGIN_MESSAGE = 'doompi:activate-plugin-composition';
 const REFRESH_MESSAGE = 'doompi:refresh-bundle';
 const RESET_MESSAGE = 'doompi:reset-bundle-trust';
+const PLUGIN_FETCH_MESSAGE = 'doompi:plugin-fetch';
+const PLUGIN_FETCH_RESULT_MESSAGE = 'doompi:plugin-fetch-result';
+const PLUGIN_FETCH_TIMEOUT_MS = 120_000;
 
 interface ActivateBundleMessage {
   type: typeof ACTIVATE_MESSAGE;
@@ -62,6 +65,59 @@ type WorkerRequest =
 
 type WorkerReply = { ok: true; revision?: number } | { ok: false; code: string; message: string };
 
+type PluginFetchResult =
+  | {
+      type: typeof PLUGIN_FETCH_RESULT_MESSAGE;
+      requestId: number;
+      ok: true;
+      status: number;
+      headers: Array<[string, string]>;
+      body: ArrayBuffer;
+    }
+  | { type: typeof PLUGIN_FETCH_RESULT_MESSAGE; requestId: number; ok: false; message: string };
+
+let pluginFetchRequestId = 0;
+
+function parsePluginFetchResult(value: unknown, requestId: number): PluginFetchResult | undefined {
+  if (!isRecord(value) || value.type !== PLUGIN_FETCH_RESULT_MESSAGE || value.requestId !== requestId) return undefined;
+  if (value.ok === false && typeof value.message === 'string') return value as PluginFetchResult;
+  if (
+    value.ok !== true ||
+    typeof value.status !== 'number' ||
+    !Array.isArray(value.headers) ||
+    !value.headers.every(
+      (header) => Array.isArray(header) && header.length === 2 && header.every((part) => typeof part === 'string'),
+    ) ||
+    !(value.body instanceof ArrayBuffer)
+  ) {
+    return undefined;
+  }
+  return value as PluginFetchResult;
+}
+
+async function fetchThroughClient(port: MessagePort, path: string): Promise<Response> {
+  const requestId = ++pluginFetchRequestId;
+  return await new Promise((resolve, reject) => {
+    const timeout = worker.setTimeout(() => {
+      port.removeEventListener('message', onMessage);
+      reject(new Error('The cockpit page did not answer the plugin asset request.'));
+    }, PLUGIN_FETCH_TIMEOUT_MS);
+    const onMessage = (event: MessageEvent<unknown>): void => {
+      const result = parsePluginFetchResult(event.data, requestId);
+      if (result === undefined) return;
+      worker.clearTimeout(timeout);
+      port.removeEventListener('message', onMessage);
+      if (!result.ok) {
+        reject(new Error(result.message));
+        return;
+      }
+      resolve(new Response(result.body, { status: result.status, headers: result.headers }));
+    };
+    port.addEventListener('message', onMessage);
+    port.start();
+    port.postMessage({ type: PLUGIN_FETCH_MESSAGE, requestId, path });
+  });
+}
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -149,15 +205,12 @@ async function fetchManifest(): Promise<unknown> {
   return await response.json();
 }
 
-async function fetchPluginManifest(manifestUrl: string): Promise<unknown> {
-  const response = await fetch(manifestUrl, {
-    credentials: 'include',
-    cache: 'no-store',
-    redirect: 'error',
-  });
-  if (!response.ok || response.redirected || new URL(response.url).origin !== worker.location.origin) {
-    throw new Error(`The signed plugin manifest request failed (${String(response.status)}).`);
-  }
+async function fetchPluginManifest(
+  manifestUrl: string,
+  fetchPlugin: (path: string) => Promise<Response>,
+): Promise<unknown> {
+  const response = await fetchPlugin(manifestUrl);
+  if (!response.ok) throw new Error(`The signed plugin manifest request failed (${String(response.status)}).`);
   return await response.json();
 }
 
@@ -173,7 +226,10 @@ async function prunePluginCompositions(): Promise<void> {
   }
 }
 
-async function activatePluginComposition(request: ActivatePluginCompositionMessage): Promise<WorkerReply> {
+async function activatePluginComposition(
+  request: ActivatePluginCompositionMessage,
+  fetchPlugin: (path: string) => Promise<Response>,
+): Promise<WorkerReply> {
   const host = await readActiveBundle();
   if (host === undefined) {
     return { ok: false, code: 'no-pin', message: 'No trusted cockpit signing key is pinned.' };
@@ -185,7 +241,7 @@ async function activatePluginComposition(request: ActivatePluginCompositionMessa
 
   let envelope: unknown;
   try {
-    envelope = await fetchPluginManifest(request.manifestUrl);
+    envelope = await fetchPluginManifest(request.manifestUrl, fetchPlugin);
   } catch (error) {
     return { ok: false, code: 'manifest-fetch', message: error instanceof Error ? error.message : String(error) };
   }
@@ -210,14 +266,8 @@ async function activatePluginComposition(request: ActivatePluginCompositionMessa
   try {
     for (const asset of verified.manifest.assets) {
       const source = `${request.rawAssetBaseUrl}${asset.path}`;
-      const response = await fetch(source, {
-        credentials: 'include',
-        cache: 'no-store',
-        redirect: 'error',
-      });
-      if (!response.ok || response.redirected || new URL(response.url).origin !== worker.location.origin) {
-        throw new Error(`The raw plugin asset ${asset.path} was unavailable.`);
-      }
+      const response = await fetchPlugin(source);
+      if (!response.ok) throw new Error(`The raw plugin asset ${asset.path} was unavailable.`);
       const bytes = await response.arrayBuffer();
       const assetResult = await verifyBundleAsset(verified.manifest, asset.path, bytes);
       if (!assetResult.ok) throw new Error(`The raw plugin asset ${asset.path} failed ${assetResult.failure.code}.`);
@@ -259,11 +309,14 @@ async function activatePluginComposition(request: ActivatePluginCompositionMessa
 
 const pluginActivations = new Map<string, Promise<WorkerReply>>();
 
-function queuePluginActivation(request: ActivatePluginCompositionMessage): Promise<WorkerReply> {
+function queuePluginActivation(
+  request: ActivatePluginCompositionMessage,
+  fetchPlugin: (path: string) => Promise<Response>,
+): Promise<WorkerReply> {
   const previous = pluginActivations.get(request.compositionId) ?? Promise.resolve({ ok: true } as WorkerReply);
   const activation = previous.then(
-    async () => await activatePluginComposition(request),
-    async () => await activatePluginComposition(request),
+    async () => await activatePluginComposition(request, fetchPlugin),
+    async () => await activatePluginComposition(request, fetchPlugin),
   );
   pluginActivations.set(request.compositionId, activation);
   void activation.then(
@@ -375,7 +428,7 @@ async function activateBundle(publicKey: string, minimumRevision: number): Promi
   }
 }
 
-async function handleMessage(request: WorkerRequest): Promise<WorkerReply> {
+async function handleMessage(request: WorkerRequest, port: MessagePort): Promise<WorkerReply> {
   if (request.type === RESET_MESSAGE) {
     for (const held of await caches.keys()) {
       if (held.startsWith(CACHE_PREFIX) || held.startsWith(PLUGIN_CACHE_PREFIX)) await caches.delete(held);
@@ -389,7 +442,9 @@ async function handleMessage(request: WorkerRequest): Promise<WorkerReply> {
   if (request.type === ACTIVATE_MESSAGE) {
     return await activateBundle(request.publicKey, request.minimumRevision);
   }
-  if (request.type === ACTIVATE_PLUGIN_MESSAGE) return await queuePluginActivation(request);
+  if (request.type === ACTIVATE_PLUGIN_MESSAGE) {
+    return await queuePluginActivation(request, (path) => fetchThroughClient(port, path));
+  }
   const current = await readActiveBundle();
   if (current === undefined) return { ok: false, code: 'no-pin', message: 'No host signing key is pinned.' };
   return await activateBundle(current.signerPublicKey, current.revision);
@@ -416,7 +471,7 @@ worker.addEventListener('message', (event) => {
     return;
   }
   event.waitUntil(
-    handleMessage(request)
+    handleMessage(request, port)
       .then((reply) => port.postMessage(reply))
       .catch((error: unknown) =>
         port.postMessage({

--- a/packages/clients/doompi-web/src/pwa/workerClient.ts
+++ b/packages/clients/doompi-web/src/pwa/workerClient.ts
@@ -1,3 +1,4 @@
+import { sealedTransport } from '@agimon-ai/doompi-web-security/browser';
 import type { SessionWebComposition } from '../types/hub.ts';
 
 export interface BundleActivationRequest {
@@ -6,6 +7,54 @@ export interface BundleActivationRequest {
 }
 
 export type WorkerResult = { ok: true; revision?: number } | { ok: false; code: string; message: string };
+
+const PLUGIN_FETCH_MESSAGE = 'doompi:plugin-fetch';
+const PLUGIN_FETCH_RESULT_MESSAGE = 'doompi:plugin-fetch-result';
+
+interface PluginFetchRequest {
+  type: typeof PLUGIN_FETCH_MESSAGE;
+  requestId: number;
+  path: string;
+}
+
+function parsePluginFetchRequest(value: unknown): PluginFetchRequest | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const request = value as Partial<PluginFetchRequest>;
+  if (
+    request.type !== PLUGIN_FETCH_MESSAGE ||
+    !Number.isSafeInteger(request.requestId) ||
+    typeof request.path !== 'string' ||
+    !request.path.startsWith('/api/web-plugins/')
+  ) {
+    return undefined;
+  }
+  return request as PluginFetchRequest;
+}
+
+async function answerPluginFetch(port: MessagePort, request: PluginFetchRequest): Promise<void> {
+  try {
+    const response = await sealedTransport.fetch(request.path, { cache: 'no-store', credentials: 'include' });
+    const body = await response.arrayBuffer();
+    port.postMessage(
+      {
+        type: PLUGIN_FETCH_RESULT_MESSAGE,
+        requestId: request.requestId,
+        ok: true,
+        status: response.status,
+        headers: [...response.headers.entries()],
+        body,
+      },
+      [body],
+    );
+  } catch (error) {
+    port.postMessage({
+      type: PLUGIN_FETCH_RESULT_MESSAGE,
+      requestId: request.requestId,
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
 
 function isWorkerResult(value: unknown): value is WorkerResult {
   if (typeof value !== 'object' || value === null || !('ok' in value) || typeof value.ok !== 'boolean') return false;
@@ -24,26 +73,42 @@ async function requestWorker(message: object): Promise<WorkerResult> {
   const serviceWorker = await activeWorker();
   const channel = new MessageChannel();
   return await new Promise((resolve) => {
-    const timeout = window.setTimeout(
-      () => resolve({ ok: false, code: 'worker-timeout', message: 'The trusted service worker did not answer.' }),
-      120_000,
-    );
-    channel.port1.addEventListener(
-      'message',
-      (event: MessageEvent<unknown>) => {
-        window.clearTimeout(timeout);
-        resolve(
-          isWorkerResult(event.data)
-            ? event.data
-            : {
-                ok: false,
-                code: 'invalid-worker-response',
-                message: 'The trusted service worker returned invalid data.',
-              },
-        );
-      },
-      { once: true },
-    );
+    const timeout = window.setTimeout(() => {
+      channel.port1.close();
+      resolve({ ok: false, code: 'worker-timeout', message: 'The trusted service worker did not answer.' });
+    }, 120_000);
+    channel.port1.addEventListener('message', (event: MessageEvent<unknown>) => {
+      const isPluginFetch =
+        typeof event.data === 'object' &&
+        event.data !== null &&
+        (event.data as { type?: unknown }).type === PLUGIN_FETCH_MESSAGE;
+      if (isPluginFetch) {
+        const pluginFetch = parsePluginFetchRequest(event.data);
+        if (pluginFetch !== undefined) {
+          void answerPluginFetch(channel.port1, pluginFetch);
+        } else {
+          const requestId = (event.data as { requestId?: unknown }).requestId;
+          channel.port1.postMessage({
+            type: PLUGIN_FETCH_RESULT_MESSAGE,
+            requestId: Number.isSafeInteger(requestId) ? requestId : -1,
+            ok: false,
+            message: 'The trusted service worker requested an invalid plugin path.',
+          });
+        }
+        return;
+      }
+      window.clearTimeout(timeout);
+      channel.port1.close();
+      resolve(
+        isWorkerResult(event.data)
+          ? event.data
+          : {
+              ok: false,
+              code: 'invalid-worker-response',
+              message: 'The trusted service worker returned invalid data.',
+            },
+      );
+    });
     channel.port1.start();
     serviceWorker.postMessage(message, [channel.port2]);
   });

--- a/packages/clients/doompi-web/src/pwa/workerClient.ts
+++ b/packages/clients/doompi-web/src/pwa/workerClient.ts
@@ -126,6 +126,7 @@ export async function activateVerifiedPluginComposition(composition: SessionWebC
     manifestUrl: composition.manifestUrl,
     rawAssetBaseUrl: composition.rawAssetBaseUrl,
     verifiedAssetBaseUrl: composition.verifiedAssetBaseUrl,
+    relayThroughClient: sealedTransport.active(),
   });
 }
 

--- a/packages/clients/doompi-web/tests/integration/remoteAccess.test.ts
+++ b/packages/clients/doompi-web/tests/integration/remoteAccess.test.ts
@@ -291,6 +291,7 @@ describe('the tunnel listener refuses everything unpaired', () => {
     ['GET', '/api/sessions/remote/files'],
     ['GET', '/api/auth/providers'],
     ['GET', '/api/plugin/anything'],
+    ['GET', `/api/web-plugins/${'a'.repeat(64)}/1/manifest`],
     ['GET', '/index.html'],
     ['GET', '/favicon.ico'],
     ['GET', '/api/remote'],

--- a/packages/clients/doompi-web/tests/unit/workerClient.test.ts
+++ b/packages/clients/doompi-web/tests/unit/workerClient.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(),
+}));
+
+vi.mock('@agimon-ai/doompi-web-security/browser', () => ({
+  sealedTransport: { fetch: mocks.fetch },
+}));
+
+import { activateVerifiedPluginComposition } from '../../src/pwa/workerClient.ts';
+
+const composition = {
+  id: 'a'.repeat(64),
+  revision: 1,
+  manifestUrl: `/api/web-plugins/${'a'.repeat(64)}/1/manifest`,
+  rawAssetBaseUrl: `/api/web-plugins/${'a'.repeat(64)}/1/assets`,
+  verifiedAssetBaseUrl: `/verified-plugins/${'a'.repeat(64)}/1`,
+  entryPath: '/entry.js',
+  stylePaths: [],
+  channels: [],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  mocks.fetch.mockReset();
+});
+
+describe('the trusted worker client', () => {
+  it('relays plugin downloads through the shared sealed HTTP transport', async () => {
+    mocks.fetch.mockResolvedValue(
+      new Response('{"signed":true}', { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    const worker = {
+      postMessage: vi.fn((_: unknown, ports: MessagePort[]) => {
+        const port = ports[0];
+        port.addEventListener('message', (event: MessageEvent<unknown>) => {
+          const result = event.data as { type?: string; requestId?: number; status?: number };
+          if (result.type === 'doompi:plugin-fetch-result') {
+            expect(result.status).toBe(200);
+            port.postMessage({ ok: true, revision: 1 });
+          }
+        });
+        port.start();
+        port.postMessage({ type: 'doompi:plugin-fetch', requestId: 7, path: composition.manifestUrl });
+      }),
+    };
+    vi.stubGlobal('window', globalThis);
+    vi.stubGlobal('navigator', { serviceWorker: { ready: Promise.resolve({ active: worker }) } });
+
+    await expect(activateVerifiedPluginComposition(composition)).resolves.toEqual({ ok: true, revision: 1 });
+    expect(mocks.fetch).toHaveBeenCalledWith(composition.manifestUrl, {
+      cache: 'no-store',
+      credentials: 'include',
+    });
+  });
+
+  it('does not relay worker requests outside the plugin publication API', async () => {
+    const worker = {
+      postMessage: vi.fn((_: unknown, ports: MessagePort[]) => {
+        const port = ports[0];
+        port.addEventListener('message', (event: MessageEvent<unknown>) => {
+          const result = event.data as { type?: string; ok?: boolean };
+          if (result.type === 'doompi:plugin-fetch-result' && result.ok === false) {
+            port.postMessage({ ok: false, code: 'manifest-fetch', message: 'refused' });
+          }
+        });
+        port.start();
+        port.postMessage({ type: 'doompi:plugin-fetch', requestId: 8, path: '/api/sessions' });
+      }),
+    };
+    vi.stubGlobal('window', globalThis);
+    vi.stubGlobal('navigator', { serviceWorker: { ready: Promise.resolve({ active: worker }) } });
+
+    await expect(activateVerifiedPluginComposition(composition)).resolves.toEqual({
+      ok: false,
+      code: 'manifest-fetch',
+      message: 'refused',
+    });
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/clients/doompi-web/tests/unit/workerClient.test.ts
+++ b/packages/clients/doompi-web/tests/unit/workerClient.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  active: vi.fn(() => true),
   fetch: vi.fn(),
 }));
 
 vi.mock('@agimon-ai/doompi-web-security/browser', () => ({
-  sealedTransport: { fetch: mocks.fetch },
+  sealedTransport: { active: mocks.active, fetch: mocks.fetch },
 }));
 
 import { activateVerifiedPluginComposition } from '../../src/pwa/workerClient.ts';
@@ -33,7 +34,8 @@ describe('the trusted worker client', () => {
       new Response('{"signed":true}', { status: 200, headers: { 'content-type': 'application/json' } }),
     );
     const worker = {
-      postMessage: vi.fn((_: unknown, ports: MessagePort[]) => {
+      postMessage: vi.fn((message: unknown, ports: MessagePort[]) => {
+        expect(message).toMatchObject({ relayThroughClient: true });
         const port = ports[0];
         port.addEventListener('message', (event: MessageEvent<unknown>) => {
           const result = event.data as { type?: string; requestId?: number; status?: number };
@@ -78,6 +80,23 @@ describe('the trusted worker client', () => {
       code: 'manifest-fetch',
       message: 'refused',
     });
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('keeps loopback plugin downloads inside the service worker', async () => {
+    mocks.active.mockReturnValueOnce(false);
+    const worker = {
+      postMessage: vi.fn((message: unknown, ports: MessagePort[]) => {
+        expect(message).toMatchObject({ relayThroughClient: false });
+        const port = ports[0];
+        port.start();
+        port.postMessage({ ok: true, revision: 1 });
+      }),
+    };
+    vi.stubGlobal('window', globalThis);
+    vi.stubGlobal('navigator', { serviceWorker: { ready: Promise.resolve({ active: worker }) } });
+
+    await expect(activateVerifiedPluginComposition(composition)).resolves.toEqual({ ok: true, revision: 1 });
     expect(mocks.fetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- route service-worker plugin manifest and asset downloads through the page's shared sealed HTTP transport
- preserve service-worker signature and asset hash verification
- keep direct remote plugin API requests blocked
- add regression coverage for transport routing and remote guard behavior

## Root cause

The service worker downloaded `/api/web-plugins/...` directly. The remote guard correctly rejects direct API requests because remote HTTP traffic must use the sealed gateway. Plugin activation then installed an empty registry, so the activity dock displayed `nothing supervised yet`.

## Verification

- `pnpm lint:vibe --preflight-only`
- `pnpm nx lint @agimon-ai/doompi-web`
- `pnpm nx typecheck @agimon-ai/doompi-web`
- `pnpm nx build @agimon-ai/doompi-web`
- `pnpm nx test @agimon-ai/doompi-web`, 1,293 tests passed
- relevant Playwright activity and pairing tests completed successfully, 11 passed and 2 passed on retry
- the two retrying activity tests passed cleanly in a focused rerun

The global installation and running hub were not changed.
