### PR TITLE
feat: add global computer-use opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ not. Use it as-is, build your own config on top, or raid it for parts.
 | [Automation](docs/automation.md)                               | Workflows, native plugin examples, and loops                                       |
 | [Features](docs/features.md)                                   | Fixed host packages, selectable features, and capability contracts                 |
 | [Configuration](docs/configuration.md)                         | The four YAML files, field-specific merge rules, examples, and matrix checks       |
+| [Composition and bundling](docs/bundling.md)                   | How configuration becomes TUI runtime bundles and synchronized generations         |
 | [Security model](docs/securities.md)                           | Threat model, remote-access boundaries, containment, and known limits              |
 | [Trust and data boundaries](docs/trust-and-data-boundaries.md) | Executable inputs, credentials, model calls, voice, native binaries, and telemetry |
 | [Observability](docs/observability.md)                         | Session metrics, local log storage, trace lookup, and telemetry controls           |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,9 +2,16 @@
 
 [Back to DoomPi](../README.md)
 
-DoomPi resolves configuration into an ordered set of standard Pi extension factories. Pi owns the extension runner, registration API, reload, and module replacement. DoomPi owns configuration resolution, composed factory loading, runtime artifacts, composition identity, and transition coordination.
+DoomPi adds composition and lifecycle policy around Pi without replacing Pi's runtime. Pi still owns extension registration, the runner, reload, and module replacement. DoomPi owns the decisions Pi should not have to infer: which factories belong together, how their services find one another, which prepared artifact matches a selection, and whether a change is live, reloadable, or requires another process.
 
-This document defines the current boundaries and contributor invariants.
+The architecture follows four boundaries:
+
+1. **One canonical composition:** launcher, synchronized startup, and detached children use the same resolver and fingerprint.
+2. **Pi owns module execution:** DoomPi plans and coordinates; Pi performs factory loading and replacement.
+3. **Cordis owns live collaboration:** packages publish versioned services instead of importing selectable implementations.
+4. **Repository identity owns generated state:** synchronized artifacts are immutable and selected through a validated repository or worktree registration.
+
+This guide explains those runtime boundaries and the contributor invariants they create. [Composition and runtime bundling](bundling.md) explains the artifact pipeline in reader-facing terms.
 
 ## System model
 
@@ -117,7 +124,7 @@ doompi could not read its synchronized state. Run doompi sync.
 existing repository Pi settings and removes a legacy repository alias. `dpi` supplies its overlay
 in memory and uses the same repository-isolated publication without requiring persisted settings.
 
-The shared hub pins web assets and package APIs to its startup repository. Session API requests resolve through the session `cwd`, so concurrent sessions can use different repositories without changing the hub registration. Outside a synchronized repository, the server uses packaged web assets and inherits the package APIs of the installation running it, so a session in an unsynchronized checkout still mounts the cockpit's own APIs instead of none. Explicit `--assets`, `DOOMPI_WEB_DIST`, and `DOOMPI_API_DIR` overrides retain precedence.
+The web hub serves the package-owned browser shell unless an explicit asset override is configured. For each session, it resolves a complete web generation from that session's repository, then uses the global generation as a web-only fallback. That selection keeps the client plugin composition, hub channels, and session-associated hub APIs together. A `session` selector proxies to the API socket owned by the session server; `hubSession` selects hub APIs from the session's web generation; no selector uses the deterministic default hub API generation. `--assets`, `DOOMPI_WEB_DIST`, and `DOOMPI_API_DIR` remain explicit operator overrides. See [Web bundling and serving](../packages/clients/doompi-web/docs/bundle.md).
 
 Configuration drift and missing synchronization are diagnosed separately. `doompi sync --check` is read-only: it re-resolves configuration and package paths, compares the active fingerprint, and validates the registration, bootstrap, and full bundle map.
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -2,16 +2,32 @@
 
 [Back to DoomPi](../README.md)
 
+DoomPi has two automation levels:
+
+```text
+Loop      repeats a prompt inside one live session
+Workflow  runs a dependency graph with a separate DoomPi session per step
+```
+
+Use Loop when state should stay in one conversation. Use Workflow when jobs need explicit dependencies, timeouts, artifacts, or different compositions. A loop can act as a dispatcher that chooses and launches workflows.
+
 Commands in this guide run from the repository root.
 
-## Autopilot
+## Workflow execution model
 
-Copilot helps while you are present. Loop and Workflow keep work moving when you are not.
-Together they can dispatch structured jobs from one live session.
+Workflow mode reads GitHub Actions-style job graphs. `needs` creates dependencies between jobs. Each `interactiveRun` starts the DoomPi command written by the workflow, so the definition owns the mode, domains, working directory, and other launch policy for that step.
 
-### Workflows
+```text
+workflow definition
+       |
+       +-- job: implement -> DoomPi session A
+       |          |
+       |          +-- artifacts and result
+       |
+       +-- job: article, needs implement -> DoomPi session B
+```
 
-Workflow mode uses GitHub Actions-style jobs. Each step launches the DoomPi session declared by its `interactiveRun`. In this example, the article job waits for implementation and uses a different domain:
+Steps do not inherit the dispatcher's entire toolbox. This is the main reason to use separate sessions: implementation can load development tools while writing can load only the blog domain.
 
 ```yaml
 on:
@@ -38,9 +54,11 @@ jobs:
               --cwd "$PWD" "$JOB_SYSTEM_PROMPT"
 ```
 
-### Native plugin and workflow examples
+`--auto-stop` closes an interactive automation session after its agent settles. Timeouts remain workflow policy and should reflect the cost and expected duration of each job.
 
-This source repository includes a complete, deliberately small example stack:
+## Repository examples
+
+This repository carries a small native plugin and workflow stack:
 
 ```text
 plugins/
@@ -53,18 +71,16 @@ automations/workflows/
   blog-writing.workflow.yml
 ```
 
-Each plugin has both `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json`, while its
-`skills/` and `agents/` content is shared. `.doom/domains.yaml` exposes the `development`,
-`testing`, and `blog` domains plus the `engineering` alias. `.doom/modes.yaml` mirrors the
-standalone package set with workspace-local paths, keeps its canonical modes, and adds a layer-free
-`examples` base mode for the tracked workflows. Inspect the exact session before launch:
+Each plugin has Codex and Claude plugin manifests while sharing its `skills/` and `agents/` content. `.doom/domains.yaml` exposes the `development`, `testing`, and `blog` domains plus the `engineering` alias. `.doom/modes.yaml` uses workspace-local package paths and adds the layer-free `examples` major mode for these workflows.
+
+Inspect the exact session before launching it:
 
 ```bash
 doompi --major-mode examples --domains engineering --explain
 doompi --major-mode examples --domains blog --explain
 ```
 
-The same bundles can be installed directly through either native marketplace:
+The same plugins can be installed through their native marketplaces. DoomPi adds no private plugin schema:
 
 ```bash
 # Codex
@@ -76,10 +92,11 @@ claude plugin marketplace add ./ --scope user
 claude plugin install development@doompi-examples --scope user
 ```
 
-Substitute `testing` or `blog-writing` to install another bundle. No DoomPi-specific plugin
-schema is involved.
+Substitute `testing` or `blog-writing` for another plugin.
 
-List and dry-run the tracked workflows before spending a model call:
+## Validate before spending a model call
+
+List and dry-run workflow definitions first:
 
 ```bash
 pnpm exec workflow-mcp list-workflows automations/workflows
@@ -89,10 +106,14 @@ pnpm exec workflow-mcp run-workflow automations/workflows/blog-writing.workflow.
   --dry-run --skip-launch --prompt "Write a practical guide to scoped agent tooling"
 ```
 
-Real runs delegate to tmux by default; set `WORKFLOW_LAUNCHER=cmux` to use cmux. Development workflows do not create branches, commits, or pushes. Blog workflows leave Markdown, sources, and a publication checklist in the workflow run directory. They do not write into a site or call a CMS. These examples are source-repository fixtures and are not included in the published npm package.
+Real runs use tmux by default. Set `WORKFLOW_LAUNCHER=cmux` to use cmux. The tracked development workflows do not create branches, commits, or pushes. Blog workflows write Markdown, sources, and a publication checklist into the workflow run directory. They do not publish to a site or CMS.
 
-### Loop
+These examples are repository fixtures and are not included in the published npm package.
 
-Workflow definitions are exposed like skills, so the agent can choose one for the job. A
-loop can send a subagent to fetch the next task, then dispatch the workflow that matches
-it. One session becomes the dispatcher instead of the place every job has to fit.
+## Loop as a dispatcher
+
+Loop mode runs a prompt immediately and repeats it on an interval inside the current session. Workflow definitions are exposed like skills, so a loop can ask a subagent for the next task and dispatch the matching workflow.
+
+That keeps scheduling and routing in one live session while each unit of work gets a fresh, explicit composition. Do not use Loop when the work needs durable job dependencies or isolated artifacts; that is Workflow's boundary.
+
+See [Features](features.md#modes-and-automation) for the user-facing controls and [Configuration](configuration.md) for selecting the packages that provide them.

--- a/docs/bundling.md
+++ b/docs/bundling.md
@@ -1,0 +1,112 @@
+# Composition and runtime bundling
+
+[Back to DoomPi](../README.md)
+
+DoomPi does two separate jobs before Pi opens its TUI:
+
+1. **Composition** decides which extension factories belong in the session and in what order.
+2. **Bundling** turns that resolved plan into JavaScript Pi can load.
+
+The composition is the contract. A bundle is one way to deliver it. If launcher bundling is unavailable, DoomPi can still give Pi the same ordered extension entries individually.
+
+## From configuration to a composition
+
+DoomPi reads the home configuration first and the nearest repository configuration second. The active profile, major mode, domains, and minor modes supply runtime selections. `modes.yaml` supplies the default packages, named layers, and the layer order for each major mode.
+
+The resolver converts those inputs into one canonical plan:
+
+```text
+home and repository configuration
+               +
+       current selections
+               |
+               v
+ resolveExtensionComposition()
+       |                 |
+       |                 +-- detached-child factories
+       +-- TUI factories
+               |
+               +-- composition fingerprint
+```
+
+The TUI factory list begins with the Cordis host and ends with its finalizer. Fixed host factories load first, followed by configured defaults and the selected layers in canonical order. When the same resolved extension appears more than once, DoomPi keeps every authored occurrence for diagnostics but activates the factory once, at its first position.
+
+The resolver also produces a SHA-256 fingerprint. It covers the parent and detached-child activation plans, so it changes when the executable composition changes. DoomPi uses that fingerprint to name bundles, detect stale synchronized state, and decide whether a selection can update live or needs a reload or relaunch.
+
+## The launcher path
+
+Running `doompi` or `dpi` resolves the active composition and provisions the packages it needs. The launcher then tries to flatten the ordered extension factories into one aggregate runtime bundle.
+
+```text
+active composition -> aggregate JavaScript bundle -> Pi extension runner -> TUI
+```
+
+This keeps Pi startup pointed at one generated entry and freezes the resolver's activation order. The aggregate file is not a different plugin system and does not change which skills, tools, prompts, or extensions load. If the compiler cannot create the aggregate bundle, the launcher falls back to the same canonical extension entries in order.
+
+This path is useful for trying a composition immediately. It can compile as part of launch, so it is not the path used for a registered synchronized installation.
+
+## The synchronized path
+
+`doompi sync` prepares runtime state before the next TUI starts. It provisions the defaults and every declared named layer, resolves the possible compositions, and writes their bundles into one immutable generation under `~/.pi/.doom/sync`.
+
+A generation contains more than TUI JavaScript:
+
+- resolved state and composition fingerprints
+- the bootstrap loaded by Pi
+- runtime bundles for recorded compositions
+- package resources
+- web plugin artifacts and package API routes when available
+
+The generated bootstrap does not compile extensions during startup. It reads the validated registration for the current repository or worktree, selects the bundle recorded for the active fingerprint, validates it, and imports it. If no recorded aggregate bundle is available, it can use the canonical entries stored for that composition.
+
+This design has three practical reasons:
+
+- **Predictable startup:** Pi loads already prepared files instead of discovering and compiling a graph while the TUI opens.
+- **Repository isolation:** two repositories or Git worktrees can select different package sets without sharing mutable `current` state.
+- **Safe publication:** readers see the old complete generation or the new complete generation, never half of each.
+
+## Publishing a generation
+
+Synchronization follows one transaction-like sequence:
+
+1. Stage every artifact in a new generation directory.
+2. Validate paths, manifests, source fingerprints, repository identity, and required files.
+3. Atomically publish the registration that points readers at that generation.
+4. Retain one previous generation and attempt to clean older ones.
+
+Published generations are not edited in place. A cleanup failure is reported, but it does not invalidate the generation that was already published.
+
+The registration is part of the boundary. It pins the repository identity, worktree, DoomPi package, Pi entry, state hash, and generation paths. A missing, stale, foreign, traversing, or malformed registration is rejected rather than replaced with a guessed source checkout or another repository's state.
+
+## What happens when a selection changes
+
+DoomPi resolves the candidate selection before applying it:
+
+| Result                                           | TUI behavior                                          |
+| ------------------------------------------------ | ----------------------------------------------------- |
+| Same executable fingerprint                      | Update the live selection without replacing factories |
+| Recorded compatible composition                  | Reload the prepared composition                       |
+| Parent activation changed in a launcher session  | Relaunch Pi with the new plan                         |
+| Required synchronized bundle is missing or stale | Stop the transition and ask for `doompi sync`         |
+
+Domain and profile values can still change runtime data even when the extension factory set stays the same. The fingerprint answers whether executable composition changed, not whether every session value is identical.
+
+## Why web bundling is separate
+
+The runtime bundle above is Node.js code loaded by Pi. It is not the browser cockpit.
+
+DoomPi Web starts from the same synchronized package composition, but it has different outputs and constraints: React and CSS need browser compilation, server channels must remain on the host, and one hub may serve sessions from different repositories. The web package therefore builds and serves its own per-session plugin compositions while keeping a stable package-owned shell.
+
+See [DoomPi Web bundling](../packages/clients/doompi-web/docs/bundle.md) for that pipeline and the reasons behind its design.
+
+## Checking synchronized state
+
+Use the read-only check when startup says synchronized state is unavailable:
+
+```bash
+doompi sync --check
+```
+
+Run `doompi sync` to install missing required packages and publish a replacement generation. `dpi sync` builds the same repository-isolated state for the side-by-side runner without persisting a Pi settings overlay.
+
+See [Configuration](configuration.md) for merge rules and [Architecture](architecture.md) for runtime ownership and transition coordination.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,63 +2,82 @@
 
 [Back to DoomPi](../README.md)
 
-## Setup commands
+The commands fall into three paths:
 
-| Command               | Effect                                                                                                                                                                                                      |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dpi init`            | Creates missing `.doom` files in the current repository. It does not change Pi settings.                                                                                                                    |
-| `dpi init --force`    | Replaces the repository's four `.doom` files with the current templates.                                                                                                                                    |
-| `dpi sync`            | Installs required configured packages, builds synchronized state, and prepares an in-memory Pi settings overlay. It does not persist that overlay.                                                          |
-| `dpi`                 | Runs the pinned Pi version with the synchronized DoomPi overlay. Other arguments pass to Pi, except `--sandbox`, which DoomPi handles.                                                                      |
-| `doompi init`         | Creates missing files in `~/.pi/.doom`, writes the DoomPi extension alias and theme, and registers both in Pi user settings.                                                                                |
-| `doompi init --force` | Replaces the four personal `.doom` files, then refreshes the Pi integration resources.                                                                                                                      |
-| `doompi sync`         | Installs required configured packages and publishes synchronized state. Requires the user integration created by `doompi init`; reconciles existing repository Pi settings without rewriting user settings. |
-| `doompi sync --check` | Checks package resolution, configuration drift, synchronized artifacts, the alias, the theme, and Pi settings without writing. It exits non-zero when anything is stale or legacy state needs migration.    |
+```text
+dpi       side-by-side DoomPi without persisted Pi integration
+doompi    explicit DoomPi setup, sync, inspection, and launch harness
+pi        normal Pi command after doompi init registers DoomPi
+```
 
-Both sync commands accept the matrix options below. Generated state lives under `~/.pi/.doom/sync` in a repository- and worktree-specific namespace. After publication, sync retains one superseded generation and attempts to remove older generations. Cleanup failures are reported without failing the published sync.
+Use `dpi` to evaluate the distribution, `doompi init` to make it part of regular Pi startup, and `doompi` when one run needs explicit matrix options.
 
-## Compatibility mode
+## Setup and synchronization
+
+| Command               | Effect                                                                                                            |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `dpi init`            | Creates missing `.doom` files in the current repository without changing Pi settings.                             |
+| `dpi init --force`    | Replaces the repository's four `.doom` files with current templates.                                              |
+| `dpi sync`            | Installs required packages and publishes synchronized state for an in-memory Pi settings overlay.                 |
+| `dpi`                 | Runs pinned Pi with that in-memory overlay. DoomPi handles `--sandbox`; remaining arguments pass to Pi.           |
+| `doompi init`         | Creates missing personal `.doom` files and registers the DoomPi extension alias and theme in Pi settings.         |
+| `doompi init --force` | Replaces the four personal `.doom` files and refreshes the Pi integration resources.                              |
+| `doompi sync`         | Installs required packages and publishes state for the registered integration without rewriting Pi user settings. |
+| `doompi sync --check` | Checks package resolution, drift, artifacts, alias, theme, and Pi settings without writing.                       |
+
+Synchronized state is repository- and worktree-scoped under `~/.pi/.doom/sync`. Publication is atomic and retains one superseded generation. See [Composition and runtime bundling](bundling.md) for the lifecycle.
+
+## Matrix and launch options
+
+The matrix describes the session DoomPi should resolve before Pi starts.
+
+| Option                      | Effect                                                                                 |
+| --------------------------- | -------------------------------------------------------------------------------------- |
+| `--major-mode <name>`       | Select one major mode from `.doom/modes.yaml`.                                         |
+| `--domains <names>`         | Select comma-separated content domains. `--domain` is also accepted.                   |
+| `--no-domains`              | Select no domains. It cannot be combined with `--domains`.                             |
+| `--profile <name>`          | Select a persona and environment profile.                                              |
+| `--mcp`, `--no-mcp`         | Enable or disable MCP configuration for this run.                                      |
+| `--agents`, `--no-agents`   | Enable or disable spawnable agent resources.                                           |
+| `--hooks`, `--no-hooks`     | Enable or disable repository and plugin hooks.                                         |
+| `--plugin-dir <path>`       | Add an explicit plugin directory. Repeat for more than one.                            |
+| `--add-dir <path>`          | Add an accessible directory. Repeat for more than one.                                 |
+| `--cwd <path>`              | Run Pi in the selected directory. `--cd` is also accepted.                             |
+| `--preset <name>`           | Select `default`, `kimi`, or `ollama` provider normalization.                          |
+| `--automation`              | Add Pi print mode, JSON output, and project approval unless already supplied.          |
+| `--auto-stop`               | Exit an interactive session after the agent settles. Rejected in print and JSON modes. |
+| `--sandbox`                 | Run through the sandbox harness exported by a selected layer. `dpi` accepts it too.    |
+| `--allow-protected-writes`  | Permit writes to repository paths DoomPi otherwise protects.                           |
+| `--mute`                    | Disable DoomPi notifications for this run.                                             |
+| `--output-format vibe-lint` | Read one Vibe-Lint request from stdin and write one JSON response.                     |
+| `-h`, `--help`              | Print harness help without resolving the repository.                                   |
+| `-v`, `--version`           | Print the installed package version.                                                   |
+
+Remaining arguments pass to Pi.
+
+## Inspection and generated output
+
+| Option             | Effect                                                                           |
+| ------------------ | -------------------------------------------------------------------------------- |
+| `--explain`        | Print the resolved matrix and estimated prompt cost, then exit.                  |
+| `--emit-mcp <dir>` | Write resolved MCP configuration to a directory, then exit. MCP must be enabled. |
+
+`--explain` is read-only with respect to DoomPi configuration, but it is not a no-execution boundary. Schema inspection can start each allowed stdio MCP server. Add `--no-mcp` when those commands must not run. See [Executable inputs](trust-and-data-boundaries.md#executable-inputs).
+
+## Compatibility frontends
 
 ```bash
 doompi compat <codex|claude|antigravity> [matrix options] [provider arguments]
 ```
 
-Compatibility mode resolves the selected DoomPi matrix, then launches the named frontend. It consumes `--major-mode`, `--domains`, `--domain`, `--profile`, and `--skip-permissions`. Other arguments pass through unchanged. Put `--` before a provider-native option whose name collides with a DoomPi matrix option.
+Compatibility mode resolves the DoomPi matrix and launches the named frontend. It consumes `--major-mode`, `--domains`, `--domain`, `--profile`, and `--skip-permissions`; other arguments pass through. Use `--` before a provider option whose name collides with a DoomPi option.
 
-`--skip-permissions` disables the frontend's approval prompts for that run. It maps to `--dangerously-skip-permissions` for Claude and Antigravity, and `--yolo` for Codex. DoomPi prints a warning to stderr whenever it enables a bypass. See [Approval prompts in compatibility mode](trust-and-data-boundaries.md#approval-prompts-in-compatibility-mode).
-
-## Launch options
-
-| Option                      | Effect                                                                                                                                    |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `--major-mode <name>`       | Selects one major mode from `.doom/modes.yaml`.                                                                                           |
-| `--domains <names>`         | Selects comma-separated content domains. `--domain` is also accepted.                                                                     |
-| `--no-domains`              | Loads no content domains. It cannot be combined with `--domains`.                                                                         |
-| `--profile <name>`          | Selects a persona and environment profile.                                                                                                |
-| `--explain`                 | Resolves the matrix, prints its contents and estimated prompt cost, then exits. MCP schema inspection may start configured stdio servers. |
-| `--emit-mcp <dir>`          | Writes the resolved MCP configuration to a directory, then exits. MCP must be enabled.                                                    |
-| `--mcp`, `--no-mcp`         | Enables or disables MCP configuration for this run. Use `--no-mcp` with `--explain` to avoid starting MCP servers.                        |
-| `--agents`, `--no-agents`   | Enables or disables spawnable agent resources.                                                                                            |
-| `--hooks`, `--no-hooks`     | Enables or disables repository and plugin hooks.                                                                                          |
-| `--plugin-dir <path>`       | Loads an explicit plugin directory. Repeat the option to load more than one.                                                              |
-| `--add-dir <path>`          | Adds an accessible directory. Repeat the option to add more than one.                                                                     |
-| `--cwd <path>`              | Runs Pi in that directory. `--cd` is also accepted.                                                                                       |
-| `--preset <name>`           | Selects `default`, `kimi`, or `ollama` provider normalization.                                                                            |
-| `--automation`              | Adds Pi print mode, JSON output, and project approval unless already supplied.                                                            |
-| `--auto-stop`               | Exits an interactive Pi session after the agent settles. It is rejected in print and JSON modes.                                          |
-| `--sandbox`                 | Runs the session through the sandbox harness exported by a selected layer. `dpi` accepts this option too.                                 |
-| `--allow-protected-writes`  | Allows writes to repository paths that DoomPi otherwise protects.                                                                         |
-| `--mute`                    | Disables DoomPi notifications for this run.                                                                                               |
-| `--output-format vibe-lint` | Reads one vibe-lint request from stdin and writes one JSON response.                                                                      |
-| `-h`, `--help`              | Prints DoomPi harness help without resolving the repository.                                                                              |
-| `-v`, `--version`           | Prints the DoomPi package version.                                                                                                        |
-
-DoomPi forwards remaining launch arguments to Pi. `--explain` is not a no-execution security boundary: it starts each allowed stdio MCP server when it must inspect tool schemas. See [Executable inputs](trust-and-data-boundaries.md#executable-inputs).
+`--skip-permissions` disables the frontend's approval prompts for that run. DoomPi maps it to `--dangerously-skip-permissions` for Claude and Antigravity and `--yolo` for Codex, and prints a warning. Scoping the loaded tools and approving individual actions are separate controls. See [Approval prompts in compatibility mode](trust-and-data-boundaries.md#approval-prompts-in-compatibility-mode).
 
 ## Troubleshooting and direct use
 
-- Run `doompi sync --check` to identify drift or missing configured packages. Run `doompi sync` to install required packages and rebuild state.
-- Runner tries bundled RMUX, `rmux` on `PATH`, then `tmux` on `PATH`. If none is available, non-interactive commands use a supervised subprocess and interactive commands are rejected. Linux native artifacts require a compatible loader and libc environment.
-- Leader menus and overlays require Pi's interactive TUI. Commands and tools remain available in JSON, RPC, and other headless sessions when the owning package supports them.
+- Run `doompi sync --check` to identify drift, then `doompi sync` to install missing packages and publish a replacement generation.
+- Leader menus require Pi's interactive TUI. Commands and tools may remain available in JSON, RPC, and other headless modes when their package supports those modes.
+- Runner tries bundled RMUX, `rmux` on `PATH`, then `tmux` on `PATH`. Without one, non-interactive commands use a supervised subprocess and interactive commands are rejected.
 - Install a directly loaded Pi subsystem with `pi install npm:@agimon-ai/<package>`. Library consumers use `npm install`. Do not install native RMUX or RTK packages directly.
-- The root `doom-runner` command delegates to Runner from the active repository. If Runner is not selected, it asks you to add `@agimon-ai/doompi-runner` to `modes.yaml`.
+- The root `doom-runner` command delegates to Runner from the active repository. If Runner is absent, add `@agimon-ai/doompi-runner` to `modes.yaml`.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,36 +2,46 @@
 
 [Back to DoomPi](../README.md)
 
-## Philosophy
+DoomPi separates two decisions that agent setups often mix together:
 
-An agent does not need every tool for every job. DoomPi separates the base session from
-the things you switch on for a while: modes choose behavior, domains choose subject
-matter, and profiles choose a point of view.
+1. **Composition** decides which executable extensions form the session.
+2. **Context selection** decides which subject matter and point of view are active within that composition.
 
-### Major and minor modes
+```text
+major mode -> extension layers -> executable session shape
+minor modes ------------------> temporary behavior inside the session
+domains ----------------------> skills, agents, hooks, and MCP access
+profile ----------------------> persona text and environment defaults
+```
 
-A major mode is the base config. It names the extension layers for development, marketing,
-or whatever else you do. Define as many as you like; only one is active at a time, and you
-can switch it without leaving the session.
+This separation keeps the base predictable and lets temporary capabilities leave context when the job no longer needs them.
 
-Minor modes are batteries-included switches inside that base. They start off, stack freely,
-and keep their model tools and skills out of context until turned on. DoomPi ships six:
+## Major modes define the base
 
-- **Help mode:** expose package-owned guidance only while you need it.
-- **Plan mode:** remove Pi's file-editing tools while you agree on an approach.
-- **Loop mode:** run a prompt now, then run it again on a schedule.
-- **Goal mode:** keep one objective in view until it is done or dismissed.
-- **Workflow mode:** run jobs with dependencies, timeouts, and artifacts.
-- **Voice mode:** replace typing with local speech.
+A major mode names an ordered list of extension layers. Only one is active at a time. A development mode may include editing and delegation layers; a writing mode may choose a different package graph.
 
-### Domains
+Changing a major mode first resolves the candidate composition. DoomPi then decides whether Pi can reload it or whether the launcher must start a replacement process. In a synchronized session, the candidate must already have a prepared runtime bundle. See [Composition and runtime bundling](bundling.md).
 
-A domain is a named group of agent plugins. It carries the skills and MCP servers for one
-kind of work, and `/domains` switches it while the session is running.
+Major modes answer: **what kind of session is this?**
 
-Plugins are cataloged once and domains refer to their names. A configured root may be a
-Codex-compatible marketplace or a folder whose direct children are plugins, so a repository
-with many plugins does not need one entry per directory:
+## Minor modes change temporary behavior
+
+Minor modes are switches within the current base. They do not define the package graph. The owning packages are already in the composition, but their instructions, tools, or behavior stay inactive until selected.
+
+DoomPi ships these minor modes:
+
+- **Help:** expose package-owned guidance while it is needed.
+- **Plan:** remove Pi's file-editing tools while an approach is agreed.
+- **Loop:** run a prompt now and repeat it on a schedule.
+- **Goal:** keep one objective active until it is completed or dismissed.
+- **Workflow:** run jobs with dependencies, timeouts, and artifacts.
+- **Voice:** use local capture and speech for a hands-free session.
+
+Minor modes answer: **what should this session do for the next part of the work?**
+
+## Domains scope subject-matter capabilities
+
+A domain selects agent plugins for one kind of work. Plugins can contribute skills, agents, hooks, and MCP configuration. The plugin is cataloged once; domains refer to that catalog entry and may enable all or only part of it.
 
 ```yaml
 plugins:
@@ -48,23 +58,17 @@ domains:
     plugins: [pi-development, remote-review]
 ```
 
-DoomPi also checks personal and repository Codex marketplace layouts. Marketplace IDs use
-`plugin@marketplace`. Remote Git and npm sources are downloaded once into the persistent
-`~/.pi/.doom/plugin-cache` directory. Cache entries are reused until their source descriptor
-changes; use a Git SHA or exact npm version for reproducible installs. Home and repository
-catalogs merge, and repository names replace matching home names.
+A root may be a Codex-compatible marketplace, one plugin, or a directory whose direct children are plugins. Discovery is deliberately nonrecursive. A deeply nested tool does not become executable by accident.
 
-A blog is not one task. Research it, draft it, make the assets, then review it. Turn on the
-`visual` domain while making assets; the other three steps have no reason to carry it.
+Home and repository catalogs merge, with repository entries replacing names from home configuration. Remote Git and npm plugins are cached under `~/.pi/.doom/plugin-cache`. Pin a Git SHA or exact npm version when reproducibility matters.
 
-### Profile
+Use `--domains development,review`, an alias configured in `domains.yaml`, or `/domains` in a running session. `--no-domains` gives the session no domain plugin context.
 
-An LLM has no house style until you give it one. A profile can supply a narrative, brand
-rules, or a different voice. It is optional; no profile is a perfectly good profile.
+Domains answer: **which knowledge and external systems belong to this job?**
 
-Profile roots remove the need to list every persona folder. A root may itself contain the
-persona files, or its direct-child folders become profiles named after those folders. DoomPi
-recognizes `profile.md`, `SOUL.md`, and `AGENTS.md` and never searches deeper directories.
+## Profiles supply a point of view
+
+A profile supplies persona files and string environment defaults. It can hold editorial rules, a company narrative, or a review posture. No profile is a valid selection.
 
 ```yaml
 profiles:
@@ -76,17 +80,22 @@ profiles:
         EDITOR_MODE: strict
 ```
 
-Roots from the home and repository files accumulate relative to their declaring config.
-Repository discoveries replace same-named home discoveries. Explicit entries override
-discovery and can add string environment defaults; repository entries replace matching home
-entries. Select one at launch with `--profile editor` or switch with `/profile`.
+A profile root may contain persona files itself or contain direct-child profile directories. DoomPi recognizes `profile.md`, `SOUL.md`, and `AGENTS.md` and concatenates them in that order. Discovery does not recurse.
 
-## Why scope the session
+Explicit entries override discovered profiles. Environment values already exported by the caller win over profile defaults. Select a profile with `--profile editor` or `/profile`.
 
-Every tool schema and skill name consumes context and gives the model another possible choice. A smaller composition uses fewer tokens before work starts and reduces the number of irrelevant tools the model can select. Workflow jobs can choose their own composition instead of inheriting the previous job's toolbox.
+Profiles answer: **from what perspective should the session work?**
 
-### Copilot
+## Why context is scoped
 
-Press `SPC` on an empty draft to open the Leader map. A space typed inside a prompt remains a space. The map shows only commands contributed by the active composition.
+Every tool schema, skill name, and instruction consumes context and creates another action the model might choose. A smaller selection reduces the tokens spent before work starts and removes irrelevant choices. Workflow steps can select their own composition and domains instead of inheriting everything from the dispatching session.
 
-Autonomous Voice mode keeps the session available when typing is impractical. The primary agent can narrate its opening, meaningful milestones, and final answer, subject to the configured capture, transcription, model, and speech engines.
+This is not a security boundary. Removing a capability from model context is different from sandboxing a process or requiring approval. See [Trust and data boundaries](trust-and-data-boundaries.md).
+
+## The interface follows the active composition
+
+Press `SPC` on an empty draft to open the Leader map. It shows commands contributed by the packages active in the current composition. A space inside a nonempty prompt remains ordinary text.
+
+Autonomous Voice mode applies only to its exact active TUI session. It can narrate openings, milestones, and final answers according to the configured capture, transcription, model, and speech engines.
+
+See [Configuration](configuration.md) for definitions and merge behavior, and [Features](features.md) for the packages that implement these concepts.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,14 +2,30 @@
 
 [Back to DoomPi](../README.md)
 
-DoomPi reads four configuration files:
+DoomPi splits configuration by responsibility so package composition, content access, and persona do not become one unreviewable file:
 
-- `config.yaml` defines runtime settings such as trust, editor, planning, and voice behavior.
-- `modes.yaml` defines default packages, extension layers, and major modes.
-- `domains.yaml` catalogs plugins and sets session access.
-- `profiles.yaml` supplies persona files and environment defaults.
+| File            | Architectural role                    | Main question                                                     |
+| --------------- | ------------------------------------- | ----------------------------------------------------------------- |
+| `config.yaml`   | Runtime policy and default selections | How should the host behave?                                       |
+| `modes.yaml`    | Package graph and major modes         | Which extensions form the session?                                |
+| `domains.yaml`  | Plugin catalog and access projection  | Which skills, agents, hooks, and MCP servers belong to this work? |
+| `profiles.yaml` | Persona and environment defaults      | From what point of view should the session work?                  |
 
-DoomPi reads personal defaults from `~/.pi/.doom/` and repository settings from `<repository>/.doom/`. Relative personal paths resolve from `~/.pi/.doom/`; relative repository paths resolve from the repository root. Merge behavior depends on the file and field, so the sections below state it explicitly.
+```text
+~/.pi/.doom/* personal defaults
+           +
+<repository>/.doom/* local policy
+           |
+           v
+validated resolved configuration
+           |
+           +-- composition -> runtime bundle
+           +-- selections  -> session context and access
+```
+
+Personal configuration is read first; the nearest repository configuration is applied second. Repository values are not an unrestricted deep merge. Some records replace by name, some fields merge, and some values are personal-only. Those rules keep local policy explicit and prevent a repository from silently inheriting or replacing sensitive personal settings.
+
+Relative personal paths resolve from `~/.pi/.doom/`. Relative repository paths resolve from the repository root. Invalid values and unknown keys fail during configuration loading rather than being ignored. See [Composition and runtime bundling](bundling.md) for what happens after configuration resolves.
 
 ## `config.yaml`: set runtime policy
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,34 +2,73 @@
 
 [Back to DoomPi](../README.md)
 
-Run these commands from the repository root:
+DoomPi is a package graph, not one application build. Nx owns that graph: a package target builds its dependencies first, while repository-wide targets validate the complete distribution.
+
+```text
+package source
+     |
+     +-- package lint, typecheck, build, test
+     |
+     +-- architecture preflight
+     |
+     +-- workspace and example checks
+     |
+     +-- packed-install system tests for release behavior
+```
+
+Run commands from the repository root. See [CONTRIBUTING.md](../CONTRIBUTING.md) for package boundaries, the required workflow, commit rules, and pull-request guidance.
+
+## Local setup
 
 ```bash
 pnpm install
-pnpm build
-pnpm examples:check
-pnpm nx build @agimon-ai/doompi
-pnpm nx test @agimon-ai/doompi
-pnpm nx typecheck @agimon-ai/doompi
-pnpm nx lint @agimon-ai/doompi
 ```
 
-`pnpm build` builds every workspace project through Nx. The four targeted commands then build, test, type-check, and lint the root runtime package.
+Node.js and pnpm versions are pinned in the root package metadata. Installation also materializes the pinned Runner native payloads and builds the repository-owned Vibe-Lint plugins.
 
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for repository boundaries, required checks, commit rules, and pull-request guidance.
+## Work on one package
+
+Run the package's four standard targets:
+
+```bash
+pnpm nx lint @agimon-ai/doompi
+pnpm nx typecheck @agimon-ai/doompi
+pnpm nx build @agimon-ai/doompi
+pnpm nx test @agimon-ai/doompi
+```
+
+Replace the project name with the package being changed. Before editing governed files, inspect their architecture rules with `pnpm vibe-lint check --rules-only <paths>`. After the change, run `pnpm lint:vibe --preflight-only`.
+
+Use the extra check that matches the contract being changed:
+
+- `pnpm examples:check` for plugin, domain, marketplace, or workflow examples
+- `pnpm audit:workspace` for dependencies, package metadata, or workspace structure
+- `pnpm test:system` for packaging, startup, or release-facing behavior
+
+`pnpm build` builds the complete workspace through Nx. Prefer the affected package targets during iteration, then widen validation when the change crosses package boundaries.
+
+## Why packed tests are separate
+
+Unit tests run against workspace source and built dependencies. Packed-install tests create npm tarballs, install the packages, and exercise the published entry points. They catch missing resources, incorrect export maps, workspace-only imports, and startup behavior that ordinary workspace resolution can hide.
+
+The serial system suite also measures startup paths. Run it before a release-affecting change rather than on every small edit.
+
+## Release architecture
+
+DoomPi uses one independent `alpha` release group in `nx.json`. The group includes the root runtime, fixed core, selectable features, clients, web packages, Runner native payloads, and repository-owned lint plugins.
+
+The group is released together because a consumer composition crosses those package boundaries. Hand-publishing a short subset can leave synchronized manifests, workspace contracts, or native payload versions inconsistent.
 
 ## Maintainer release flow
 
-DoomPi uses the independent `alpha` release group in `nx.json`. Do not hand-publish a short package subset: the group includes the root runtime, fixed core, selectable features, clients, native Runner payloads, web packages, and repository-owned lint plugins. Workspace dependencies determine the build graph, and the release workflow publishes the selected versions under the `alpha` tag.
-
-The release-cut workflow selects affected release projects, runs the full candidate validation, and previews or writes the prerelease versions. After the release pull request merges, the publish workflow:
+The release-cut workflow selects affected release projects, runs candidate validation, and previews or writes prerelease versions. After its pull request merges, the publish workflow:
 
 1. verifies Runner payloads;
-2. runs the workspace audit, formatting check, build, examples check, lint, architecture preflight, typecheck, tests, and packed-install system tests;
-3. publishes versions missing from npm under `alpha` with `pnpm nx release publish`;
-4. waits for every release version to appear under `alpha`, then creates its Git tag; and
+2. runs workspace audit, formatting, build, examples, lint, architecture preflight, typecheck, unit tests, and packed-install system tests;
+3. publishes npm versions that do not yet exist under the `alpha` tag;
+4. waits for each version to become visible, then creates its Git tag; and
 5. promotes the published versions to `latest`.
 
-Generated changelogs remain owned by Nx release tooling. See the [release-cut workflow](../.github/workflows/release-cut.yml) and [publish workflow](../.github/workflows/release-publish.yml) for the executable contract.
+Generated changelogs belong to Nx release tooling. The executable contract lives in the [release-cut workflow](../.github/workflows/release-cut.yml) and [publish workflow](../.github/workflows/release-publish.yml).
 
 DoomPi is maintained by [Agimon](https://agimon.ai/about).

--- a/docs/features.md
+++ b/docs/features.md
@@ -2,10 +2,21 @@
 
 [Back to DoomPi](../README.md)
 
-DoomPi is a distribution, not one giant extension. Each package owns one job; shared TUI,
-Cordis services, and session contracts make them behave like one. Use the generated
-`default.packages` list together, remove packages you do not want, or replace its entries one
-at a time. Selectable packages are not runtime dependencies of the root package or of one another.
+DoomPi is a distribution of small Pi extensions, not one extension with every feature inside it. Package boundaries are capability boundaries: each package owns its state, UI, tools, and cleanup; neutral Cordis contracts let packages collaborate without importing one another's implementations.
+
+```text
+fixed host
+  configuration, lifecycle, selection, contracts, shared UI
+        |
+        +-- default packages     ordinary distribution capabilities
+        +-- named layers        selectable composition changes
+        +-- minor-mode packages behavior activated inside a composition
+        +-- client packages     standalone server and browser processes
+```
+
+Selectable packages are not runtime dependencies of the root package or of one another. This lets a repository remove or replace one feature without rebuilding the host's private dependency graph. Use the generated `default.packages` list as the supported distribution, then remove entries or move them into named layers when a smaller composition is more useful.
+
+The catalog below is grouped by architectural role rather than npm location. See [Composition and runtime bundling](bundling.md) for how selected packages become a Pi runtime, and [Architecture](architecture.md) for their service lifecycle.
 
 ## Foundation and interface
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,69 +2,92 @@
 
 [Back to DoomPi](../README.md)
 
-## Install
+DoomPi can run beside an existing Pi setup or become the extension configuration used by the regular `pi` command. Start with the side-by-side path. It gives you the same composition and synchronized runtime without changing Pi's persisted settings.
 
-```bash
-npm install -g @agimon-ai/doompi
+## What installation adds
+
+```text
+@agimon-ai/doompi
+        |
+        +-- pinned Pi used by dpi
+        +-- fixed DoomPi host
+        +-- configuration and sync commands
+
+repository .doom files
+        |
+        +-- selectable feature packages installed when needed
 ```
 
-The package pins and installs the upstream Pi version used by `dpi`.
+The root package contains the fixed host foundation. Features named in `.doom/modes.yaml` remain separate packages and resolve from the consumer repository. This keeps the host stable while each repository chooses its own composition.
 
-The root package contains the fixed host foundation only. Feature packages are selected by
-`.doom/modes.yaml` and installed into the consumer repository when they are first needed.
-
-## Status and requirements
-
-DoomPi is alpha software. Configuration and package boundaries may still change between alpha
-releases.
+## Requirements
 
 - Node.js 22.19.0 or newer for the published package
 - Node.js 22.22.1 or newer when contributing from this workspace
 - macOS or Linux on arm64 or x64 for the bundled Runner backend
 - Pi 0.85.0 and Pi TUI 0.85.0 for packages that declare them as peer requirements
 
-## Try DoomPi without replacing your Pi setup
+DoomPi is alpha software. Configuration and package boundaries may change between alpha releases.
 
-`dpi` is the comparison runner. Use it to try DoomPi beside your current `pi` customization
-before registering anything in Pi's settings:
+## Install
 
 ```bash
-dpi init    # create missing .doom files in this repository
-dpi sync    # install required packages and build synchronized state
-dpi         # run the pinned Pi version with an in-memory settings overlay
+npm install -g @agimon-ai/doompi
+```
+
+The package pins the Pi version used by `dpi`.
+
+## Try it without replacing Pi
+
+Run these commands inside a repository:
+
+```bash
+dpi init    # create missing repository .doom files
+dpi sync    # install configured packages and publish synchronized state
+dpi         # run pinned Pi with an in-memory DoomPi settings overlay
 pi          # run your existing Pi setup for comparison
 ```
 
-`dpi init` creates `.doom/config.yaml`, `.doom/modes.yaml`, `.doom/domains.yaml`, and
-`.doom/profiles.yaml` in the current repository. It preserves existing files unless you pass
-`--force` and does not create or change `.pi/settings.json`.
+`dpi init` creates `.doom/config.yaml`, `.doom/modes.yaml`, `.doom/domains.yaml`, and `.doom/profiles.yaml`. It preserves existing files unless `--force` is present and does not change `.pi/settings.json`.
 
-`dpi sync` installs missing required feature packages and publishes generated state for the in-memory settings overlay. It does not rewrite Pi user settings, the global extension alias, or the user theme. Sync provisions every declared layer, so switching to a prepared mode does not depend on the root package's private dependencies.
+`dpi sync` resolves the repository composition, installs required feature packages, and publishes an immutable runtime generation. It provisions every declared layer so a prepared mode switch does not depend on the root package's private dependencies. See [Composition and runtime bundling](bundling.md) for the build and publication model.
 
-### Sync storage and worktrees
+`dpi` keeps Pi's existing global and repository settings, then applies the DoomPi extension and theme overlay in memory. It does not persist that overlay.
 
-DoomPi stores generated sync state under `~/.pi/.doom/sync`, outside the repository. Each
-Git worktree gets isolated runtime state while immutable build artifacts may be shared.
+## Where synchronized state lives
 
-`dpi` preserves Pi's normal global and repository settings, then applies DoomPi's extension
-and theme settings in memory. It never writes those values to `.pi/settings.json`.
+Generated state lives under `~/.pi/.doom/sync`, outside the repository. Registrations are scoped by repository and Git worktree. Two worktrees can select different compositions without sharing mutable runtime state, while immutable compiler output may still be reused.
 
-Use `dpi sync --check` to detect stale state during the side-by-side experiment, and `dpi sync`
-to rebuild it. After permanent registration, use `doompi sync --check` and `doompi sync`.
-
-When you are comfortable with DoomPi and no longer need the side-by-side experiment, register
-it for normal Pi:
+Check state without writing:
 
 ```bash
-doompi init    # seed ~/.pi/.doom and register the extension alias and theme
-doompi sync    # publish synchronized state using the registered integration
-pi             # start DoomPi through the regular Pi command
+dpi sync --check
 ```
 
-`doompi` remains available as an explicit harness when you want per-run matrix flags:
+Run `dpi sync` again when the check reports drift.
+
+## Register DoomPi with Pi
+
+Once the comparison setup behaves as expected:
+
+```bash
+doompi init    # seed personal config and register the extension alias and theme
+doompi sync    # publish synchronized state for the registered integration
+pi             # start DoomPi through regular Pi
+```
+
+`doompi init` owns the personal configuration and Pi integration. `doompi sync` updates generated runtime state but does not rewrite that integration. After registration, use `doompi sync --check` and `doompi sync` instead of their `dpi` forms.
+
+## Inspect a composition before launch
+
+The explicit `doompi` harness accepts per-run selections:
 
 ```bash
 doompi --major-mode copilot --no-domains
 doompi --major-mode minimal --no-domains
 doompi --major-mode copilot --no-domains --explain
 ```
+
+`--explain` prints the resolved mode, domains, profile, plugins, skills, agents, MCP boundary, and estimated prompt cost. MCP schema inspection can start configured stdio servers. Add `--no-mcp` when inspection must not execute them.
+
+Next, read [Concepts](concepts.md) for the selection model and [Configuration](configuration.md) for the four files and their merge rules.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,11 +2,35 @@
 
 [Back to DoomPi](../README.md)
 
-DoomPi Log keeps current-session metrics in the Pi process. A local Log Sink is optional and adds persistent history and trace lookup. DoomPi does not ship a collector, dashboard, or remote telemetry endpoint.
+DoomPi separates live metrics from retained telemetry:
 
-Run the commands below from the repository root. The package filter is intentional: `log-sink-mcp` is a packaged dependency of `@agimon-ai/doompi-log`, not a root executable.
+```text
+Pi and browser events
+        |
+        v
+DoomPi Log in the Pi process ------> current-session counters and findings
+        |
+        +-- optional OTLP export --> Log Sink or configured collector
+                                          |
+                                          +-- persistent metrics and trace lookup
+```
 
-## Start, inspect, and stop a local sink
+The in-process view works without a collector. A Log Sink adds history. DoomPi ships neither a vendor collector nor a hosted dashboard, and it drops export when no endpoint is configured unless file fallback is explicitly enabled.
+
+## What each layer owns
+
+| Layer                   | Lifetime                 | Purpose                                                             |
+| ----------------------- | ------------------------ | ------------------------------------------------------------------- |
+| DoomPi Log              | Current Pi process       | Aggregate session counters, usage, failures, and findings           |
+| Browser telemetry route | Current web hub          | Validate and forward bounded cockpit performance and failure events |
+| Log Sink                | Background local process | Retain records and answer metrics or trace queries                  |
+| External OTLP endpoint  | Operator-defined         | Export records outside DoomPi's local processes                     |
+
+Repository-local instance selection keeps development histories separate. It is a routing convention, not an access-control boundary.
+
+## Run a local sink
+
+Run these commands from the repository root. The package filter matters because `log-sink-mcp` is a packaged dependency of `@agimon-ai/doompi-log`, not a root executable.
 
 ```bash
 pnpm --filter @agimon-ai/doompi-log exec log-sink-mcp start
@@ -14,22 +38,20 @@ pnpm --filter @agimon-ai/doompi-log exec log-sink-mcp status
 pnpm --filter @agimon-ai/doompi-log exec log-sink-mcp stop
 ```
 
-The default instance is scoped to the current repository. Run all lifecycle and query commands from the same repository so they resolve the same instance. By default, records persist in `./logs/session.db`. `status` prints the resolved instance, process, port, health URL, and database path.
+The default instance is scoped to the current repository and persists records in `./logs/session.db`. Run lifecycle and query commands from the same repository so they resolve the same instance. `status` prints the process, port, health URL, database path, and resolved instance.
 
-After the sink starts, launch DoomPi normally. In Pi, `/log-metrics` and `SPC h l` both open Log Metrics. Headline counters and findings are aggregated in-process even without a sink. Historical top-consumer and token-burn panels require sink data.
+After the sink starts, launch DoomPi normally. `/log-metrics` and `SPC h l` open the live metrics view. Headline counters work without a sink; historical top-consumer and token-burn panels require retained records.
 
-Query the repository-local database directly:
+Query the local database:
 
 ```bash
 pnpm --filter @agimon-ai/doompi-log exec log-sink-mcp logs metrics --service pi --group-by agent
 pnpm --filter @agimon-ai/doompi-log exec log-sink-mcp logs trace <trace-id>
 ```
 
-`logs metrics` reports workflow, token, failure, and per-tool consumption metrics. `logs trace` prints the chronological records for one trace ID. Add `--global` only when the writer and query are intentionally configured to use the shared global instance.
+`logs metrics` groups workflow, token, failure, and tool consumption. `logs trace` prints one trace chronologically. Add `--global` only when both writer and reader intentionally use the shared global instance.
 
-## Disposable smoke workflow
-
-Use an in-memory sink when checking startup and ingestion without creating `./logs/session.db`:
+## Smoke-test ingestion without persistence
 
 ```bash
 pnpm --filter @agimon-ai/doompi-log exec log-sink-mcp start --in-memory --port 3100
@@ -41,42 +63,44 @@ curl --fail --request POST http://127.0.0.1:3100/logs \
 pnpm --filter @agimon-ai/doompi-log exec log-sink-mcp stop
 ```
 
-The in-memory database belongs to the background sink process and disappears when it stops. Use the persistent default workflow when testing `logs metrics`, `logs trace`, or historical Pi panels across separate CLI processes.
+The in-memory database belongs to the sink process and disappears when it stops. Use the persistent workflow when testing history across separate CLI processes.
 
-## Disable controls
+## Browser telemetry
 
-Set either control before starting Pi:
+The cockpit posts events to `POST /api/telemetry/browser`; the hub records them under the `doom-web` service. The route accepts at most 60 batches per minute and 10 events per batch. Any invalid event rejects the complete batch.
+
+Only two shapes are accepted:
+
+- Performance events use six fixed names: `web.browser.ready`, `web.browser.protocol_ready`, `web.browser.session_socket_ready`, `web.browser.reconnect`, `web.browser.backlog`, and `web.browser.telemetry_drop`. They carry one bounded duration or count.
+- Failure events use `web.browser.error` with a fixed source, error name, bounded message, optional bounded stack, and optional session ID.
+
+Query browser records with:
+
+```bash
+pnpm --filter @agimon-ai/doompi-log exec log-sink-mcp logs query --service doom-web --limit 20
+```
+
+## Disable collection or export
+
+Set controls before starting Pi:
 
 ```bash
 AGENT_TELEMETRY_DISABLED=1 doompi
 OTEL_SDK_DISABLED=1 doompi
 ```
 
-`AGENT_TELEMETRY_DISABLED` disables DoomPi's Pi telemetry extension for that process. `OTEL_SDK_DISABLED` disables OpenTelemetry SDK export globally for that process. When metrics collection is disabled, `/log-metrics` and `SPC h l` show the disabled state rather than zero activity. `AGENT_OTEL_TRACES` controls span export separately, so disabling traces alone does not disable logs.
+`AGENT_TELEMETRY_DISABLED` disables DoomPi's Pi telemetry extension. `OTEL_SDK_DISABLED` disables OpenTelemetry SDK export for the process. The metrics UI reports that collection is disabled rather than showing zero activity. `AGENT_OTEL_TRACES` controls span export separately, so disabling traces alone does not disable logs.
 
-## Cockpit browser telemetry
+## Data boundary
 
-The web cockpit posts its own events to `POST /api/telemetry/browser` on the DoomPi Web server, which records them under the `doom-web` service. The route is rate limited to 60 batches per minute, accepts at most 10 events per batch, and rejects a whole batch when any event fails validation.
+Operational telemetry is not harmless merely because prompts are omitted:
 
-Two event shapes are accepted and nothing else:
+- Prompts, tool inputs, and results are omitted by default. `AGENT_OTEL_REDACT=0` includes them and may expose source, commands, credentials, and model content.
+- Records can still include session identifiers, working directory, model, tool names, token and cost totals, errors, workflow identity, and caller-supplied attributes.
+- Browser errors carry bounded free-text message and stack fields. Stack text can contain bundle paths and function names. Session IDs are hashed for correlation.
+- `./logs/session.db` outlives Pi. Protect, rotate, or remove it according to repository policy.
+- A local sink is not a sandbox. Processes that can read the repository or connect to the sink can read its records.
+- `LOG_SINK_PI_FILE_FALLBACK=1` creates another local retention surface when no endpoint exists.
+- Standard OTLP environment variables and `LOG_SINK_ENDPOINT` can route records elsewhere. Inspect the launch environment before assuming data stays local.
 
-- Performance events, a closed set of six names (`web.browser.ready`, `web.browser.protocol_ready`, `web.browser.session_socket_ready`, `web.browser.reconnect`, `web.browser.backlog`, `web.browser.telemetry_drop`) carrying only a bounded `duration_ms` or `count`.
-- Failure events, all under the single name `web.browser.error`, carrying a `source` from a closed set (`window_error`, `unhandled_rejection`, `session_socket`), an `error_name`, a `message`, an optional `stack`, and an optional `session_id`. These are recorded at error level, so `logs agent-issues` and any error-severity query surface them.
-
-Query them with the service filter:
-
-```bash
-pnpm --filter @agimon-ai/doompi-log exec log-sink-mcp logs query --service doom-web --limit 20
-```
-
-## Privacy and data boundaries
-
-- Prompts, tool inputs, and tool results are omitted by default. `AGENT_OTEL_REDACT=0` includes them and can expose source, commands, credentials, or model content.
-- Operational metadata can still be sensitive. Records can include session and parent-session IDs, working directory, model, tool names, token and cost totals, errors, workflow identity, and caller-supplied attributes.
-- Cockpit failure events are the one browser payload that carries free text. The `message` is capped at 300 characters and the optional `stack` at 800, and a stack contains bundle paths and function names from the page. Both are recorded as the log record's exception, not as attributes, so they are exempt from attribute sanitisation by design. The `session_id` is hashed into the same `id_` form the agent uses, which is what lets a browser failure be correlated with the session that produced it.
-- A default local sink writes to `./logs/session.db` and retains data after Pi exits. Protect, rotate, or remove that file according to the repository's data policy. `--in-memory` avoids this persistence.
-- Local scope is an instance-selection rule, not a security sandbox. Processes with access to the repository or local sink can read its records.
-- Without a configured or discovered endpoint, export is dropped by default. `LOG_SINK_PI_FILE_FALLBACK=1` opts into file fallback and therefore creates another local retention surface.
-- DoomPi configures no vendor collector. Standard OTLP endpoint environment variables or `LOG_SINK_ENDPOINT` can route data elsewhere, so inspect the launch environment before assuming records stay local.
-
-See [Trust and data boundaries](trust-and-data-boundaries.md#telemetry) for the repository-wide telemetry boundary.
+See [Trust and data boundaries](trust-and-data-boundaries.md#telemetry) for the repository-wide policy.

--- a/docs/securities.md
+++ b/docs/securities.md
@@ -2,11 +2,18 @@
 
 [Back to DoomPi](../README.md)
 
-This document explains DoomPi's threat model, remote-access controls, containment boundary, and known limits. [Trust and data boundaries](trust-and-data-boundaries.md) inventories what happens to credentials, commands, model traffic, and telemetry.
+A DoomPi agent may have shell access. The security architecture therefore separates four questions:
 
-## The premise
+```text
+Who can reach the listener?  -> listener, Host, and Origin policy
+Which device may act?        -> host-approved pairing and device session
+What can the relay read?     -> signed assets and sealed application traffic
+What can the agent reach?    -> optional container and mounted workspaces
+```
 
-A DoomPi agent has a shell. Security controls therefore answer two separate questions: who may ask the agent to act, and what the agent can reach. Authentication controls the first. Containment controls the second. Enabling either one does not enable the other.
+These controls compose, but none substitutes for another. Authentication decides who may ask the agent to act. Sealing limits what a tunnel provider can read or change after bootstrap. Containment limits which host resources the agent can reach. A paired and encrypted session is still dangerous when it controls an uncontained shell.
+
+This guide starts with the threat model, then follows a remote request from listener classification through device proof, transport protection, and containment. [Trust and data boundaries](trust-and-data-boundaries.md) inventories executable inputs, credentials, model calls, voice, native binaries, and telemetry.
 
 ## Threat model
 
@@ -41,14 +48,14 @@ These checks address browser-driven requests; they do not authenticate a hostile
 ## The listener is the boundary
 
 One Hono app runs behind two sockets. The loopback listener is open to whoever already has an
-account on this machine. The tunnel listener faces the public internet, and everything arriving
-there must prove it holds a paired session.
+account on this machine. The tunnel listener faces the public internet. Except for the exact bootstrap
+allowlist below, every request arriving there must prove it holds a paired session.
 
 The discriminator is the socket a request arrived on, read from the connection's own local port. It
 cannot be a header: `cloudflared` connects from `127.0.0.1` exactly like every local client, and
 there is no header a remote caller cannot set. It is phrased as allow-only-if-provably-local, so a
-missing value, an unreadable port, or a socket torn down mid-request all resolve to `tunnel` and
-therefore require a credential. The mirror-image phrasing fails open on every one of those.
+missing value, an unreadable port, or a socket torn down mid-request all resolve to `tunnel` and are
+subjected to tunnel policy. The mirror-image phrasing fails open on every one of those.
 
 The guard is the first middleware on the app. Hono composes matching handlers in registration order,
 so a guard added after a terminating handler never runs for that path.
@@ -101,10 +108,9 @@ escape hatch, not part of the boundary.
 The host mints a 256-bit code and shows it as a QR. It is good for two minutes, is consumed by the
 first claim, and is retired the moment a new one is minted.
 
-Scanning does not pair anything. It raises a request the host must approve, on the host's own screen,
-within three minutes. An approved request stays collectable for twice that window, so a host
-approving in the last second still reaches the phone's next poll, and it can be collected exactly
-once.
+Scanning does not pair anything. It raises a request the host must approve on the host's own screen within three minutes. An approved request stays collectable for twice that window, so an approval in the last second still reaches the phone's next poll. It can be collected once.
+
+The status poll carries its request ID in the query string. That ID can redeem an approved request, so it is a short-lived credential and may appear in proxy or edge logs. Keep those logs inside the same trust boundary.
 
 Guessing is not the threat at 256 bits; a scripted attempt being quiet is. Ten wrong codes a minute
 is the limit, so the eleventh is refused, and fifty failures across the life of a tunnel close the
@@ -115,11 +121,9 @@ Any local process can reach the tunnel listener directly and set that header to 
 
 ### Sessions
 
-Redeeming an approved request mints a 256-bit token. Only its SHA-256 is retained, so the store is
-useless to anyone who reads it. It travels as `__Host-doompi_device`, and the prefix is the point:
-the browser refuses the cookie unless it is `Secure`, `Path=/`, and `Domain`-less, so no sibling
-subdomain can read or overwrite it. `Secure` is a constant in the code rather than derived, because
-`cloudflared` forwards plaintext and `x-forwarded-proto` is attacker-controllable.
+Redeeming an approved request mints a 256-bit token. Only its SHA-256 is retained. The browser receives the token in `__Host-doompi_device`, an `HttpOnly`, `Secure`, `SameSite=Lax` cookie with `Path=/` and no `Domain`. The prefix makes the browser enforce the Secure, Path, and Domain constraints. `Secure` is constant rather than derived because `cloudflared` forwards plaintext and `x-forwarded-proto` is attacker-controlled.
+
+The cookie is a bearer credential. `HttpOnly` prevents browser JavaScript from reading it, but same-origin code can still send requests with it. Origin checks, signed code delivery, and device revocation therefore remain part of the boundary.
 
 Session expiry is off by default. While it is off, the server accepts a paired session until the device is revoked or remote access is disabled; the browser cookie still has a thirty-day ceiling. When expiry is enabled, the configured idle and absolute limits both apply. Disabling remote access revokes every device, closes remote sockets, and clears pending pairing state.
 
@@ -137,9 +141,15 @@ detectable.
 
 ### Step-up
 
-Three actions ask for a fresh gesture on top of a live session, because each one widens what the
-session can reach: `provider.login`, `provider.logout`, and `session.create`. The assertion travels
-in `x-doompi-assertion` and its challenge is good for sixty seconds.
+A fresh passkey gesture is required for actions that widen machine access even when the device cookie is valid:
+
+- `provider.login` and `provider.logout`
+- `session.create`
+- `settings.write`
+- `mcp.discover` and `mcp.authorize`
+- `computer-use.activate`
+
+The assertion travels in `x-doompi-assertion`; its challenge is valid for sixty seconds. Ordinary prompting and tool approval remain on the device-session boundary. Quick tunnels cannot supply a stable relying-party ID, so passkey enrollment and step-up are unavailable there.
 
 ## Keeping the relay out of it
 
@@ -170,10 +180,9 @@ URLs, not Cache Storage, IndexedDB, signatures, or Push payloads.
 
 ### The payload is sealed
 
-The QR carries an ephemeral P-256 public key alongside the pairing code, in the URL fragment, which
-no browser sends to any server. The device completes an ECDH against it and both sides derive
-AES-256-GCM keys through HKDF-SHA256, separately per direction. Socket frames and API bodies then
-travel as ciphertext.
+The QR carries an ephemeral P-256 public key alongside the pairing code, in the URL fragment, which no browser sends to a server. The device completes ECDH against it and both sides derive AES-256-GCM keys through HKDF-SHA256, separately per direction.
+
+After channel establishment, session and protocol socket frames travel as ciphertext. Ordinary remote HTTP calls use the sealed HTTP gateway, which encrypts the request and response payloads. Pairing, passkey ceremonies, PWA bootstrap assets, and channel establishment are intentionally unsealed because they are needed before a sealed channel exists.
 
 Nonces are twelve bytes: a four byte random prefix and an eight byte counter. At 2^32 messages the
 channel refuses to seal any more rather than reusing a nonce, which for AES-GCM is the failure that

--- a/docs/trust-and-data-boundaries.md
+++ b/docs/trust-and-data-boundaries.md
@@ -2,7 +2,20 @@
 
 [Back to DoomPi](../README.md)
 
-This document inventories what DoomPi does with executable configuration, credentials, commands, model traffic, native binaries, voice data, and telemetry. The [Security model](securities.md) explains the threat model and the boundaries around a cockpit reachable from another device.
+DoomPi crosses several trust boundaries because it composes executable plugins, launches tools, and can move a session into another process or container. The useful question is not whether an input is called configuration. It is **where its code runs, which credentials cross with it, and where its output is retained**.
+
+```text
+configured code and commands
+          |
+          v
+host Pi process --------------------> model providers
+          |
+          +-- optional sandbox -----> brokered credentials and network
+          +-- Runner ---------------> native multiplexer and log tools
+          +-- telemetry ------------> local sink or configured OTLP endpoint
+```
+
+This guide follows those crossings. It distinguishes containment from convenience, credential brokering from process isolation, and collection from export. The [Security model](securities.md) applies the same method to a cockpit reachable from another device.
 
 ## Executable inputs
 

--- a/packages/clients/doompi-desktop/README.md
+++ b/packages/clients/doompi-desktop/README.md
@@ -1,91 +1,48 @@
-# @agimon-ai/doompi-desktop
+# DoomPi Desktop
 
-Run DoomPi in an Electron window backed by the web cockpit and session server. The packaged app
-includes its Node runtime and agent, so users do not need Node.js, pnpm, or a source checkout.
+DoomPi Desktop packages the DoomPi cockpit as an Electron application. It is a desktop shell over the same hub, session-server, web, and agent architecture used by the command-line cockpit. Electron owns application startup and the native window. It does not replace the hub or introduce a separate session model.
 
-This workspace-private package builds desktop release artifacts, not an npm package. It declares
-no public package exports and is not a Pi extension.
+The package is workspace-private. It produces macOS arm64 and Linux x64 release artifacts rather than a published npm library.
 
-## How it works
+## Run from the workspace
 
-The app is a thin shell around the cockpit that already exists.
-
-```
-Electron main
-  |- spawns the staged cockpit with ELECTRON_RUN_AS_NODE=1
-  |    |- spawns doompi-server per session
-  |         |- spawns the agent
-  '- BrowserWindow -> http://127.0.0.1:7433
-```
-
-The shell owns process startup, the window, and runtime staging:
-
-**The runtime is this app's own binary.** Electron is Node when `ELECTRON_RUN_AS_NODE`
-is set, and the variable is inherited, so one assignment on the cockpit's
-environment reaches the session server and the agent below it. No second Node
-ships, and no code in `doompi-web`, `doompi-server` or `doompi` core knows it is
-running inside a desktop app.
-
-**The window loads loopback HTTP, not bundled files.** The cockpit builds every
-socket URL from `location`, so a `file://` or custom-scheme origin would break
-its transport, and the service worker would not register. `http://127.0.0.1` is
-a trustworthy origin to Chromium, so everything keeps working unchanged, and the
-same bundle is still served to a remote paired browser.
-
-**The runtime is a build artifact, not a deployed package tree.** Vite bundles
-the cockpit, server, agent, and workspace JavaScript into `build/runtime`. Its
-runtime plugin copies the built web assets, RMUX and RTK payloads, platform-native
-addons, and the scoped browser package graph needed to compose user plugins. The
-runtime build also downloads a pinned, checksum-verified `cloudflared` binary so
-remote access works without a separate system install. It never walks or ships
-the general workspace `node_modules` tree.
-
-## Layout
-
-| Path                              | Purpose                                              |
-| --------------------------------- | ---------------------------------------------------- |
-| `src/bin/main.ts`                 | Electron entry: lifecycle, single-instance lock, IPC |
-| `src/bin/preload.ts`              | The whole renderer bridge, deliberately two members  |
-| `src/adapters/hubProcess.ts`      | Starts, health-checks and stops the cockpit          |
-| `src/adapters/mainWindow.ts`      | Window creation and navigation confinement           |
-| `src/services/hubLaunch.ts`       | Pure path, environment and socket-budget logic       |
-| `vite.runtime.config.ts`          | Bundles the child-process runtime artifact           |
-| `scripts/desktopRuntimePlugin.ts` | Copies composition assets and native payloads        |
-| `scripts/downloadCloudflared.mjs` | Stages the pinned remote-access tunnel binary        |
-| `scripts/signHubBinaries.cjs`     | Signs native binaries before the app is signed       |
-
-## Commands
-
-Run from the repository root after installing workspace dependencies:
+From the repository root:
 
 ```bash
-pnpm nx run @agimon-ai/doompi-desktop:build     # compile main and preload
-pnpm --filter @agimon-ai/doompi-desktop build:runtime # bundle the child runtime
-pnpm --filter @agimon-ai/doompi-desktop start   # build the artifact and run locally
-pnpm nx run @agimon-ai/doompi-desktop:package   # produce installers
-pnpm --filter @agimon-ai/doompi-desktop test
+pnpm install
+pnpm cockpit:build
+pnpm --filter @agimon-ai/doompi-desktop start
 ```
 
-## State
+The desktop process starts a cockpit on loopback, waits for its health endpoint, and loads that HTTP origin in the application window. It prefers port `7433` and selects a free ephemeral port when that port is unavailable.
 
-The app shares `~/.doompi/run` with the CLI rather than using
-`app.getPath('userData')`, so a session started here is visible to `doompi` in a
-terminal and the other way round. `DOOMPI_RUNTIME_DIR` overrides it. Startup
-checks that the registry path leaves room for session sockets and refuses paths that exceed its
-socket-path budget before starting a session.
+For development, tests, and release packaging, see [Getting started](./docs/getting-started.md).
 
-## Limits
+## Architecture
 
-The staged runtime does not make agents isolated from the host. Sessions retain the filesystem
-and command access of the user running the app. Remote access uses the cockpit's pairing and
-transport controls; see [the cockpit README](../doompi-web/README.md#remote-access).
+```text
+Electron main process
+  ├─ BrowserWindow + minimal preload API
+  └─ packaged cockpit process
+       └─ hub
+          └─ session server
+             └─ agent process
+```
 
-Local installer builds do not verify release signing, notarization, or every target platform.
+The application stages the existing web client, server, DoomPi runtime, native helpers, and package resources into a release runtime. The cockpit child runs with Electron's executable in Node mode, so the release does not carry another Node executable.
 
-## Signing
+Sessions use the normal DoomPi runtime directory, `~/.doompi/run` by default or `DOOMPI_RUNTIME_DIR` when configured. Desktop and command-line clients therefore discover the same session registry.
 
-macOS builds are Developer ID signed and notarized in CI from
-`APPLE_CERTIFICATE_P12_BASE64`, `APPLE_CERTIFICATE_PASSWORD`,
-`APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD` and
-`APPLE_TEAM_ID`. Without an identity, electron-builder still produces unsigned
-artifacts, so local builds work with no credentials. Linux ships unsigned.
+Read [Architecture](./docs/architecture.md) for process ownership and lifecycle details. Read [Runtime and packaging](./docs/runtime-and-packaging.md) for the staged runtime, signing, and artifact model.
+
+## Security boundary
+
+The renderer is sandboxed, has no Node integration, and receives only the desktop platform marker and application version through preload. Navigation remains on the cockpit origin, while approved external HTTPS links open in the system browser.
+
+These controls reduce renderer privilege. They do not sandbox the cockpit or its agents. The local hub and agent processes run with the user's operating-system authority, and other local processes can reach the loopback service. Remote access inherits the web cockpit's authentication and transport model.
+
+Read [Security](./docs/security.md) for the complete boundary and its limitations.
+
+## License
+
+Source is available under the [DoomPi Desktop License](./LICENSE). Use is free for production and commercial purposes, but redistribution and offering the software as a hosted or managed service are not permitted.

--- a/packages/clients/doompi-desktop/docs/architecture.md
+++ b/packages/clients/doompi-desktop/docs/architecture.md
@@ -1,0 +1,111 @@
+# Desktop architecture
+
+DoomPi Desktop turns the existing browser cockpit into a native application without creating a second control plane. Electron supplies process startup, a constrained renderer, application lifecycle, and release packaging. The cockpit continues to own HTTP serving, sessions, and agents.
+
+This split keeps browser and desktop behavior on the same protocol and session model. It also means the desktop application inherits the cockpit's authority and operational limits rather than containing them.
+
+## System topology
+
+```text
+Electron application
+  │
+  ├─ main process
+  │    ├─ acquires the single-instance lock
+  │    ├─ selects a loopback port
+  │    ├─ starts and supervises the cockpit child
+  │    └─ owns BrowserWindow and native IPC handlers
+  │
+  ├─ preload
+  │    └─ exposes platform and app version only
+  │
+  └─ renderer
+       └─ loads http://127.0.0.1:<port>
+
+cockpit child
+  └─ DoomPi Web hub
+       ├─ serves the web shell
+       ├─ watches session registry records
+       └─ starts doompi-server processes
+            ├─ publish their session records
+            └─ start agent processes
+```
+
+The renderer loads a loopback HTTP origin instead of `file://`. The web client derives its socket URLs from the page location and bootstraps through a service worker, both of which require an HTTP origin in this design. The same web application and hub contracts can therefore run in a browser or inside Electron. The hub and session server do not need to know which client opened them.
+
+## Ownership boundaries
+
+### Electron main process
+
+The main process owns desktop-only concerns:
+
+- one running desktop application instance
+- loopback port selection
+- cockpit child startup and shutdown
+- health-gated window loading
+- window bounds and navigation policy
+- native application IPC
+- desktop computer-use host wiring
+
+It does not resolve plugin composition, create DoomPi sessions, or launch agents directly. Those operations stay below the hub boundary.
+
+### Cockpit and session processes
+
+The staged `@agimon-ai/doompi-web` CLI remains the cockpit control plane. It serves the web client and launches the staged `@agimon-ai/doompi-server` command when the cockpit creates a session. Each session server owns its registry record and agent process.
+
+Session discovery uses the normal DoomPi runtime directory:
+
+```text
+DOOMPI_RUNTIME_DIR, when set
+~/.doompi/run, otherwise
+```
+
+Electron's user-data directory is not a second session registry. Desktop and command-line tooling can observe the same session records.
+
+### Renderer and preload
+
+The renderer is an unprivileged web client. Its preload surface contains two values:
+
+- `platform: 'desktop'`
+- `version()`
+
+Node integration is disabled, context isolation and the Chromium sandbox are enabled, and the session partition is not persisted. Native capability must be implemented in the main process and exposed deliberately. It is not inherited by arbitrary renderer code.
+
+## Startup lifecycle
+
+1. Electron removes command-line `--inspect` flags and acquires a single-instance lock.
+2. The main process resolves the packaged runtime and chooses a loopback port. It prefers `7433` when that port is bindable, otherwise it asks the operating system for a free port.
+3. It creates a hidden window with the constrained web preferences and loads the startup page.
+4. It starts the staged cockpit CLI with `ELECTRON_RUN_AS_NODE=1` and a desktop-specific environment.
+5. It polls `/api/health` until the cockpit answers or the startup deadline expires.
+6. Electron shows the window when the startup page is ready, then replaces that page with the cockpit after the health check succeeds.
+7. Closing the window quits the application. The main process terminates the cockpit child it started.
+
+If a healthy cockpit appears on the selected port between selection and launch, startup can attach to it. In that case Electron does not own that process and does not stop it on exit. This is a race-safe fallback, not general discovery of an already occupied default port.
+
+A failed startup stops an owned child, closes the window, and surfaces an error dialog before exiting.
+
+## Window and navigation model
+
+The application starts with an in-memory loading page, then replaces it with the loopback cockpit after the health check succeeds. The window uses fixed initial and minimum dimensions. The application does not persist window bounds.
+
+Main-frame navigation is restricted to the initial cockpit origin. New windows are denied. HTTPS links to other origins are handed to the operating system browser only after URL parsing and protocol checks. Other schemes remain blocked.
+
+This policy limits common renderer escape paths, but it does not make the served cockpit content harmless. The loopback server and the renderer still form one application trust boundary.
+
+## Why a shell instead of a fork
+
+A separate desktop session implementation would duplicate lifecycle, authentication, plugin loading, and agent-launch behavior. Keeping those capabilities in the hub has three practical effects:
+
+- browser and desktop clients use the same observable contracts
+- fixes in session and agent orchestration apply to both surfaces
+- the Electron layer stays small enough to audit as native glue
+
+The tradeoff is that desktop startup includes a local HTTP service and a process tree rather than a single renderer process. Diagnostics must consider Electron, the cockpit child, session servers, and agents separately.
+
+## Related guides
+
+- [Getting started](./getting-started.md)
+- [Runtime and packaging](./runtime-and-packaging.md)
+- [Security](./security.md)
+- [Web architecture](../../doompi-web/docs/architecture.md)
+- [Server lifecycle](../../doompi-server/docs/lifecycle.md)

--- a/packages/clients/doompi-desktop/docs/getting-started.md
+++ b/packages/clients/doompi-desktop/docs/getting-started.md
@@ -1,0 +1,93 @@
+# Getting started with DoomPi Desktop
+
+DoomPi Desktop is built from the monorepo. This package is private and does not expose a library API or a standalone npm installation path.
+
+## Prerequisites
+
+Use the repository-pinned toolchain:
+
+- Node.js `22.22.1`
+- pnpm `11.1.3`
+
+Install the workspace dependencies from the repository root:
+
+```bash
+pnpm install
+```
+
+## Run the application
+
+Build the cockpit and start Electron:
+
+```bash
+pnpm cockpit:build
+pnpm --filter @agimon-ai/doompi-desktop start
+```
+
+`start` builds the Electron main and preload entries, stages the desktop runtime, and launches the generated main entry. It does not provide hot reload. Stop the application normally or interrupt the command.
+
+The desktop selects a loopback cockpit port automatically. To move session discovery to another directory, set `DOOMPI_RUNTIME_DIR` before starting:
+
+```bash
+DOOMPI_RUNTIME_DIR=/tmp/doompi-run \
+  pnpm --filter @agimon-ai/doompi-desktop start
+```
+
+The main process removes inherited `DOOMPI_*` variables before starting the packaged cockpit, then supplies its own runtime paths, port, desktop marker, and agent command. `DOOMPI_RUNTIME_DIR` is the explicit exception carried into that environment.
+
+Keep the registry path short. Desktop requires at least 40 bytes of path budget after the registry directory for a session socket. It rejects a path that cannot meet that bound before the cockpit starts, avoiding a later Unix-socket failure with a less useful error.
+
+## Run focused checks
+
+From the repository root:
+
+```bash
+pnpm nx run @agimon-ai/doompi-desktop:lint
+pnpm nx run @agimon-ai/doompi-desktop:typecheck
+pnpm nx run @agimon-ai/doompi-desktop:build
+pnpm nx run @agimon-ai/doompi-desktop:test
+pnpm nx run @agimon-ai/doompi-desktop:test:e2e
+```
+
+The unit target covers process launch, window restrictions, runtime staging, and native host policy. The end-to-end target launches the generated Electron entry against a fixture cockpit and verifies the application shell.
+
+## Build a release artifact
+
+Run the package target through Nx so its dependency builds execute:
+
+```bash
+pnpm nx run @agimon-ai/doompi-desktop:package
+```
+
+Release artifacts are written under `packages/clients/doompi-desktop/release`. Current targets are:
+
+- macOS arm64 DMG and ZIP
+- Linux x64 AppImage and DEB
+
+Packaging is not a portable cross-platform build. Build each target on the corresponding operating system, especially macOS where nested executable signing and Apple notarization are part of the release path.
+
+For artifact structure, signing inputs, and the absence of an in-app updater, read [Runtime and packaging](./runtime-and-packaging.md).
+
+## Troubleshooting
+
+### The cockpit never becomes ready
+
+The application waits for the staged hub's `/api/health` endpoint. Check the terminal output for the cockpit child failure. Common causes are an incomplete runtime stage, a missing packaged entry or native binary, a sync or initialization error, or another process taking the selected port before the child binds it.
+
+### Port 7433 is already in use
+
+This is normally harmless. Desktop selects a free ephemeral port when its preferred port is occupied.
+
+### Desktop and CLI show different sessions
+
+Confirm both processes use the same `DOOMPI_RUNTIME_DIR`. With no override, both use `~/.doompi/run`.
+
+### Computer use reports unavailable
+
+The current macOS backend reports permission state but intentionally refuses activation because its signed native adapter has not passed the packaged capability probe. This is the expected current behavior, not a prompt to bypass the check.
+
+## Next steps
+
+- [Understand the process topology](./architecture.md)
+- [Inspect runtime and release assembly](./runtime-and-packaging.md)
+- [Review authority and security limits](./security.md)

--- a/packages/clients/doompi-desktop/docs/runtime-and-packaging.md
+++ b/packages/clients/doompi-desktop/docs/runtime-and-packaging.md
@@ -1,0 +1,126 @@
+# Desktop runtime and packaging
+
+A DoomPi Desktop release is not only an Electron main bundle. It must carry a runnable cockpit, browser assets, the DoomPi CLI, runtime packages, and platform-native helpers. The build assembles those parts into one versioned application artifact while preserving their existing process boundaries.
+
+## Artifact model
+
+The package produces three build directories:
+
+```text
+packages/clients/doompi-desktop/
+  dist/
+    bin/
+      main.cjs
+      preload.cjs
+  build/
+    runtime/
+      doompi-web/          staged web package and browser assets
+      doompi-server/       staged cockpit CLI and server package
+      doompi/              staged DoomPi runtime
+      node_modules/        runtime packages and platform helpers
+      native/              native resolution tree
+      catalog/             installable DoomPi package archives
+      vendor/              npm, Vite, and cloudflared payloads
+  release/                   installer and archive artifacts
+```
+
+The exact nested files are build outputs, not public import paths. The stable contract is that the Electron entries live in the application archive while executable runtime resources are copied beside it under Electron's resources directory.
+
+## Build pipeline
+
+### Electron entries
+
+`tsdown` compiles the main process and preload into CommonJS entries. The application manifest points Electron at `dist/bin/main.cjs`.
+
+The renderer is not compiled here. It is the normal `@agimon-ai/doompi-web` build served by the staged cockpit.
+
+### Runtime staging
+
+A Vite SSR build stages the runtime. Its plugin copies the web distribution, server distribution, DoomPi distribution, required package resources, native binaries, and an npm CLI into `build/runtime` before electron-builder assembles the application.
+
+The staging step validates required entry points and executable targets. Missing or ambiguous artifacts fail the build rather than producing a partially runnable desktop application.
+
+A local package catalog is built from the workspace's DoomPi packages. The runtime synchronization path can install the selected DoomPi composition from these packaged archives instead of assuming that the source checkout or workspace `node_modules` exists on the user's machine.
+
+### Native helpers
+
+Platform-native executables and add-ons must remain outside Electron's asar archive because the operating system needs to execute or load them directly. electron-builder copies the entire staged runtime into the application's resources directory, including runner helpers, native Node dependencies, and the Cloudflare tunnel helper.
+
+`cloudflared` is downloaded for the current packaging platform from a pinned release. The download is checked against a platform-specific SHA-256 digest before the file is accepted. The build does not silently substitute an unverified binary.
+
+## One Electron binary, two modes
+
+The cockpit and agent descendants are launched with:
+
+```text
+ELECTRON_RUN_AS_NODE=1
+```
+
+Electron's executable then behaves as Node for those child processes. This avoids shipping and updating a second Node executable. On macOS, helpers also set `ELECTRON_NO_ATTACH_CONSOLE=1` so Node-mode descendants do not behave like separate dock applications.
+
+This reuse is an implementation choice, not a privilege boundary. The child processes still have normal Node authority under the current user.
+
+## Runtime environment
+
+The launcher constructs a controlled environment for the cockpit:
+
+- packaged server, DoomPi, web, catalog, npm CLI, resource, and binary paths
+- selected loopback port
+- `DOOMPI_CLIENT=desktop`
+- an agent command that reuses the Electron executable in Node mode
+- the shared session runtime directory
+- a cache directory inside Electron's user-data directory
+
+Inherited `DOOMPI_*` values are removed before these settings are applied, except that an explicit `DOOMPI_RUNTIME_DIR` selects the shared registry location. Provider credentials and unrelated operating-system variables are not part of that prefix and continue to follow the normal DoomPi configuration model.
+
+## macOS signing and notarization
+
+macOS packages contain nested Mach-O binaries. They are signed from the deepest runtime components outward before electron-builder signs the enclosing application. The signing script:
+
+1. discovers staged Mach-O files and native modules
+2. sorts them deepest-first
+3. signs each file with the configured identity and entitlements
+
+This ordering matters because changing a nested signed file after signing the outer bundle invalidates the enclosing signature.
+
+Release signing and notarization use electron-builder's standard environment inputs, including:
+
+- `CSC_LINK`
+- `CSC_KEY_PASSWORD`
+- `CSC_NAME`
+- `APPLE_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD`
+- `APPLE_TEAM_ID`
+
+Local development can build unsigned output. A distributed macOS artifact requires the release credentials and successful notarization.
+
+## Platform targets
+
+The current electron-builder configuration produces:
+
+| Platform | Architecture | Formats       |
+| -------- | ------------ | ------------- |
+| macOS    | arm64        | DMG, ZIP      |
+| Linux    | x64          | AppImage, DEB |
+
+Windows and macOS x64 are not configured release targets.
+
+## Updates and compatibility
+
+The application contains no in-app updater implementation. A new version is delivered as a new whole-application artifact. Documentation and release automation must not imply an automatic update channel until one is implemented and verified.
+
+Because the runtime is staged with the application, the shell, server, DoomPi code, and packaged catalog form one tested desktop generation. User data and the session registry remain outside the application bundle. Replacing the application therefore replaces its runtime generation without relocating normal user state.
+
+## Tradeoffs
+
+The staged-runtime approach provides repeatable installation and avoids dependence on a source checkout. Its costs are larger release artifacts, platform-specific assembly, nested signing, and duplicated package material inside the artifact.
+
+Using the same cockpit code prevents a desktop-only protocol fork. Its cost is a multi-process application whose readiness and shutdown must be supervised rather than a single embedded renderer bundle.
+
+## Related guides
+
+- [Desktop architecture](./architecture.md)
+- [Getting started](./getting-started.md)
+- [Security](./security.md)
+- [DoomPi bundling](../../../../docs/bundling.md)
+- [Web bundle model](../../doompi-web/docs/bundle.md)

--- a/packages/clients/doompi-desktop/docs/security.md
+++ b/packages/clients/doompi-desktop/docs/security.md
@@ -1,0 +1,96 @@
+# Desktop security
+
+DoomPi Desktop combines three trust domains: Electron's renderer, a loopback cockpit, and local agent processes. Security depends on keeping their authority distinct. Renderer restrictions reduce the impact of web-content compromise, but they do not contain the cockpit or the agents that the cockpit launches.
+
+## Trust model
+
+```text
+untrusted or mixed-origin web content
+  │ blocked navigation / external-browser handoff
+  ▼
+DoomPi renderer
+  │ narrow preload contract
+  ▼
+Electron main process
+  │ starts and supervises
+  ▼
+loopback cockpit
+  │ creates sessions
+  ▼
+agent processes with current-user authority
+```
+
+The application trusts its packaged Electron code and staged cockpit runtime. It treats arbitrary renderer navigation as untrusted. The operating-system user remains the ultimate authority boundary for the cockpit and agent processes.
+
+## Renderer containment
+
+The BrowserWindow enables:
+
+- context isolation
+- Chromium sandboxing
+- disabled Node integration
+- disabled webview tags
+- an in-memory Electron session partition
+
+The preload exposes only the desktop platform marker and a request for the application version. It does not expose filesystem, shell, process, or general IPC access.
+
+These settings reduce direct access from renderer JavaScript to Electron and Node. They are defense in depth, not proof that the cockpit origin is safe. A renderer compromise can still act with the current cockpit user's web capabilities and send requests available to that origin.
+
+## Navigation and external links
+
+Main-frame navigation is allowed only within the initial cockpit origin. New window creation is denied. A parsed `https:` URL targeting another origin may open in the user's default browser. Other URL schemes are not handed to the external browser.
+
+This keeps external content out of the privileged application window. It does not assess whether an allowed HTTPS destination is trustworthy once opened in the external browser.
+
+## Loopback is a host boundary, not authentication
+
+The desktop cockpit binds to `127.0.0.1`. This prevents direct network exposure on other interfaces, but any process running as the same user can generally connect to the loopback service. Local mode should not be described as authenticated isolation from hostile local software.
+
+Desktop does not add a second authentication system. When remote access is enabled, the web cockpit's pairing, device cookie, passkey step-up, channel sealing, and tunnel policies apply unchanged. Their precise protections and exceptions are documented in [Web security](../../doompi-web/docs/security.md).
+
+## Process authority
+
+The Electron main process, cockpit, session servers, and agents run as the current operating-system user. Agents may read files, run commands, and access credentials available to that user, subject to DoomPi's own tool and package policies.
+
+The renderer sandbox does not extend to those child processes. `ELECTRON_RUN_AS_NODE=1` changes how Electron's executable starts them, not what permissions they receive.
+
+Treat a plugin, layer, or agent package as executable code. Packaged catalogs make code available offline; they do not make that code safe.
+
+## Runtime integrity
+
+Desktop releases stage their runtime instead of resolving core application files from arbitrary workspace paths at startup. Required runtime entries are validated during the build. The bundled `cloudflared` download is pinned and SHA-256 verified.
+
+On macOS, native files and the enclosing application are code-signed, then the release is configured for notarization. These measures provide provenance and tamper detection for distributed artifacts. They do not prevent signed code from misusing user-granted authority or protect an unsigned local development build.
+
+## Computer-use boundary
+
+Desktop contains a bounded host protocol for macOS computer-use operations. Its policy is designed around semantic actions rather than arbitrary shell input, with session-bound grants, expiry, sequencing, and emergency-stop handling. Local and remote approval paths are distinct, and the server remains responsible for remote step-up policy.
+
+The current macOS backend reports Accessibility and Screen Recording permission state but identifies its native adapter as unavailable. Target discovery and activation fail closed because the signed packaged adapter has not passed its capability probe. The existence of IPC handlers or native resources must not be documented as an enabled computer-use feature.
+
+If the adapter is enabled later, operating-system Accessibility and Screen Recording grants will enlarge the application's authority substantially. Renderer isolation alone would not constrain those native privileges. The capability probe, explicit grants, server policy, and audit trail must all remain in the path.
+
+## Data locations
+
+Two storage locations have different purposes:
+
+- `~/.doompi/run`, or `DOOMPI_RUNTIME_DIR`, holds the shared DoomPi session registry.
+- Electron's user-data directory holds desktop-owned cache data used by the packaged runtime.
+
+The BrowserWindow session partition is in memory, so Electron does not intentionally persist renderer session storage through a `persist:` partition. This is not a general data-erasure guarantee. The cockpit, browser engine, logs, providers, tools, and agents may write data through their own storage paths.
+
+## Operational guidance
+
+- Install release artifacts only from a trusted distribution source and verify platform signatures where available.
+- Keep remote access disabled unless it is required.
+- Treat quick-tunnel mode according to the web security guide's documented limitations.
+- Review plugins and layers before enabling them.
+- Do not grant macOS Accessibility or Screen Recording permissions based only on the presence of the desktop application. The current adapter remains unavailable.
+- Use a dedicated operating-system account when agent access must be separated from personal files or credentials.
+
+## Related guides
+
+- [Desktop architecture](./architecture.md)
+- [Runtime and packaging](./runtime-and-packaging.md)
+- [Web security](../../doompi-web/docs/security.md)
+- [Trust and data boundaries](../../../../docs/trust-and-data-boundaries.md)

--- a/packages/clients/doompi-desktop/package.json
+++ b/packages/clients/doompi-desktop/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@agimon-ai/doompi": "workspace:*",
+    "@agimon-ai/doompi-config": "workspace:*",
     "@agimon-ai/doompi-server": "workspace:*",
     "@agimon-ai/doompi-web": "workspace:*",
     "@playwright/test": "1.62.1",

--- a/packages/clients/doompi-desktop/src/bin/main.ts
+++ b/packages/clients/doompi-desktop/src/bin/main.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
+import { loadDoomConfig } from '@agimon-ai/doompi-config';
 import { app, BrowserWindow, dialog, ipcMain, Menu, MenuItem, shell } from 'electron';
 import { createMacOsComputerUseBackend } from '../adapters/macos/computerUseBackend.ts';
 import { freePort, portIsFree, startHub } from '../adapters/hubProcess.ts';
@@ -91,6 +92,7 @@ async function start(): Promise<void> {
           hostGeneration: randomUUID(),
           now: Date.now,
           newId: randomUUID,
+          enabled: () => loadDoomConfig(os.homedir(), os.homedir()).computerUse?.enabled === true,
           confirmLocalActivation: async ({ applicationName, windowTitle, durationSeconds }) => {
             const result = await dialog.showMessageBox(window, {
               type: 'warning',

--- a/packages/clients/doompi-desktop/src/services/computerUseHost.ts
+++ b/packages/clients/doompi-desktop/src/services/computerUseHost.ts
@@ -34,6 +34,7 @@ export interface ComputerUseHostOptions {
   readonly hostGeneration: string;
   readonly now: () => number;
   readonly newId: () => string;
+  readonly enabled: () => boolean;
   readonly confirmLocalActivation?: (confirmation: LocalActivationConfirmation) => Promise<boolean>;
 }
 
@@ -160,6 +161,7 @@ export class ComputerUseHost {
   readonly #hostGeneration: string;
   readonly #now: () => number;
   readonly #newId: () => string;
+  readonly #enabled: () => boolean;
   readonly #confirmLocalActivation: ((confirmation: LocalActivationConfirmation) => Promise<boolean>) | undefined;
   #active: ActiveGrant | undefined;
   #queue: Promise<void> = Promise.resolve();
@@ -174,6 +176,7 @@ export class ComputerUseHost {
     this.#hostGeneration = options.hostGeneration;
     this.#now = options.now;
     this.#newId = options.newId;
+    this.#enabled = options.enabled;
     this.#confirmLocalActivation = options.confirmLocalActivation;
   }
 
@@ -212,6 +215,19 @@ export class ComputerUseHost {
       if (this.#revoked) return this.#failure(request, 'desktop_unavailable', 'The Desktop capability is unavailable.');
       if (signal?.aborted === true) return this.#failure(request, 'request_cancelled', 'The request was cancelled.');
       await this.#expireIfNeeded();
+      if (!this.#enabled()) {
+        const active = this.#active;
+        if (active !== undefined) {
+          this.#clearExpiryTimer();
+          this.#active = undefined;
+          await this.#backend.stop({ ...active, reason: 'global_setting_disabled' });
+        }
+        if (request.operation === 'status') {
+          return this.#success(request, { available: false, busy: false, ownedBySession: false });
+        }
+        if (request.operation === 'stop') return this.#success(request, { stopped: active !== undefined });
+        return this.#failure(request, 'desktop_unavailable', 'Enable computer use in global settings first.');
+      }
       switch (request.operation) {
         case 'status':
           return this.#success(request, {
@@ -253,6 +269,8 @@ export class ComputerUseHost {
       if (!(await this.#confirmLocalActivation(activation.confirmation)))
         return this.#failure(request, 'confirmation_denied', 'Native Desktop confirmation was denied.');
     }
+    if (!this.#enabled())
+      return this.#failure(request, 'desktop_unavailable', 'Computer use was disabled during confirmation.');
     const durationSeconds = activation.confirmation.durationSeconds;
     const grant: ActiveGrant = {
       sessionId: request.sessionId,
@@ -262,7 +280,12 @@ export class ComputerUseHost {
       nextSequence: 1,
     };
     const result = await this.#backend.activate({ ...grant, payload: request.payload, signal });
-    if (signal?.aborted === true || this.#revoked || revocationGeneration !== this.#revocationGeneration) {
+    if (
+      signal?.aborted === true ||
+      this.#revoked ||
+      !this.#enabled() ||
+      revocationGeneration !== this.#revocationGeneration
+    ) {
       await this.#backend.stop({ ...grant, reason: 'request_cancelled' });
       return this.#failure(request, 'request_cancelled', 'The activation request was cancelled.');
     }

--- a/packages/clients/doompi-desktop/tests/unit/computerUseHost.test.ts
+++ b/packages/clients/doompi-desktop/tests/unit/computerUseHost.test.ts
@@ -36,6 +36,7 @@ function activation(durationSeconds = 60, requestId = 'confirmation-1') {
 function fixture(confirmLocalActivation = vi.fn(async () => true)) {
   let now = 1000;
   let ids = 0;
+  let enabled = true;
   const backend: ComputerUseBackend = {
     status: vi.fn(async () => ({ ready: true })),
     targets: vi.fn(async () => ({ targets: [] })),
@@ -49,9 +50,15 @@ function fixture(confirmLocalActivation = vi.fn(async () => true)) {
     hostGeneration: 'host-1',
     now: () => now,
     newId: () => `id-${String(++ids)}`,
+    enabled: () => enabled,
     confirmLocalActivation,
   });
-  return { backend, host, advance: (milliseconds: number) => (now += milliseconds) };
+  return {
+    backend,
+    host,
+    advance: (milliseconds: number) => (now += milliseconds),
+    setEnabled: (value: boolean) => (enabled = value),
+  };
 }
 
 describe('ComputerUseHost', () => {
@@ -64,6 +71,22 @@ describe('ComputerUseHost', () => {
     expect(busy).toMatchObject({ ok: false, code: 'busy_in_another_session' });
   });
 
+  it('fails closed and stops an active grant when the global setting is disabled', async () => {
+    const { backend, host, setEnabled } = fixture();
+    expect(await host.handle(request('session-a', 'activate', activation()))).toMatchObject({ ok: true });
+
+    setEnabled(false);
+
+    expect(await host.handle(request('session-a', 'status'))).toMatchObject({
+      ok: true,
+      result: { available: false, busy: false },
+    });
+    expect(backend.stop).toHaveBeenCalledWith(expect.objectContaining({ reason: 'global_setting_disabled' }));
+    expect(await host.handle(request('session-a', 'targets'))).toMatchObject({
+      ok: false,
+      code: 'desktop_unavailable',
+    });
+  });
   it('rejects stale and replayed activation confirmations', async () => {
     const { host } = fixture();
     const expired = { ...activation(), confirmationExpiresAt: 999 };

--- a/packages/clients/doompi-desktop/tests/unit/computerUseHostBridge.test.ts
+++ b/packages/clients/doompi-desktop/tests/unit/computerUseHostBridge.test.ts
@@ -33,6 +33,7 @@ function backendFixture() {
     hostGeneration: 'host-1',
     now: Date.now,
     newId: () => crypto.randomUUID(),
+    enabled: () => true,
     confirmLocalActivation: async () => true,
   });
   return { host, activationSignal: () => activationSignal };

--- a/packages/clients/doompi-server/README.md
+++ b/packages/clients/doompi-server/README.md
@@ -1,18 +1,27 @@
 # @agimon-ai/doompi-server
 
-Headless DoomPi session server. It supervises a Pi RPC agent behind an authenticated Unix socket so clients can attach and reattach.
+**A headless server for one DoomPi session.**
 
-Part of [DoomPi](https://www.npmjs.com/package/@agimon-ai/doompi). Web and desktop clients use
-this server through the cockpit hub. It registers no Pi extension.
+`doompi-server` owns a Pi RPC agent and exposes it through an authenticated Unix socket. A client can
+attach, disconnect, and reattach while the agent keeps running. The server also publishes Pi's routed
+session protocol, optional session package APIs, and a registry record for the web cockpit.
 
-## How it runs
+This is a standalone process, not a Pi extension. Do not add it to `.doom/modes.yaml`; `doompi init`
+does not configure it.
 
-`doompi-server` is a standalone process, not a Pi extension. Do not add it to `.doom/modes.yaml`. `doompi init` does not configure it.
+## Contents
+
+| Guide                          | What it covers                                                      |
+| ------------------------------ | ------------------------------------------------------------------- |
+| [Lifecycle](docs/lifecycle.md) | Startup, agent selection, relaunches, registry, and shutdown        |
+| [IPC](docs/ipc.md)             | Unix sockets, framing, attach and replay, and the Pi protocol       |
+| [API](docs/api.md)             | Session package APIs and the TypeScript export surface              |
+| [Security](docs/security.md)   | Filesystem permissions, tokens, trust boundaries, and remote access |
 
 ## Requirements
 
 - Node.js 22.19.0 or newer
-- A runnable DoomPi agent. The server checks the working directory's installation, `DOOMPI_AGENT_COMMAND`, then `doompi` on `PATH`.
+- A DoomPi installation in the session repository, `DOOMPI_AGENT_COMMAND`, or the installed DoomPi package
 
 ## Install
 
@@ -20,104 +29,116 @@ this server through the cockpit hub. It registers no Pi extension.
 npm install -g @agimon-ai/doompi-server
 ```
 
-## Run
+## Quick start
+
+Create a private runtime directory and token, then pass the agent arguments after `--`:
 
 ```bash
 runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/doompi-session.XXXXXX")"
 (umask 077; openssl rand -base64 32 > "$runtime_dir/token")
 
-doompi-server --listen "$runtime_dir/session.sock" --auth-token-file "$runtime_dir/token" -- --major-mode copilot
+doompi-server \
+  --listen "$runtime_dir/session.sock" \
+  --auth-token-file "$runtime_dir/token" \
+  -- --major-mode copilot
 ```
 
-The server starts `doompi --mode rpc` with the arguments after `--`, then publishes the session on the socket. It creates the socket with owner-only access under a restrictive umask.
+The token is read from the file, not from the command line. Keep the runtime directory private. The
+server appends `--mode rpc` to the agent invocation and waits for the agent to exit.
 
-The session gets an identity at spawn: the server mints a session id (or takes `--session-id`) and
-passes it to Pi together with the `--name` you gave it, so the cockpit knows the session before its
-first frame.
-
-The agent command resolves for each working directory. A repository-local `@agimon-ai/doompi` takes precedence, `DOOMPI_AGENT_COMMAND` can name a binary or `.mjs` file, and `doompi` on `PATH` is the fallback.
-
-## Major-mode relaunches
-
-A launcher-class session cannot recompose its extension closure in place, so switching to a major
-mode with a different layer set normally stays pending until someone reruns the launcher. This
-server performs that relaunch itself: the runtime journals the switch, writes a relaunch file the
-server points it at, and the server ends the agent's input for a graceful exit, then respawns it
-with the new `--major-mode` under the same session id and socket. Clients stay attached; the
-replacement resumes the same Pi session and acknowledges the journaled transition. An agent that
-ignores the request is killed after a grace period, and an exit without the file ends the session
-as before.
-
-## The session registry
-
-Every server announces itself by writing one JSON record to
-`~/.doompi/run/sessions/<session id>.json` (override the directory with `--registry-dir` or
-`DOOMPI_RUNTIME_DIR`). The record names the socket, the working directory, the token file, and the
-server pid; writing it is the whole act of registration, and the server withdraws it on exit. The
-web cockpit watches this directory to find every running session, and deletes records whose pid is
-gone, so a crashed server does not haunt the rail.
-
-## Serving the web cockpit
-
-Add `--web` to make sure a browser cockpit is reachable:
+To serve the browser cockpit from the same process, install the optional web package and add `--web`:
 
 ```bash
-doompi-server --listen "$runtime_dir/session.sock" --auth-token-file "$runtime_dir/token" --name doompi-web --web 7433 -- --major-mode copilot
+npm install -g @agimon-ai/doompi-web
+doompi-server \
+  --listen "$runtime_dir/session.sock" \
+  --auth-token-file "$runtime_dir/token" \
+  --name doompi-web \
+  --web \
+  -- --major-mode copilot
 ```
 
-The port is optional and defaults to 7433. The cockpit is a multi-session hub: if one already
-answers on the port, this server just logs its URL and appears there through the registry; only
-otherwise does it start the hub in-process. An embedded hub dies with its server, so for several
-sessions the durable topology is a standalone `doompi-web`. The cockpit binds loopback and reads
-tokens from token files, so the browser never holds a session credential. `--web` requires
-[@agimon-ai/doompi-web](https://www.npmjs.com/package/@agimon-ai/doompi-web), which is an optional
-peer: without it the flag reports what to install rather than failing obscurely.
+`--web` uses port `7433` by default. If a DoomPi cockpit already answers there, this server registers
+its session with that hub instead of starting another one. A standalone `doompi-web` process is the
+durable choice for several sessions.
 
-## Protocol
+## How it works
 
-Newline-delimited JSON in both directions, carrying Pi's own RPC frames untouched. The server adds
-only a handshake:
+The server resolves the session identity, composes or delegates the configured DoomPi installation,
+and starts one agent in RPC mode. It binds the session socket at `--listen`, the Pi protocol socket at
+`<listen>.pi`, and a package API socket at `api.sock` beside the session socket when session APIs are
+available. Only after these services are ready does it write the session record.
 
-| Frame                                          | Direction        | Meaning                                        |
-| ---------------------------------------------- | ---------------- | ---------------------------------------------- |
-| `{"type":"attach","token":"..."}`              | client to server | Must be the first frame                        |
-| `{"type":"attached","replayed":N,"dropped":M}` | server to client | Accepted, with what the client missed          |
-| `{"type":"attach_error","reason":"..."}`       | server to client | Refused, and the connection closes             |
-| `{"type":"replay","frame":{...}}`              | server to client | One frame emitted while no client was attached |
+A session has one supervised agent and one client on the framed session socket. Frames pass through
+unchanged after the attach handshake. If the client disconnects, the agent continues and a bounded
+backlog is replayed on the next attach. The [IPC guide](docs/ipc.md) describes the wire contracts.
 
-Everything else passes through: client frames go to the agent, agent frames go to the client.
+A major-mode change that needs a new extension composition is handled as a relaunch. The server keeps
+the session id, sockets, and registry record while it asks the current agent to exit cleanly and starts
+the replacement. See the [lifecycle guide](docs/lifecycle.md) for the state transitions.
 
-## Attach and reattach
+## Command line
 
-One client holds a session at a time; a second attach is refused rather than allowed to fight over
-the same agent. When the web cockpit runs, the hub is that one client and browser tabs multiplex
-behind it. Losing the client does not end the run. Frames buffer while nobody is attached and
-replay on the next attach, so a dropped connection or a reloaded page recovers instead of losing
-the session. The buffer is bounded and reports how many frames it had to drop.
+| Option                     | Default               | Meaning                                           |
+| -------------------------- | --------------------- | ------------------------------------------------- |
+| `--listen <path>`          | required              | Unix socket for the framed session transport      |
+| `--auth-token-file <path>` | required              | File containing the attach token                  |
+| `--name <name>`            | `untitled`            | Name shown by clients and written to the registry |
+| `--session-id <id>`        | generated UUID        | Session id; it must not contain `/`               |
+| `--registry-dir <path>`    | `~/.doompi/run`       | Parent of the session registry                    |
+| `--web [port]`             | no cockpit, or `7433` | Start or join the browser cockpit                 |
+| `-- <agent arguments>`     | none                  | Arguments passed to the DoomPi agent              |
 
-## Current limits
+Options before `--` belong to `doompi-server`. Everything after it belongs to the agent. If agent
+arguments already contain `--session-id` or `--name`, those values are used for the session identity.
 
-- The executable itself is not covered end to end. Tests cover the supervisor, socket, handshake, and replay paths.
-- Transport uses a Unix socket only. Tunnel it, for example over SSH, for remote access.
-- Each server process runs one agent. Run several servers for several sessions; the registry and cockpit hub present them as one set.
+The registry directory can also be set with `DOOMPI_RUNTIME_DIR`. Agent selection uses
+`DOOMPI_AGENT_COMMAND` when the repository does not pin a different DoomPi launcher. `DOOMPI_API_DIR`
+can point the server at a generated session API directory. `DOOMPI_WEB_MODULE` selects the web module
+used by `--web`.
+
+## Registry
+
+Each running server writes one owner-only JSON record at
+`<registry-dir>/sessions/<session id>.json`. It contains the session id and name, working directory,
+socket paths, server pid, and creation time. It stores the token file path, never the token itself.
+The web cockpit watches these records and treats a dead pid as stale. The [security guide](docs/security.md)
+explains why the directory and its paths must remain private.
 
 ## Public API
 
+The package exports the socket servers, agent process adapter, Pi session service, transcript projection,
+and framing helpers:
+
 ```ts
-import { serveSessionSocket, spawnAgentProcess } from '@agimon-ai/doompi-server';
+import {
+  createAgentServerService,
+  serveProtocolSocket,
+  serveSessionSocket,
+  spawnAgentProcess,
+} from '@agimon-ai/doompi-server';
 ```
+
+Use the [API guide](docs/api.md) for the session package API and the complete export roles.
+
+## Limits
+
+- One `doompi-server` process supervises one agent.
+- The framed Unix socket allows one attached client at a time.
+- The server's transports are Unix sockets, not network listeners. Use a trusted tunnel or the web
+  cockpit for remote access.
+- The executable path is covered by component and integration tests, but not by an end-to-end test of
+  every installed-package combination.
 
 ## Development
 
-Run from this package directory in the workspace:
+Run from this package directory:
 
 ```bash
 pnpm build
 pnpm typecheck
 pnpm test
 pnpm lint
-pnpm exec vibe-lint check .
-npm pack --dry-run
 ```
 
 Maintained by [Agimon](https://agimon.ai/about).

--- a/packages/clients/doompi-server/README.md
+++ b/packages/clients/doompi-server/README.md
@@ -2,28 +2,13 @@
 
 **A headless server for one DoomPi session.**
 
-`doompi-server` owns a Pi RPC agent and exposes it through an authenticated Unix socket. A client can
-attach, disconnect, and reattach while the agent keeps running. The server also publishes Pi's routed
-session protocol, optional session package APIs, and a registry record for the web cockpit.
+`doompi-server` owns one Pi RPC agent behind local Unix sockets. A client can disconnect and reattach while the agent keeps running. The server also publishes Pi's routed protocol, optional package APIs, and a registry record used by DoomPi Web.
 
-This is a standalone process, not a Pi extension. Do not add it to `.doom/modes.yaml`; `doompi init`
-does not configure it.
-
-## Contents
-
-| Guide                          | What it covers                                                      |
-| ------------------------------ | ------------------------------------------------------------------- |
-| [Lifecycle](docs/lifecycle.md) | Startup, agent selection, relaunches, registry, and shutdown        |
-| [IPC](docs/ipc.md)             | Unix sockets, framing, attach and replay, and the Pi protocol       |
-| [API](docs/api.md)             | Session package APIs and the TypeScript export surface              |
-| [Security](docs/security.md)   | Filesystem permissions, tokens, trust boundaries, and remote access |
-
-## Requirements
-
-- Node.js 22.19.0 or newer
-- A DoomPi installation in the session repository, `DOOMPI_AGENT_COMMAND`, or the installed DoomPi package
+This is a standalone process, not a Pi extension. Do not add it to `.doom/modes.yaml`.
 
 ## Install
+
+Requires Node.js 22.19.0 or newer and a DoomPi installation.
 
 ```bash
 npm install -g @agimon-ai/doompi-server
@@ -31,7 +16,7 @@ npm install -g @agimon-ai/doompi-server
 
 ## Quick start
 
-Create a private runtime directory and token, then pass the agent arguments after `--`:
+Create a private runtime directory and token, then pass agent arguments after `--`:
 
 ```bash
 runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/doompi-session.XXXXXX")"
@@ -43,106 +28,44 @@ doompi-server \
   -- --major-mode copilot
 ```
 
-The token is read from the file, not from the command line. Keep the runtime directory private. The
-server appends `--mode rpc` to the agent invocation and waits for the agent to exit.
+The token is read from the file, not the command line. Keep the runtime directory private.
 
-To serve the browser cockpit from the same process, install the optional web package and add `--web`:
+Add `--web` to start or join DoomPi Web on port 7433. A standalone `doompi-web` process is the better choice when several sessions share one cockpit.
 
-```bash
-npm install -g @agimon-ai/doompi-web
-doompi-server \
-  --listen "$runtime_dir/session.sock" \
-  --auth-token-file "$runtime_dir/token" \
-  --name doompi-web \
-  --web \
-  -- --major-mode copilot
-```
-
-`--web` uses port `7433` by default. If a DoomPi cockpit already answers there, this server registers
-its session with that hub instead of starting another one. A standalone `doompi-web` process is the
-durable choice for several sessions.
+See [Getting started](docs/getting-started.md) for command options, agent selection, registry configuration, and the web integration.
 
 ## How it works
 
-The server resolves the session identity, composes or delegates the configured DoomPi installation,
-and starts one agent in RPC mode. It binds the session socket at `--listen`, the Pi protocol socket at
-`<listen>.pi`, and a package API socket at `api.sock` beside the session socket when session APIs are
-available. Only after these services are ready does it write the session record.
+The server resolves the configured DoomPi installation and starts one agent in RPC mode. It opens three local transports:
 
-A session has one supervised agent and one client on the framed session socket. Frames pass through
-unchanged after the attach handshake. If the client disconnects, the agent continues and a bounded
-backlog is replayed on the next attach. The [IPC guide](docs/ipc.md) describes the wire contracts.
+- `--listen` is the token-protected framed session socket.
+- `<listen>.pi` is the Pi routed protocol socket.
+- `api.sock` serves optional session package APIs.
 
-A major-mode change that needs a new extension composition is handled as a relaunch. The server keeps
-the session id, sockets, and registry record while it asks the current agent to exit cleanly and starts
-the replacement. See the [lifecycle guide](docs/lifecycle.md) for the state transitions.
+After the transports are ready, the server writes an owner-only registry record. DoomPi Web reads that record to find the sockets and token file. The token itself is not stored in the record, but the paths are sensitive and the registry must remain private.
 
-## Command line
+The framed socket allows one attached client. If it disconnects, the agent continues and the server keeps a bounded in-memory replay window. A major-mode change that needs a different extension composition relaunches the agent while keeping the server, session ID, sockets, and registry record.
 
-| Option                     | Default               | Meaning                                           |
-| -------------------------- | --------------------- | ------------------------------------------------- |
-| `--listen <path>`          | required              | Unix socket for the framed session transport      |
-| `--auth-token-file <path>` | required              | File containing the attach token                  |
-| `--name <name>`            | `untitled`            | Name shown by clients and written to the registry |
-| `--session-id <id>`        | generated UUID        | Session id; it must not contain `/`               |
-| `--registry-dir <path>`    | `~/.doompi/run`       | Parent of the session registry                    |
-| `--web [port]`             | no cockpit, or `7433` | Start or join the browser cockpit                 |
-| `-- <agent arguments>`     | none                  | Arguments passed to the DoomPi agent              |
+See [Lifecycle](docs/lifecycle.md) for startup and relaunch behavior, [IPC](docs/ipc.md) for wire contracts, and [Session APIs](docs/api.md) for package handlers and TypeScript exports.
 
-Options before `--` belong to `doompi-server`. Everything after it belongs to the agent. If agent
-arguments already contain `--session-id` or `--name`, those values are used for the session identity.
+## Security
 
-The registry directory can also be set with `DOOMPI_RUNTIME_DIR`. Agent selection uses
-`DOOMPI_AGENT_COMMAND` when the repository does not pin a different DoomPi launcher. `DOOMPI_API_DIR`
-can point the server at a generated session API directory. `DOOMPI_WEB_MODULE` selects the web module
-used by `--web`.
+The server listens on Unix sockets, not public network ports. Filesystem permissions protect the Pi protocol and package API sockets. The framed session socket also requires the attach token. These controls do not defend against root, a compromised owner account, or trusted package code.
 
-## Registry
+A browser never receives the Unix attach token. Remote browsers authenticate to DoomPi Web with a separate device cookie, and the web package owns the remote-access boundary. Do not expose any server socket through an unauthenticated TCP forwarder.
 
-Each running server writes one owner-only JSON record at
-`<registry-dir>/sessions/<session id>.json`. It contains the session id and name, working directory,
-socket paths, server pid, and creation time. It stores the token file path, never the token itself.
-The web cockpit watches these records and treats a dead pid as stale. The [security guide](docs/security.md)
-explains why the directory and its paths must remain private.
+Read [Security and trust boundaries](docs/security.md) before sharing a runtime directory or connecting the server to a remote cockpit.
 
-## Public API
+## Guides
 
-The package exports the socket servers, agent process adapter, Pi session service, transcript projection,
-and framing helpers:
-
-```ts
-import {
-  createAgentServerService,
-  serveProtocolSocket,
-  serveSessionSocket,
-  spawnAgentProcess,
-} from '@agimon-ai/doompi-server';
-```
-
-Use the [API guide](docs/api.md) for the session package API and the complete export roles.
-
-## Limits
-
-- One `doompi-server` process supervises one agent.
-- The framed Unix socket allows one attached client at a time.
-- The server's transports are Unix sockets, not network listeners. Use a trusted tunnel or the web
-  cockpit for remote access.
-- The executable path is covered by component and integration tests, but not by an end-to-end test of
-  every installed-package combination.
-
-## Development
-
-Run from this package directory:
-
-```bash
-pnpm build
-pnpm typecheck
-pnpm test
-pnpm lint
-```
-
-Maintained by [Agimon](https://agimon.ai/about).
+| Guide                                      | What it covers                                             |
+| ------------------------------------------ | ---------------------------------------------------------- |
+| [Getting started](docs/getting-started.md) | Installation, options, registry, and web integration       |
+| [Lifecycle](docs/lifecycle.md)             | Startup, agent selection, relaunches, and shutdown         |
+| [IPC](docs/ipc.md)                         | Unix sockets, attach and replay, framing, and Pi protocol  |
+| [Session APIs](docs/api.md)                | Package API routes and the TypeScript export surface       |
+| [Security](docs/security.md)               | Permissions, tokens, trusted inputs, and remote boundaries |
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/packages/clients/doompi-server/docs/api.md
+++ b/packages/clients/doompi-server/docs/api.md
@@ -1,0 +1,140 @@
+# Session APIs
+
+This guide covers two surfaces that are easy to confuse:
+
+1. session package APIs, which are HTTP handlers mounted on a local `api.sock`; and
+2. the TypeScript exports from `@agimon-ai/doompi-server`, which let another Node process compose the
+   same services.
+
+## Session package APIs
+
+A package declares a session API in its `package.json` under `doompiApi`. The declaration names a
+kebab-case base path and a built module for each scope it offers:
+
+```json
+{
+  "doompiApi": {
+    "basePath": "runner",
+    "session": {
+      "entry": "./src/api/session.ts",
+      "dist": "./dist/api/session.mjs"
+    }
+  }
+}
+```
+
+The manifest can contain an array of declarations. `entry` and `dist` must be package-relative paths
+without `..`; `dist` is required because the host imports the built module. A generated API bundle
+exports an `apis` array. Each entry has this shape:
+
+```ts
+interface DoomApi {
+  basePath: string;
+  start(context: DoomApiContext): {
+    fetch(request: Request): Response | Promise<Response>;
+    close(): void;
+  };
+}
+```
+
+A package's API is mounted only when its declaration is included in the generated session bundle. The
+server resolves that bundle from the synchronized repository containing the session's working directory.
+If that repository has no registration, it falls back to the installation that launched the server.
+`DOOMPI_API_DIR` overrides the generated directory. The server imports `<api directory>/session.routes.mjs`;
+no module is an ordinary no-API state.
+
+Broken entries do not take down the agent. The loader skips invalid values, duplicate base paths, and
+modules that do not export an `apis` array. If an API's `start()` throws, that API stays unmounted and
+the server notices the failure. When two loaded APIs claim a base path, the first one keeps it.
+
+### Routes and handler paths
+
+The server binds the package API server to `api.sock` in the session socket directory. It accepts only
+paths below `/api/plugin/`:
+
+```text
+/api/plugin/<basePath>/<package route>
+```
+
+The mount prefix is removed before the handler runs. A request to
+`/api/plugin/runner/runs/r1/log` therefore reaches the `runner` handler as `/runs/r1/log`. The handler
+also receives the original request headers and body.
+
+A path outside `/api/plugin/` returns HTTP 404. An unknown base path returns a JSON 404. An exception
+from a handler returns a generic JSON 500 and the other APIs remain available. Closing the server calls
+every mounted handler's `close()` method and removes `api.sock`. If no API starts successfully, the
+socket is not created and the registry record has no `apiSocketPath`.
+
+### Host context
+
+A session API receives a context with:
+
+| Field           | Value                                                                     |
+| --------------- | ------------------------------------------------------------------------- |
+| `scope`         | Always `session`                                                          |
+| `sessionId`     | The server's resolved session id                                          |
+| `cwd`           | The agent's working directory                                             |
+| `internalToken` | A server-generated random token shared with the child session environment |
+| `hubToken`      | The configured attach token, shared with the cockpit hub context          |
+| `onNotice`      | A callback for host-visible diagnostics                                   |
+
+The server does not pass a browser credential to the package API. The internal and hub tokens are
+process context for trusted package code, not route authentication. A session API is local to the
+server's Unix socket; the web cockpit is responsible for authenticating and proxying browser requests.
+
+## TypeScript server exports
+
+The package keeps its export map closed at `.` and `./package.json`. The main export includes these
+roles:
+
+| Export                                    | Role                                                                 |
+| ----------------------------------------- | -------------------------------------------------------------------- |
+| `spawnAgentProcess`                       | Spawn one RPC agent with piped stdin and stdout and inherited stderr |
+| `serveSessionSocket`                      | Serve the token-protected framed Unix socket with reconnect backlog  |
+| `serveProtocolSocket`                     | Serve a Pi 0.85 routed `ServerHost` over a Unix socket               |
+| `createAgentServerService`                | Build management and session services around one agent               |
+| `createAgentSessionRuntime`               | Project agent frames into replicated snapshot and progress state     |
+| `createRpcTranscript`                     | Reduce Pi RPC events into the session transcript model               |
+| `createFrameDecoder`, `encodeFrame`       | Decode and encode newline-delimited JSON frames                      |
+| `createDetachedBacklog`                   | Provide a bounded detached-client replay buffer                      |
+| `evaluateHandshake`                       | Validate the first attach frame and token                            |
+| `parseServeOptions`, `SERVE_USAGE`        | Parse the executable's server options                                |
+| `SESSION_RECORD_VERSION`, `SessionRecord` | Describe the registry record format                                  |
+
+A minimal protocol composition looks like this:
+
+```ts
+import { createAgentServerService, serveProtocolSocket, spawnAgentProcess } from '@agimon-ai/doompi-server';
+
+const agent = spawnAgentProcess({ command, args, cwd, env });
+const service = createAgentServerService({
+  agent,
+  sessionId: 'session-id',
+  sessionName: 'work',
+  cwd,
+  createdAt: Date.now(),
+});
+const protocol = await serveProtocolSocket({ socketPath: '/private/session.sock.pi', service });
+```
+
+`serveSessionSocket` uses the same `AgentProcess` but exposes the lower-level framed transport. Load the
+token from an owner-only file before constructing the socket:
+
+```ts
+import { serveSessionSocket } from '@agimon-ai/doompi-server';
+
+const socket = serveSessionSocket({
+  socketPath: '/private/session.sock',
+  token: tokenFromOwnerOnlyFile,
+  agent,
+});
+```
+
+Call `close()` on each returned server during shutdown. The executable's complete ordering, including
+agent supervision and registry cleanup, is in [Lifecycle](lifecycle.md).
+
+## Related guides
+
+- [IPC](ipc.md) has wire examples for the framed and Pi protocol sockets.
+- [Lifecycle](lifecycle.md) explains when API modules load and when the socket closes.
+- [Security](security.md) describes the local access boundary and context token handling.

--- a/packages/clients/doompi-server/docs/api.md
+++ b/packages/clients/doompi-server/docs/api.md
@@ -1,15 +1,48 @@
 # Session APIs
 
-This guide covers two surfaces that are easy to confuse:
+Session APIs let a DoomPi package add HTTP behavior beside the agent it extends. The handler runs in `doompi-server`, receives session context from the host, and is reached through a local Unix socket. A browser never loads the server module directly.
 
-1. session package APIs, which are HTTP handlers mounted on a local `api.sock`; and
-2. the TypeScript exports from `@agimon-ai/doompi-server`, which let another Node process compose the
-   same services.
+This guide also covers the package's TypeScript exports. They are a separate surface for Node.js callers that want to compose the server services themselves.
 
-## Session package APIs
+## The design
 
-A package declares a session API in its `package.json` under `doompiApi`. The declaration names a
-kebab-case base path and a built module for each scope it offers:
+```text
+package.json doompiApi declaration
+                |
+                v
+       doompi sync generation
+         session.routes.mjs
+                |
+                v
+         doompi-server
+      start(context) per API
+                |
+                v
+    HTTP over local api.sock
+                |
+         DoomPi Web proxy
+                |
+              browser
+```
+
+The generated route module is part of the synchronized composition. That matters for two reasons:
+
+- the API implementation follows the same repository and package selection as the agent
+- discovery and validation happen during sync instead of by scanning arbitrary modules at request time
+
+The server starts each handler once, routes requests to it by a fixed base path, and calls `close()` during shutdown. One broken optional API is isolated so it does not take down the agent or unrelated packages.
+
+## Why the API is process-local
+
+A session API may inspect session state, read bounded files, or control a package service. It therefore runs next to the session and receives trusted host context. The server exposes it on `api.sock`, not on a network port.
+
+DoomPi Web owns browser authentication and proxies approved requests to that socket. Keeping those responsibilities separate avoids teaching every package about device cookies, tunnels, and session discovery. It also means a handler must not mistake local transport for validation: package code still has to validate input and enforce its own resource bounds.
+
+Hub-wide APIs are a different scope and run in DoomPi Web. See the web package API guide when an operation belongs to the machine or repository rather than one live agent session.
+
+## Declare a session API
+
+A package declares `doompiApi` in `package.json`:
 
 ```json
 {
@@ -23,9 +56,13 @@ kebab-case base path and a built module for each scope it offers:
 }
 ```
 
-The manifest can contain an array of declarations. `entry` and `dist` must be package-relative paths
-without `..`; `dist` is required because the host imports the built module. A generated API bundle
-exports an `apis` array. Each entry has this shape:
+The field can also contain an array of declarations. `basePath` is kebab-case. `entry` and `dist` are package-relative paths without `..`; `dist` is required because the server imports built JavaScript, not package source.
+
+A package without session API metadata contributes nothing to this surface. A declaration is available only when it belongs to the synchronized package composition selected for the session.
+
+## Implement the handler
+
+The generated registry exports an `apis` array. Each entry implements the same lifecycle:
 
 ```ts
 interface DoomApi {
@@ -37,71 +74,68 @@ interface DoomApi {
 }
 ```
 
-A package's API is mounted only when its declaration is included in the generated session bundle. The
-server resolves that bundle from the synchronized repository containing the session's working directory.
-If that repository has no registration, it falls back to the installation that launched the server.
-`DOOMPI_API_DIR` overrides the generated directory. The server imports `<api directory>/session.routes.mjs`;
-no module is an ordinary no-API state.
+`start()` creates session-owned resources once. `fetch()` handles requests relative to the package mount. `close()` must release timers, watchers, streams, and other resources created during startup.
 
-Broken entries do not take down the agent. The loader skips invalid values, duplicate base paths, and
-modules that do not export an `apis` array. If an API's `start()` throws, that API stays unmounted and
-the server notices the failure. When two loaded APIs claim a base path, the first one keeps it.
+A typical package exports one named `api` value through its built entry. The generated registry collects those exports for the server.
 
-### Routes and handler paths
+## Selecting the API composition
 
-The server binds the package API server to `api.sock` in the session socket directory. It accepts only
-paths below `/api/plugin/`:
+The server resolves the synchronized repository containing the session working directory. Its `session.routes.mjs` is the API composition for that agent. If no repository registration is available, the server falls back to the installation that launched it. `DOOMPI_API_DIR` is an explicit operator override.
+
+This keeps APIs aligned with the agent instead of borrowing handlers from another live repository. A running server loads its API registry at startup; rebuild and restart the session after changing a server-side API.
+
+No route module is a valid no-API state. If no handler starts successfully, the server does not create `api.sock` and the registry record has no `apiSocketPath`.
+
+## Routing
+
+The socket accepts only paths under:
 
 ```text
 /api/plugin/<basePath>/<package route>
 ```
 
-The mount prefix is removed before the handler runs. A request to
-`/api/plugin/runner/runs/r1/log` therefore reaches the `runner` handler as `/runs/r1/log`. The handler
-also receives the original request headers and body.
+The host removes `/api/plugin/<basePath>` before calling the handler. A request to `/api/plugin/runner/runs/r1/log` therefore arrives as `/runs/r1/log`, with its remaining headers and body intact.
 
-A path outside `/api/plugin/` returns HTTP 404. An unknown base path returns a JSON 404. An exception
-from a handler returns a generic JSON 500 and the other APIs remain available. Closing the server calls
-every mounted handler's `close()` method and removes `api.sock`. If no API starts successfully, the
-socket is not created and the registry record has no `apiSocketPath`.
+A path outside `/api/plugin/` returns `404`. An unknown base path returns a JSON `404`. A handler exception becomes a generic JSON `500`; the other APIs remain mounted.
 
-### Host context
+When two loaded APIs claim the same base path, the first keeps it and the later declaration is skipped. Invalid registry values, modules without an `apis` array, and handlers whose `start()` throws are reported as notices rather than process failures.
 
-A session API receives a context with:
+## Host context and authority
 
-| Field           | Value                                                                     |
-| --------------- | ------------------------------------------------------------------------- |
-| `scope`         | Always `session`                                                          |
-| `sessionId`     | The server's resolved session id                                          |
-| `cwd`           | The agent's working directory                                             |
-| `internalToken` | A server-generated random token shared with the child session environment |
-| `hubToken`      | The configured attach token, shared with the cockpit hub context          |
-| `onNotice`      | A callback for host-visible diagnostics                                   |
+A session handler receives:
 
-The server does not pass a browser credential to the package API. The internal and hub tokens are
-process context for trusted package code, not route authentication. A session API is local to the
-server's Unix socket; the web cockpit is responsible for authenticating and proxying browser requests.
+| Field           | Meaning                                                     |
+| --------------- | ----------------------------------------------------------- |
+| `scope`         | Always `session`                                            |
+| `sessionId`     | Resolved identity of the owning server                      |
+| `cwd`           | Agent working directory                                     |
+| `internalToken` | Random token shared with the child session environment      |
+| `hubToken`      | Configured attach token shared with trusted cockpit context |
+| `onNotice`      | Host-visible diagnostic callback                            |
+
+The server does not pass a browser credential to the package API. `internalToken` and `hubToken` are process context for trusted package code, not automatic route authorization. If a handler needs caller locality, device identity, or step-up status from DoomPi Web, it must use the trusted caller context stamped by that proxy rather than accept browser-supplied authorization headers.
+
+Package APIs are executable trusted code. Validate bodies, bound reads and streams, constrain file paths to the intended scope, and do not return secrets merely because the request arrived on a Unix socket.
 
 ## TypeScript server exports
 
-The package keeps its export map closed at `.` and `./package.json`. The main export includes these
-roles:
+The package export map is closed at `.` and `./package.json`. The main entry exposes the same building blocks used by the executable:
 
-| Export                                    | Role                                                                 |
-| ----------------------------------------- | -------------------------------------------------------------------- |
-| `spawnAgentProcess`                       | Spawn one RPC agent with piped stdin and stdout and inherited stderr |
-| `serveSessionSocket`                      | Serve the token-protected framed Unix socket with reconnect backlog  |
-| `serveProtocolSocket`                     | Serve a Pi 0.85 routed `ServerHost` over a Unix socket               |
-| `createAgentServerService`                | Build management and session services around one agent               |
-| `createAgentSessionRuntime`               | Project agent frames into replicated snapshot and progress state     |
-| `createRpcTranscript`                     | Reduce Pi RPC events into the session transcript model               |
-| `createFrameDecoder`, `encodeFrame`       | Decode and encode newline-delimited JSON frames                      |
-| `createDetachedBacklog`                   | Provide a bounded detached-client replay buffer                      |
-| `evaluateHandshake`                       | Validate the first attach frame and token                            |
-| `parseServeOptions`, `SERVE_USAGE`        | Parse the executable's server options                                |
-| `SESSION_RECORD_VERSION`, `SessionRecord` | Describe the registry record format                                  |
+| Export                                    | Responsibility                                                   |
+| ----------------------------------------- | ---------------------------------------------------------------- |
+| `spawnAgentProcess`                       | Start one RPC agent with piped stdin/stdout and inherited stderr |
+| `serveSessionSocket`                      | Serve the token-protected framed socket and reconnect backlog    |
+| `serveProtocolSocket`                     | Serve the Pi 0.85 routed host over a Unix socket                 |
+| `createAgentServerService`                | Compose management and session services around one agent         |
+| `createAgentSessionRuntime`               | Project agent frames into replicated state and progress          |
+| `createRpcTranscript`                     | Reduce Pi RPC events into the transcript model                   |
+| `createFrameDecoder`, `encodeFrame`       | Decode and encode newline-delimited frames                       |
+| `createDetachedBacklog`                   | Maintain the bounded detached-client window                      |
+| `evaluateHandshake`                       | Validate the first attach frame and token                        |
+| `parseServeOptions`, `SERVE_USAGE`        | Parse executable options                                         |
+| `SESSION_RECORD_VERSION`, `SessionRecord` | Describe the discovery record                                    |
 
-A minimal protocol composition looks like this:
+A minimal routed protocol composition looks like this:
 
 ```ts
 import { createAgentServerService, serveProtocolSocket, spawnAgentProcess } from '@agimon-ai/doompi-server';
@@ -117,8 +151,7 @@ const service = createAgentServerService({
 const protocol = await serveProtocolSocket({ socketPath: '/private/session.sock.pi', service });
 ```
 
-`serveSessionSocket` uses the same `AgentProcess` but exposes the lower-level framed transport. Load the
-token from an owner-only file before constructing the socket:
+For the lower-level framed transport, load the token from an owner-only file:
 
 ```ts
 import { serveSessionSocket } from '@agimon-ai/doompi-server';
@@ -130,11 +163,10 @@ const socket = serveSessionSocket({
 });
 ```
 
-Call `close()` on each returned server during shutdown. The executable's complete ordering, including
-agent supervision and registry cleanup, is in [Lifecycle](lifecycle.md).
+Call `close()` on every returned service during shutdown. The executable's ordering and cleanup behavior are described in [Lifecycle](lifecycle.md).
 
 ## Related guides
 
-- [IPC](ipc.md) has wire examples for the framed and Pi protocol sockets.
-- [Lifecycle](lifecycle.md) explains when API modules load and when the socket closes.
-- [Security](security.md) describes the local access boundary and context token handling.
+- [IPC](ipc.md) explains the package API socket beside the other session transports.
+- [Lifecycle](lifecycle.md) explains when API modules load and close.
+- [Security](security.md) describes context tokens and the local trust boundary.

--- a/packages/clients/doompi-server/docs/getting-started.md
+++ b/packages/clients/doompi-server/docs/getting-started.md
@@ -1,0 +1,143 @@
+# Getting started
+
+`doompi-server` is the process boundary for one headless DoomPi session. It starts the agent, keeps it alive when a client disconnects, and publishes local endpoints that a terminal client or DoomPi Web can attach to.
+
+## Choose the topology
+
+Use the server directly when you are building a local client or need one durable headless session:
+
+```text
+client -> authenticated Unix socket -> doompi-server -> Pi RPC agent
+```
+
+Add DoomPi Web when a browser should control the session:
+
+```text
+browser -> DoomPi Web hub -> authenticated Unix socket -> doompi-server -> agent
+```
+
+The hub, not the browser, reads the session token. For several sessions, run one standalone `doompi-web` hub and let it discover multiple server records.
+
+## Requirements
+
+- Node.js 22.19.0 or newer
+- A DoomPi installation in the session repository, `DOOMPI_AGENT_COMMAND`, or the installed DoomPi package
+
+Install the published server:
+
+```bash
+npm install -g @agimon-ai/doompi-server
+```
+
+## Start a session
+
+Create both the socket and token under a private directory:
+
+```bash
+runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/doompi-session.XXXXXX")"
+(umask 077; openssl rand -base64 32 > "$runtime_dir/token")
+
+doompi-server \
+  --listen "$runtime_dir/session.sock" \
+  --auth-token-file "$runtime_dir/token" \
+  --name work \
+  -- --major-mode copilot
+```
+
+Server options appear before `--`. Everything after it is passed to DoomPi. The server appends `--mode rpc`, starts the selected agent, and waits for that child to exit.
+
+The token is a session-control capability. It is read from the file so it does not appear in the server's argument list. The server refuses an empty token but does not create or protect the file for you. Keep the runtime directory private.
+
+## What startup creates
+
+A ready session owns:
+
+| Resource          | Purpose                                                   |
+| ----------------- | --------------------------------------------------------- |
+| `session.sock`    | Token-protected raw Pi RPC attachment                     |
+| `session.sock.pi` | Pi routed state and command protocol                      |
+| `api.sock`        | Optional HTTP routes from session packages                |
+| Registry record   | Discovery metadata for DoomPi Web and other local clients |
+
+The registry record is written only after the agent and transports are ready. It contains paths to these resources and the token file, not the token value. See [Lifecycle](lifecycle.md) for startup ordering and [IPC](ipc.md) for the wire contracts.
+
+## Command options
+
+| Option                     | Default             | Meaning                                          |
+| -------------------------- | ------------------- | ------------------------------------------------ |
+| `--listen <path>`          | required            | Unix socket for the framed session transport     |
+| `--auth-token-file <path>` | required            | File containing the attach token                 |
+| `--name <name>`            | `untitled`          | Name shown by clients and stored in the registry |
+| `--session-id <id>`        | generated UUID      | Stable session identity; it must not contain `/` |
+| `--registry-dir <path>`    | `~/.doompi/run`     | Parent of the session registry                   |
+| `--web [port]`             | disabled, or `7433` | Start or join the browser cockpit                |
+| `-- <agent arguments>`     | none                | Arguments passed to DoomPi                       |
+
+Agent-side `--session-id` and `--name` values take precedence over the server options. The environment provides these operator overrides:
+
+| Variable               | Purpose                                           |
+| ---------------------- | ------------------------------------------------- |
+| `DOOMPI_RUNTIME_DIR`   | Change the registry directory                     |
+| `DOOMPI_AGENT_COMMAND` | Select a fallback JavaScript module or executable |
+| `DOOMPI_API_DIR`       | Select a generated session API directory          |
+| `DOOMPI_WEB_MODULE`    | Select the web module used by `--web`             |
+
+## How the agent is selected
+
+A headless session should follow the repository it runs inside. Selection therefore prefers:
+
+1. the nearest repository-local `@agimon-ai/doompi` installation
+2. `DOOMPI_AGENT_COMMAND` when no local installation exists
+3. the installed DoomPi package composed in process
+
+Composition errors stop startup before an agent is spawned or a registry record is published. A later major-mode change may relaunch the agent while the server identity and sockets stay in place. See [Lifecycle](lifecycle.md).
+
+## Session registry
+
+The default record is `<registry-dir>/sessions/<session-id>.json`. It contains the session identity, working directory, process ID, socket paths, creation time, and token file path.
+
+DoomPi Web watches this directory and removes records whose process is no longer alive. A custom registry directory changes discovery, not authentication. Keep the registry private because its paths tell a local process where the session and credential live.
+
+## Add the browser cockpit
+
+Install the optional web package and pass `--web`:
+
+```bash
+npm install -g @agimon-ai/doompi-web
+
+doompi-server \
+  --listen "$runtime_dir/session.sock" \
+  --auth-token-file "$runtime_dir/token" \
+  --name work \
+  --web \
+  -- --major-mode copilot
+```
+
+If DoomPi Web already answers on port 7433, the server registers with that hub. Otherwise it starts a loopback cockpit in the same process.
+
+For several sessions, start the hub independently:
+
+```bash
+doompi-web
+```
+
+Each server publishes a record under the same registry. The hub reads those records and holds one authenticated attachment per session. Browser authentication, remote tunnels, device cookies, and passkeys are owned by DoomPi Web, not this server.
+
+## Stop and recover
+
+`SIGINT` and `SIGTERM` stop the agent, close the sockets, and remove the registry record. A hard crash can leave files behind. A later server probes a stale socket before removing it, and DoomPi Web ignores records whose process is dead.
+
+A live socket is never taken over silently. If another process still owns the requested path, startup fails.
+
+## Development
+
+Run from `packages/clients/doompi-server`:
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm test
+pnpm lint
+```
+
+Read [Security](security.md) before sharing a registry or runtime directory. Read [Session APIs](api.md) when a package needs an HTTP surface beside its agent.

--- a/packages/clients/doompi-server/docs/ipc.md
+++ b/packages/clients/doompi-server/docs/ipc.md
@@ -1,0 +1,123 @@
+# IPC and wire protocols
+
+For a session, the server uses local Unix sockets for every client-facing transport. It does not open
+a TCP listener for a session. The optional `--web` cockpit is a separate loopback HTTP listener. The
+agent itself is a child process connected through newline-delimited JSON on stdin and stdout.
+
+## Endpoints
+
+| Endpoint                     | Transport                               | Role                                        |
+| ---------------------------- | --------------------------------------- | ------------------------------------------- |
+| `--listen <path>`            | newline-delimited JSON over Unix socket | Authenticated framed session attachment     |
+| `<listen>.pi`                | Pi 0.85 routed Unix protocol            | Chord services and replicated session state |
+| `dirname(<listen>)/api.sock` | HTTP over Unix socket                   | Session package APIs, when APIs are mounted |
+| agent stdin and stdout       | newline-delimited JSON pipes            | Server to Pi RPC and Pi RPC to server       |
+
+The registry record contains the absolute session, protocol, and optional package API socket paths. The
+relaunch and composition files sit beside the session socket and are server-agent handoff files, not
+client endpoints.
+
+## Agent pipe
+
+The server starts the resolved command with the caller's working directory and environment, then adds
+`--mode rpc` to its arguments. Standard input and output are pipes. Standard error is inherited by the
+process that started `doompi-server`, so agent diagnostics do not depend on an attached client.
+
+The server decodes complete JSON objects separated by `\n`. A read can end in the middle of a frame;
+the decoder retains that fragment until the next read. Empty lines are ignored. Frames are kept as
+opaque objects (`Record<string, unknown>`) so Pi can evolve its RPC vocabulary without a second server
+schema. Malformed client frames are rejected as described below.
+
+## Framed session socket
+
+### Attach handshake
+
+The first frame on a new connection must be an `attach` frame with the token from the configured token
+file:
+
+```json
+{ "type": "attach", "token": "..." }
+```
+
+An optional W3C `traceparent` field is accepted for server telemetry. A successful attach receives an
+acknowledgement before any replay frames:
+
+```json
+{ "type": "attached", "replayed": 0, "dropped": 0 }
+```
+
+The server rejects the connection when:
+
+- the first frame is not `attach`;
+- `token` is not a string or does not match the configured token;
+- another client already holds the session; or
+- the stream contains malformed JSON.
+
+Rejection uses this shape and then closes the connection:
+
+```json
+{ "type": "attach_error", "reason": "The attach token was rejected." }
+```
+
+Token comparison checks the lengths and compares equal-length bytes with a timing-safe comparison.
+After the handshake, frames from the client go to the agent and frames from the agent go to the client
+unchanged. The server does not reinterpret ordinary Pi RPC frames on this transport.
+
+### One client and reconnects
+
+Only one client can hold the framed session socket. A second connection is refused rather than sharing
+writes with the first client. Closing the client connection does not stop the agent or the server.
+
+While no client is attached, the server keeps a bounded backlog of up to 512 frames. The oldest frames
+are dropped when the limit is exceeded. On the next attach, the server sends the `attached` acknowledgement
+with the replay counts, then wraps each replayed frame:
+
+```json
+{ "type": "replay", "frame": { "type": "message_end" } }
+```
+
+`dropped` is the number of backlog frames discarded since the previous drain. The server also retains
+the latest `extension_ui_request` projection for `setStatus` and `setWidget`, so a reconnect receives the
+current status and widget state even when those frames were emitted while attached. A replay count can
+therefore include both projections and backlog frames.
+
+Frames are never added to the backlog while a client is attached. The backlog is an in-memory recovery
+window, not durable session storage. The Pi routed protocol and its transcript snapshot provide the
+authoritative state for clients that need more than that window.
+
+## Pi routed protocol
+
+The `<listen>.pi` endpoint is a Pi 0.85 `ServerHost` served by `@earendil-works/pi-server`. Its server
+identity is generated at startup and recorded as `protocolServerId`. A Pi client should read both values
+from the session registry and connect with the matching Unix transport and server id.
+
+The host publishes two Chord services:
+
+- `doompi.session-management.v1`: `attach(sessionId)` selects this server's one session, and
+  `detach()` releases that attachment.
+- `doompi.session.v1`: `state` is replicated session state; `prompt(text)`, `steer(text)`, `abort()`,
+  `setModel({ provider, id })`, and `setThinking(level)` control the supervised agent.
+
+The session service projects Pi RPC events into a snapshot plus transient progress. The snapshot carries
+the session identity, working directory, phase (`idle`, `turn`, `compaction`, or `retry`), model,
+thinking level, attachment and lock flags, revision, transcript, and queued steering messages.
+Progress carries item start, update, and finish events while a turn is running. A prompt waits for
+`agent_settled`; steering and abort require an active turn, and a second prompt while a turn is running
+is rejected without dropping the protocol connection.
+
+The protocol socket uses owner-only Unix-socket access. It has no `attach` token frame because filesystem
+permissions are its local access boundary. It is a different protocol from the framed session socket;
+clients should not send raw `attach` frames to `<listen>.pi`.
+
+## Package API socket
+
+When session package APIs are loaded, `api.sock` serves HTTP requests under
+`/api/plugin/<basePath>/...`. The host strips that prefix before invoking a package handler. For example,
+`/api/plugin/runner/runs/r1/log` reaches the `runner` API as `/runs/r1/log`. See [API](api.md) for the
+mount and handler contract.
+
+## Related guides
+
+- [Lifecycle](lifecycle.md) explains startup order, relaunches, and cleanup.
+- [API](api.md) documents package API routes and TypeScript exports.
+- [Security](security.md) explains which Unix permissions and tokens protect these transports.

--- a/packages/clients/doompi-server/docs/ipc.md
+++ b/packages/clients/doompi-server/docs/ipc.md
@@ -1,123 +1,122 @@
 # IPC and wire protocols
 
-For a session, the server uses local Unix sockets for every client-facing transport. It does not open
-a TCP listener for a session. The optional `--web` cockpit is a separate loopback HTTP listener. The
-agent itself is a child process connected through newline-delimited JSON on stdin and stdout.
+`doompi-server` exposes one agent through three local interfaces. They are separate because they serve different clients and consistency models. The low-level session bridge carries Pi RPC frames, the routed protocol exposes replicated application state, and the package API socket serves HTTP handlers.
 
-## Endpoints
+## The transport design
 
-| Endpoint                     | Transport                               | Role                                        |
-| ---------------------------- | --------------------------------------- | ------------------------------------------- |
-| `--listen <path>`            | newline-delimited JSON over Unix socket | Authenticated framed session attachment     |
-| `<listen>.pi`                | Pi 0.85 routed Unix protocol            | Chord services and replicated session state |
-| `dirname(<listen>)/api.sock` | HTTP over Unix socket                   | Session package APIs, when APIs are mounted |
-| agent stdin and stdout       | newline-delimited JSON pipes            | Server to Pi RPC and Pi RPC to server       |
+```text
+                         doompi-server
+                               |
+         +---------------------+---------------------+
+         |                     |                     |
+         v                     v                     v
+ framed session socket   Pi routed socket      package API socket
+ raw Pi RPC stream       state and commands    HTTP package routes
+ token + mode 0600       mode 0600             local filesystem boundary
+         |
+         v
+ supervised Pi RPC child over stdin/stdout
+```
 
-The registry record contains the absolute session, protocol, and optional package API socket paths. The
-relaunch and composition files sit beside the session socket and are server-agent handoff files, not
-client endpoints.
+All session transports are Unix sockets. The server does not open a TCP listener for them. This keeps discovery and authorization on the local filesystem and lets the browser hub hold session credentials without sending them to a page. The optional `--web` listener is a separate loopback HTTP service owned by DoomPi Web.
+
+## Why there are three sockets
+
+| Endpoint                     | Consumer                            | Contract                                                             |
+| ---------------------------- | ----------------------------------- | -------------------------------------------------------------------- |
+| `--listen <path>`            | DoomPi Web and legacy frame clients | Authenticated, newline-delimited Pi RPC frames with reconnect replay |
+| `<listen>.pi`                | Pi 0.85 protocol clients            | Routed Chord services and replicated session state                   |
+| `dirname(<listen>)/api.sock` | Web hub and trusted local callers   | HTTP routes contributed by session packages                          |
+
+The framed socket is intentionally narrow. It forwards the agent's protocol without inventing a second schema. The routed socket is the higher-level interface for clients that need authoritative state rather than a best-effort frame window. Package APIs remain HTTP because package features often already model requests, responses, streaming, and status codes that way.
+
+The registry record publishes the absolute paths and protocol server ID needed to locate these interfaces. Relaunch and composition handoff files may sit beside them, but they are private server-agent state, not client endpoints.
 
 ## Agent pipe
 
-The server starts the resolved command with the caller's working directory and environment, then adds
-`--mode rpc` to its arguments. Standard input and output are pipes. Standard error is inherited by the
-process that started `doompi-server`, so agent diagnostics do not depend on an attached client.
+The server starts the selected command in the session working directory, preserves the caller's environment, and adds `--mode rpc`. Agent stdin and stdout are newline-delimited JSON pipes. Agent stderr is inherited by the process that launched the server, so diagnostics remain visible even when no client is attached.
 
-The server decodes complete JSON objects separated by `\n`. A read can end in the middle of a frame;
-the decoder retains that fragment until the next read. Empty lines are ignored. Frames are kept as
-opaque objects (`Record<string, unknown>`) so Pi can evolve its RPC vocabulary without a second server
-schema. Malformed client frames are rejected as described below.
+The frame decoder accepts complete JSON objects separated by `\n`. It retains a partial trailing frame until another read completes it and ignores empty lines. Decoded frames remain opaque `Record<string, unknown>` values. This allows Pi to evolve its RPC vocabulary without requiring the bridge to duplicate every message type.
 
 ## Framed session socket
 
+### Why the server owns the attachment
+
+Only one client can hold the framed socket at a time. Serial ownership prevents two clients from interleaving commands on one agent stdin stream. Multi-browser support belongs in DoomPi Web: the hub holds the single server attachment and multiplexes browser tabs above it.
+
+The connection is authenticated because knowing a local socket path is not treated as sufficient authority for this low-level control channel.
+
 ### Attach handshake
 
-The first frame on a new connection must be an `attach` frame with the token from the configured token
-file:
+The first frame must contain the token from `--auth-token-file`:
 
 ```json
 { "type": "attach", "token": "..." }
 ```
 
-An optional W3C `traceparent` field is accepted for server telemetry. A successful attach receives an
-acknowledgement before any replay frames:
+An optional W3C `traceparent` is accepted for telemetry. After validating the token and exclusive attachment, the server acknowledges before sending any replay:
 
 ```json
 { "type": "attached", "replayed": 0, "dropped": 0 }
 ```
 
-The server rejects the connection when:
-
-- the first frame is not `attach`;
-- `token` is not a string or does not match the configured token;
-- another client already holds the session; or
-- the stream contains malformed JSON.
-
-Rejection uses this shape and then closes the connection:
+The server rejects and closes the connection when the first frame is not `attach`, the token is missing or wrong, another client already owns the session, or the stream contains malformed JSON. Errors use an `attach_error` frame:
 
 ```json
 { "type": "attach_error", "reason": "The attach token was rejected." }
 ```
 
-Token comparison checks the lengths and compares equal-length bytes with a timing-safe comparison.
-After the handshake, frames from the client go to the agent and frames from the agent go to the client
-unchanged. The server does not reinterpret ordinary Pi RPC frames on this transport.
+Token comparison checks lengths first and uses a timing-safe comparison for equal-length bytes. After attachment, ordinary frames pass between client and agent unchanged.
 
-### One client and reconnects
+### Reconnect window
 
-Only one client can hold the framed session socket. A second connection is refused rather than sharing
-writes with the first client. Closing the client connection does not stop the agent or the server.
+A client disconnect does not stop the agent. While detached, the server retains up to 512 frames in memory. When the limit is exceeded, the oldest frames are dropped.
 
-While no client is attached, the server keeps a bounded backlog of up to 512 frames. The oldest frames
-are dropped when the limit is exceeded. On the next attach, the server sends the `attached` acknowledgement
-with the replay counts, then wraps each replayed frame:
+The next successful attachment receives the replay and drop counts, followed by wrapped frames:
 
 ```json
 { "type": "replay", "frame": { "type": "message_end" } }
 ```
 
-`dropped` is the number of backlog frames discarded since the previous drain. The server also retains
-the latest `extension_ui_request` projection for `setStatus` and `setWidget`, so a reconnect receives the
-current status and widget state even when those frames were emitted while attached. A replay count can
-therefore include both projections and backlog frames.
+The `dropped` count reports frames discarded since the previous drain. The server also keeps the latest `extension_ui_request` projections for status and widget updates, so the replay count can include those snapshots as well as backlog frames.
 
-Frames are never added to the backlog while a client is attached. The backlog is an in-memory recovery
-window, not durable session storage. The Pi routed protocol and its transcript snapshot provide the
-authoritative state for clients that need more than that window.
+Frames are not added to the backlog while a client is attached. The backlog is a short recovery window, not durable history. A client that needs authoritative state after a long absence should use the routed protocol snapshot.
 
 ## Pi routed protocol
 
-The `<listen>.pi` endpoint is a Pi 0.85 `ServerHost` served by `@earendil-works/pi-server`. Its server
-identity is generated at startup and recorded as `protocolServerId`. A Pi client should read both values
-from the session registry and connect with the matching Unix transport and server id.
+The `<listen>.pi` socket hosts a Pi 0.85 `ServerHost` through `@earendil-works/pi-server`. Its generated identity is stored in the registry as `protocolServerId`; clients must use that ID with the recorded socket path.
 
 The host publishes two Chord services:
 
-- `doompi.session-management.v1`: `attach(sessionId)` selects this server's one session, and
-  `detach()` releases that attachment.
-- `doompi.session.v1`: `state` is replicated session state; `prompt(text)`, `steer(text)`, `abort()`,
-  `setModel({ provider, id })`, and `setThinking(level)` control the supervised agent.
+- `doompi.session-management.v1` attaches or detaches this server's one session.
+- `doompi.session.v1` replicates state and accepts `prompt`, `steer`, `abort`, `setModel`, and `setThinking` commands.
 
-The session service projects Pi RPC events into a snapshot plus transient progress. The snapshot carries
-the session identity, working directory, phase (`idle`, `turn`, `compaction`, or `retry`), model,
-thinking level, attachment and lock flags, revision, transcript, and queued steering messages.
-Progress carries item start, update, and finish events while a turn is running. A prompt waits for
-`agent_settled`; steering and abort require an active turn, and a second prompt while a turn is running
-is rejected without dropping the protocol connection.
+The session service projects Pi RPC events into a stable snapshot plus transient progress. The snapshot includes identity, working directory, phase, model, thinking level, attachment and lock state, revision, transcript, and queued steering messages. Progress reports item start, update, and finish while a turn runs.
 
-The protocol socket uses owner-only Unix-socket access. It has no `attach` token frame because filesystem
-permissions are its local access boundary. It is a different protocol from the framed session socket;
-clients should not send raw `attach` frames to `<listen>.pi`.
+A prompt waits for `agent_settled`. Steering and abort require an active turn. A second prompt during a turn is rejected without dropping the protocol connection.
+
+This socket has no `attach` token frame. Owner-only filesystem access is its authorization boundary, and its wire protocol is not the framed session protocol. Sending a raw `attach` frame to `<listen>.pi` is a protocol error.
 
 ## Package API socket
 
-When session package APIs are loaded, `api.sock` serves HTTP requests under
-`/api/plugin/<basePath>/...`. The host strips that prefix before invoking a package handler. For example,
-`/api/plugin/runner/runs/r1/log` reaches the `runner` API as `/runs/r1/log`. See [API](api.md) for the
-mount and handler contract.
+When at least one session API starts, `api.sock` serves HTTP below:
+
+```text
+/api/plugin/<basePath>/...
+```
+
+The server removes `/api/plugin/<basePath>` before invoking the package handler. For example, `/api/plugin/runner/runs/r1/log` reaches the `runner` handler as `/runs/r1/log`.
+
+The socket is absent when no API starts successfully. See [Session APIs](api.md) for discovery, context, failure isolation, and handler lifetime.
+
+## Security boundary
+
+Unix sockets replace network reachability with filesystem reachability; they do not make callers harmless. The framed socket adds a token, while the routed and package API sockets rely on private paths and permissions. A process running as the owner or root remains trusted.
+
+Do not expose these sockets through an unauthenticated TCP forwarder. DoomPi Web provides the separate browser and remote-access boundary described in [Security](security.md).
 
 ## Related guides
 
-- [Lifecycle](lifecycle.md) explains startup order, relaunches, and cleanup.
-- [API](api.md) documents package API routes and TypeScript exports.
-- [Security](security.md) explains which Unix permissions and tokens protect these transports.
+- [Lifecycle](lifecycle.md) explains why the sockets outlive client attachments and agent generations.
+- [Session APIs](api.md) defines the package handler contract.
+- [Security](security.md) explains credentials, permissions, and trusted processes.

--- a/packages/clients/doompi-server/docs/lifecycle.md
+++ b/packages/clients/doompi-server/docs/lifecycle.md
@@ -1,0 +1,100 @@
+# Session lifecycle
+
+`doompi-server` owns the lifetime of one agent process and the local services that expose it. The
+session record exists only while the server is responsible for those services.
+
+## Startup
+
+The executable starts in this order:
+
+1. It parses server options before `--` and keeps the remaining arguments for the agent. `--listen`
+   and `--auth-token-file` are required.
+2. It reads and trims the token file. An empty file stops startup. The token is not accepted as a
+   server option, so it does not appear in the server's argument vector.
+3. It resolves the registry directory, then resolves the session identity. The server generates a
+   UUID unless `--session-id` is supplied. `--name` defaults to `untitled`. An agent-side
+   `--session-id` or `--name` takes precedence, and missing identity flags are appended to the agent
+   arguments.
+4. It creates the agent launcher. A repository-local `@agimon-ai/doompi` installation is used when
+   present. Otherwise `DOOMPI_AGENT_COMMAND` can select a binary or JavaScript module. With neither,
+   the server composes the installed DoomPi package in process. Composition errors fail startup before
+   an agent is spawned.
+5. It starts the supervisor and the first agent. The server appends `--mode rpc` to the resolved agent
+   arguments. The supervisor clears a leftover relaunch handoff, watches for a new one, and retains
+   early agent frames until a server consumer subscribes.
+6. It removes a socket left by a dead process, without taking a live socket path, and binds the framed
+   session socket. It then mounts session package APIs when a generated API directory is available and
+   starts the Pi routed protocol socket.
+7. It writes the registry record atomically. A reader sees either the previous complete record or the
+   new complete record, never a temporary JSON document.
+8. If `--web` was requested, it probes the configured port after registration. An existing DoomPi hub
+   is reused; otherwise the optional web package starts a loopback hub in this process.
+
+The server reports startup failures to stderr with a `[doompi-server]` prefix and exits non-zero. A
+successful startup waits on the supervised agent, not on a client connection.
+
+## Agent selection and composition
+
+The server keeps the repository's composition with the agent that it launches:
+
+- A parent directory containing a different repository-local `@agimon-ai/doompi` package wins over
+  the server's own installation. The server delegates to that package's `dist/bin/cli.mjs`.
+- If no repository-local package is found, `DOOMPI_AGENT_COMMAND` is the global fallback. A `.mjs` or
+  `.js` command runs under the current Node executable; another value is spawned as a command.
+- If neither fallback applies, the server calls DoomPi's published preparation directly, ensures the
+  selected layer packages, and launches the resulting Pi command.
+
+The initial argument list is retained for a relaunch. The target major mode replaces any previous
+`--major-mode` pair rather than accumulating another flag. This keeps a script path at the front of a
+Node-based command and puts the new selection at the end.
+
+## Steady state
+
+The process owns these services:
+
+- `--listen`, the authenticated framed session socket.
+- `<listen>.pi`, the Pi 0.85 routed protocol socket.
+- `api.sock` beside the session socket, only when one or more session package APIs start successfully.
+- A registry record under `<registry-dir>/sessions/`.
+
+The sockets and the registry keep the same session id for the whole server lifetime. Agent frames feed
+the framed client, the routed session service, and the transcript projection independently. A client
+connection is not the agent's lifetime: a disconnect only removes that client from the framed socket.
+
+## Major-mode relaunch
+
+A launcher-class session cannot replace its extension closure in place. When the DoomPi runtime is idle
+and requests a relaunch, it writes a JSON handoff to the path in `DOOMPI_RELAUNCH_FILE`. The handoff
+contains version `1`, a non-empty `majorMode`, and an `operationId`.
+
+The supervisor then:
+
+1. notices the handoff file and ends the current agent's input;
+2. waits up to 15 seconds for Pi RPC to flush and exit;
+3. kills the agent if it ignores the graceful-exit request;
+4. validates and consumes the handoff file;
+5. resolves the requested major mode and spawns the replacement;
+6. keeps the same session id, sockets, registry record, and client-facing services.
+
+A malformed handoff is ignored. An exit without a valid handoff is a real session exit. If the target
+composition cannot be built, the old exit code is returned and the server does not start a partial
+composition. While the replacement starts, clients stay attached to the server and receive frames from
+the new agent generation when it is ready.
+
+## Shutdown and cleanup
+
+`SIGINT` and `SIGTERM` stop the supervised agent and disable relaunch handling. When the agent exits,
+the server closes the optional cockpit, package API server, Pi protocol socket, and framed session
+socket. It cleans staged composition resources, removes the session record, removes socket files, and
+flushes telemetry with a bounded shutdown wait.
+
+An agent exit without a relaunch handoff returns its exit code to the executable. A crash can leave a
+registry record behind because no cleanup code ran. The web cockpit checks the recorded pid and removes
+stale records. On the next server start, a stale session socket is removed only after its probe fails;
+a live socket is left in place so `listen` fails rather than silently stealing another session.
+
+## Related guides
+
+- [IPC](ipc.md) describes each socket and the attach and replay sequence.
+- [API](api.md) describes mounted package APIs and the exported TypeScript services.
+- [Security](security.md) describes the filesystem capabilities used during this lifecycle.

--- a/packages/clients/doompi-server/docs/lifecycle.md
+++ b/packages/clients/doompi-server/docs/lifecycle.md
@@ -1,100 +1,132 @@
 # Session lifecycle
 
-`doompi-server` owns the lifetime of one agent process and the local services that expose it. The
-session record exists only while the server is responsible for those services.
+`doompi-server` separates the lifetime of an agent from the lifetime of any client. One server owns one agent, one session identity, and the local services used to reach it. A browser tab or socket client can disappear without taking the session with it.
 
-## Startup
+## The ownership model
 
-The executable starts in this order:
+```text
+doompi-server process
+  |
+  +-- agent supervisor
+  |     +-- one Pi RPC child at a time
+  |
+  +-- framed session socket
+  +-- Pi routed protocol socket
+  +-- optional package API socket
+  +-- session registry record
+  +-- optional embedded web hub
+```
 
-1. It parses server options before `--` and keeps the remaining arguments for the agent. `--listen`
-   and `--auth-token-file` are required.
-2. It reads and trims the token file. An empty file stops startup. The token is not accepted as a
-   server option, so it does not appear in the server's argument vector.
-3. It resolves the registry directory, then resolves the session identity. The server generates a
-   UUID unless `--session-id` is supplied. `--name` defaults to `untitled`. An agent-side
-   `--session-id` or `--name` takes precedence, and missing identity flags are appended to the agent
-   arguments.
-4. It creates the agent launcher. A repository-local `@agimon-ai/doompi` installation is used when
-   present. Otherwise `DOOMPI_AGENT_COMMAND` can select a binary or JavaScript module. With neither,
-   the server composes the installed DoomPi package in process. Composition errors fail startup before
-   an agent is spawned.
-5. It starts the supervisor and the first agent. The server appends `--mode rpc` to the resolved agent
-   arguments. The supervisor clears a leftover relaunch handoff, watches for a new one, and retains
-   early agent frames until a server consumer subscribes.
-6. It removes a socket left by a dead process, without taking a live socket path, and binds the framed
-   session socket. It then mounts session package APIs when a generated API directory is available and
-   starts the Pi routed protocol socket.
-7. It writes the registry record atomically. A reader sees either the previous complete record or the
-   new complete record, never a temporary JSON document.
-8. If `--web` was requested, it probes the configured port after registration. An existing DoomPi hub
-   is reused; otherwise the optional web package starts a loopback hub in this process.
+The server, not a client, is the lifecycle owner. This choice gives reconnects and agent relaunches a stable boundary: sockets, session identity, and discovery can remain available while a client disconnects or the child process changes.
 
-The server reports startup failures to stderr with a `[doompi-server]` prefix and exits non-zero. A
-successful startup waits on the supervised agent, not on a client connection.
+The registry record exists only while the server claims responsibility for those services. It is discovery state, not the source of session lifetime.
 
-## Agent selection and composition
+## Why one agent per server
 
-The server keeps the repository's composition with the agent that it launches:
+A server process supervises one agent instead of multiplexing several agents internally. This keeps failure and identity boundaries simple:
 
-- A parent directory containing a different repository-local `@agimon-ai/doompi` package wins over
-  the server's own installation. The server delegates to that package's `dist/bin/cli.mjs`.
-- If no repository-local package is found, `DOOMPI_AGENT_COMMAND` is the global fallback. A `.mjs` or
-  `.js` command runs under the current Node executable; another value is spawned as a command.
-- If neither fallback applies, the server calls DoomPi's published preparation directly, ensures the
-  selected layer packages, and launches the resulting Pi command.
+- one exit status belongs to one session
+- one relaunch handoff can replace one composition
+- one working directory and session ID describe every service
+- a client never has to select an agent after reaching a session socket
 
-The initial argument list is retained for a relaunch. The target major mode replaces any previous
-`--major-mode` pair rather than accumulating another flag. This keeps a script path at the front of a
-Node-based command and puts the new selection at the end.
+DoomPi Web provides multi-session aggregation above this layer. It watches multiple server records and gives the browser one cockpit connection.
+
+## Startup is readiness-ordered
+
+The server publishes itself only after the agent and local transports are ready:
+
+```text
+parse options and identity
+          |
+          v
+read attach token and resolve agent
+          |
+          v
+start supervisor and Pi RPC child
+          |
+          v
+bind session, API, and protocol sockets
+          |
+          v
+publish registry record
+          |
+          v
+start or join optional web hub
+```
+
+The executable performs these steps:
+
+1. Parse server options before `--`; preserve everything after it for the agent. `--listen` and `--auth-token-file` are required.
+2. Read and trim the token file. An empty token stops startup. The token is not a command option, so it does not appear in the server argument vector.
+3. Resolve the registry directory and session identity. The server generates a UUID unless `--session-id` is supplied. `--name` defaults to `untitled`. Agent-side identity flags take precedence, and missing flags are appended to the agent arguments.
+4. Resolve the agent launcher. Repository-local DoomPi wins, `DOOMPI_AGENT_COMMAND` is the next fallback, and the installed DoomPi package can compose the session in process.
+5. Start the supervisor and first agent with `--mode rpc`. The supervisor clears an old relaunch handoff, watches for a new one, and retains early frames until a server consumer subscribes.
+6. Probe and remove a stale session socket, then bind the framed socket. Mount package APIs when a generated API directory is available and start the Pi routed protocol socket.
+7. Write the registry record atomically. Readers see a complete old record or a complete new record, never a temporary document.
+8. When `--web` is enabled, probe the requested port after registration. Reuse an existing DoomPi hub or start the optional web package on loopback.
+
+A startup error is written to stderr with a `[doompi-server]` prefix and exits non-zero. Successful startup waits for the supervised agent, not for a client to connect.
+
+## Keeping composition with the repository
+
+A headless session should run the DoomPi installation selected by its repository, not whichever package happens to be nearest to the server executable. Agent resolution follows that rule:
+
+1. A repository-local `@agimon-ai/doompi` installation wins. The server delegates to its `dist/bin/cli.mjs`.
+2. Without a repository-local installation, `DOOMPI_AGENT_COMMAND` can select a JavaScript module or executable. `.js` and `.mjs` values run under the current Node executable.
+3. With neither, the server calls the installed DoomPi preparation API, ensures selected layer packages, and launches the resulting Pi command.
+
+Composition errors stop startup before an agent is spawned. The server does not publish a record for a session it could not construct.
+
+The initial agent arguments are retained for relaunch. A requested major mode replaces the existing `--major-mode` pair instead of adding another one. Script position and all unrelated arguments remain stable.
 
 ## Steady state
 
-The process owns these services:
+Once ready, the server holds a stable session boundary:
 
-- `--listen`, the authenticated framed session socket.
-- `<listen>.pi`, the Pi 0.85 routed protocol socket.
-- `api.sock` beside the session socket, only when one or more session package APIs start successfully.
-- A registry record under `<registry-dir>/sessions/`.
+| Owned resource                      | Lifetime                                    |
+| ----------------------------------- | ------------------------------------------- |
+| Session ID and name                 | Whole server process                        |
+| Framed socket at `--listen`         | Whole server process                        |
+| Pi protocol socket at `<listen>.pi` | Whole server process                        |
+| `api.sock`                          | While one or more session APIs are mounted  |
+| Registry record                     | While the server owns the session           |
+| Agent child                         | One generation; replaceable during relaunch |
 
-The sockets and the registry keep the same session id for the whole server lifetime. Agent frames feed
-the framed client, the routed session service, and the transcript projection independently. A client
-connection is not the agent's lifetime: a disconnect only removes that client from the framed socket.
+Agent frames feed the framed client, routed session service, and transcript projection independently. Losing one consumer does not end the agent. In particular, closing the framed client only begins the bounded reconnect window described in [IPC](ipc.md).
 
 ## Major-mode relaunch
 
-A launcher-class session cannot replace its extension closure in place. When the DoomPi runtime is idle
-and requests a relaunch, it writes a JSON handoff to the path in `DOOMPI_RELAUNCH_FILE`. The handoff
-contains version `1`, a non-empty `majorMode`, and an `operationId`.
+Some major-mode changes replace the extension closure and cannot be applied safely inside the current Pi process. The server treats that as an agent-generation change, not a session change.
 
-The supervisor then:
+When the agent is idle, DoomPi writes a version `1` handoff to `DOOMPI_RELAUNCH_FILE`. It contains a non-empty `majorMode` and an `operationId`. The supervisor then:
 
-1. notices the handoff file and ends the current agent's input;
-2. waits up to 15 seconds for Pi RPC to flush and exit;
-3. kills the agent if it ignores the graceful-exit request;
-4. validates and consumes the handoff file;
-5. resolves the requested major mode and spawns the replacement;
-6. keeps the same session id, sockets, registry record, and client-facing services.
+1. ends the current agent's input
+2. waits up to 15 seconds for Pi RPC to flush and exit
+3. kills the child if it ignores the graceful exit
+4. validates and consumes the handoff
+5. resolves the requested composition and starts a replacement agent
+6. keeps the session ID, sockets, registry record, and client-facing services
 
-A malformed handoff is ignored. An exit without a valid handoff is a real session exit. If the target
-composition cannot be built, the old exit code is returned and the server does not start a partial
-composition. While the replacement starts, clients stay attached to the server and receive frames from
-the new agent generation when it is ready.
+Clients remain attached to the server and receive frames from the replacement generation when it is ready.
 
-## Shutdown and cleanup
+A malformed handoff is ignored. An agent exit without a valid handoff is a real session exit. If the next composition cannot be built, the server returns the previous agent's exit code and does not publish or start a partial replacement.
 
-`SIGINT` and `SIGTERM` stop the supervised agent and disable relaunch handling. When the agent exits,
-the server closes the optional cockpit, package API server, Pi protocol socket, and framed session
-socket. It cleans staged composition resources, removes the session record, removes socket files, and
-flushes telemetry with a bounded shutdown wait.
+## Shutdown and failures
 
-An agent exit without a relaunch handoff returns its exit code to the executable. A crash can leave a
-registry record behind because no cleanup code ran. The web cockpit checks the recorded pid and removes
-stale records. On the next server start, a stale session socket is removed only after its probe fails;
-a live socket is left in place so `listen` fails rather than silently stealing another session.
+`SIGINT` and `SIGTERM` disable relaunches and stop the current agent. After the agent exits, the server closes the optional web hub, package API server, Pi protocol socket, and framed socket. It then releases staged composition resources, removes the registry record and socket files, and flushes telemetry with a bounded wait.
+
+An ordinary agent exit is returned as the executable's exit code. A hard process crash can leave registry and socket files because cleanup never ran. Recovery is defensive:
+
+- DoomPi Web checks the recorded process ID and removes dead records.
+- A later server probes a leftover session socket before removing it.
+- A live socket is never stolen. The new server lets `listen` fail instead.
+
+This favors refusing an ambiguous live path over silently attaching a new process to another session's identity.
 
 ## Related guides
 
-- [IPC](ipc.md) describes each socket and the attach and replay sequence.
-- [API](api.md) describes mounted package APIs and the exported TypeScript services.
-- [Security](security.md) describes the filesystem capabilities used during this lifecycle.
+- [Getting started](getting-started.md) covers launch options and web integration.
+- [IPC](ipc.md) explains the transports that remain stable across reconnects and relaunches.
+- [Session APIs](api.md) explains when API modules load and close.
+- [Security](security.md) describes the filesystem and credential boundaries used throughout the lifecycle.

--- a/packages/clients/doompi-server/docs/security.md
+++ b/packages/clients/doompi-server/docs/security.md
@@ -1,0 +1,87 @@
+# Security and trust boundaries
+
+`doompi-server` is a local process boundary, not a public network gateway. Its agent can run shell
+commands and load extensions, so the command, working directory, configuration, token file, generated
+API bundle, and package dependencies are trusted inputs. Anyone who can use the protected transports
+can drive that agent with the same authority.
+
+## What protects a session
+
+| Asset                 | Protection                                                                                                             | Limit                                                                                                           |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Framed session socket | Created with a `0177` umask and mode `0600`                                                                            | The owner account and root remain trusted; a writable parent can allow socket replacement                       |
+| Attach token          | Read from `--auth-token-file`, compared with a timing-safe equal-length comparison, and never put in the server's argv | The server does not create or chmod the token file; the caller must keep it owner-only                          |
+| Registry record       | Session directory is created `0700`; records are written atomically with mode `0600`; the token itself is not stored   | The record contains sensitive filesystem paths, and an existing custom directory is not tightened by the server |
+| Pi protocol socket    | `@earendil-works/pi-server` is asked for mode `0600`                                                                   | It has no token handshake, so filesystem access is its authorization boundary                                   |
+| Package API socket    | Unix socket beside the session socket, with no network bind                                                            | This package does not explicitly chmod `api.sock`; its creation mode follows Node and the process umask         |
+
+Use a private parent directory and a restrictive umask. The quick start uses `umask 077` when it creates
+the token. Apply the same care when choosing `--listen`, `--registry-dir`, or `DOOMPI_API_DIR` paths.
+A custom registry location is a path override, not an additional authentication mechanism.
+
+The registry stores `tokenFile`, `socketPath`, `apiSocketPath`, `protocolSocketPath`, `cwd`, and the
+server pid. The web cockpit accepts paths from a valid live-PID record to locate the session, so exposing
+registry files can disclose where to find the session and its credential. Keep the registry directory
+private even though it does not contain the token contents.
+
+## Token handling
+
+The attach token is required for the framed session socket and must be present in a file before startup.
+Do not put it in a command-line argument, a public environment variable, a checked-in file, or a shared
+runtime directory. The server trims the file and refuses an empty value. A new token takes effect when
+the server restarts; an already attached connection is not re-authenticated on every frame.
+
+The server also generates an internal API token and passes it to the agent as
+`DOOMPI_SESSION_API_INTERNAL_TOKEN`, alongside the API socket path. It passes the configured attach token
+to trusted session APIs as their `hubToken` context. These values are for trusted child and package code;
+the server does not send either value to a browser or put either value in a registry record.
+
+Package APIs are executable code loaded from generated synchronization output. Treat them like other
+extensions. A package API can see its session context and can choose to use the internal or hub token;
+the host does not turn those values into automatic HTTP authorization.
+
+## Browser and remote access
+
+The session server exposes only Unix sockets. With `--web`, it asks `@agimon-ai/doompi-web` to host a
+loopback cockpit or joins an existing DoomPi cockpit on the selected port. The cockpit reads session
+token files on the host and keeps the Unix attach token server-side; a browser does not receive that
+token or perform the Unix handshake itself.
+
+Remote browser access is a separate web-cockpit boundary. Remote browsers carry bearer cookies issued
+by the cockpit, not the session's Unix attach token. A bearer cookie is still authority to use the
+cockpit and, through it, the agent. Apply the web package's origin, pairing, remote-access, and
+container guidance before putting a cockpit on a tunnel or public interface. Do not expose `session.sock`,
+`<listen>.pi`, or `api.sock` through an unauthenticated TCP forwarder.
+
+A trusted SSH or local process tunnel changes reachability, not the session's trust model. The receiving
+user still needs a deliberate authorization path to the socket and should not receive the token file
+unless they are meant to control the session.
+
+## Data and diagnostics
+
+The framed socket forwards Pi RPC frames without redaction. The transcript projection keeps session
+state and transcript content in memory for the routed service. Server telemetry records lifecycle,
+transport, and coarse assistant usage events; its transcript aggregate deliberately omits message and
+tool content. Agent stderr is inherited by the terminal that started the server, so treat that terminal
+and any captured logs as trusted output.
+
+## Operational checklist
+
+- Create the token with `umask 077` and store it outside the repository.
+- Keep the socket parent, registry directory, generated API directory, and token file owner-only.
+- Treat `DOOMPI_AGENT_COMMAND`, repository-local DoomPi packages, generated API modules, and agent
+  configuration as executable code.
+- Give the protocol socket and package API socket only to trusted local processes.
+- Use the web cockpit's documented remote controls instead of publishing a Unix socket directly.
+- Rotate the token by stopping the server, replacing the owner-only token file, and starting it again.
+- Do not rely on a registry path, `DOOMPI_RUNTIME_DIR`, or a custom port as an authorization check.
+
+## Known limits
+
+Filesystem permissions do not defend against root, a compromised owner account, or a process that has
+already been granted the token. Unix sockets have no built-in TLS. Package API handlers and the agent
+are trusted code, not a sandbox. The web cockpit's bearer-cookie and remote-access controls are outside
+this package and must be reviewed separately.
+
+See [IPC](ipc.md) for the exact handshake and socket behavior and [Lifecycle](lifecycle.md) for cleanup
+and crash handling.

--- a/packages/clients/doompi-server/docs/security.md
+++ b/packages/clients/doompi-server/docs/security.md
@@ -1,87 +1,110 @@
 # Security and trust boundaries
 
-`doompi-server` is a local process boundary, not a public network gateway. Its agent can run shell
-commands and load extensions, so the command, working directory, configuration, token file, generated
-API bundle, and package dependencies are trusted inputs. Anyone who can use the protected transports
-can drive that agent with the same authority.
+`doompi-server` protects access to one local agent. It is not a sandbox and it is not a public gateway. The agent may run shell commands with the account's authority, so reaching its control interfaces is equivalent to controlling that agent.
 
-## What protects a session
+## The trust model
 
-| Asset                 | Protection                                                                                                             | Limit                                                                                                           |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Framed session socket | Created with a `0177` umask and mode `0600`                                                                            | The owner account and root remain trusted; a writable parent can allow socket replacement                       |
-| Attach token          | Read from `--auth-token-file`, compared with a timing-safe equal-length comparison, and never put in the server's argv | The server does not create or chmod the token file; the caller must keep it owner-only                          |
-| Registry record       | Session directory is created `0700`; records are written atomically with mode `0600`; the token itself is not stored   | The record contains sensitive filesystem paths, and an existing custom directory is not tightened by the server |
-| Pi protocol socket    | `@earendil-works/pi-server` is asked for mode `0600`                                                                   | It has no token handshake, so filesystem access is its authorization boundary                                   |
-| Package API socket    | Unix socket beside the session socket, with no network bind                                                            | This package does not explicitly chmod `api.sock`; its creation mode follows Node and the process umask         |
+```text
+trusted owner account
+  |
+  +-- doompi-server
+  |     +-- configured agent command and extensions
+  |     +-- generated package APIs
+  |     +-- Unix sockets and registry files
+  |
+  +-- trusted local client or DoomPi Web hub
+          |
+          +-- browser boundary owned by DoomPi Web
+```
 
-Use a private parent directory and a restrictive umask. The quick start uses `umask 077` when it creates
-the token. Apply the same care when choosing `--listen`, `--registry-dir`, or `DOOMPI_API_DIR` paths.
-A custom registry location is a path override, not an additional authentication mechanism.
+The server answers one question: which local processes can reach the session. Filesystem permissions and an attach token narrow that set. They do not defend against root, a compromised owner account, hostile code already running as that owner, or a malicious extension loaded into the agent.
 
-The registry stores `tokenFile`, `socketPath`, `apiSocketPath`, `protocolSocketPath`, `cwd`, and the
-server pid. The web cockpit accepts paths from a valid live-PID record to locate the session, so exposing
-registry files can disclose where to find the session and its credential. Keep the registry directory
-private even though it does not contain the token contents.
+Remote browser authentication, tunnel policy, passkeys, and containment belong to DoomPi Web. Adding `--web` does not turn the session server itself into a network security boundary.
 
-## Token handling
+## Security goals
 
-The attach token is required for the framed session socket and must be present in a file before startup.
-Do not put it in a command-line argument, a public environment variable, a checked-in file, or a shared
-runtime directory. The server trims the file and refuses an empty value. A new token takes effect when
-the server restarts; an already attached connection is not re-authenticated on every frame.
+The design aims to:
 
-The server also generates an internal API token and passes it to the agent as
-`DOOMPI_SESSION_API_INTERNAL_TOKEN`, alongside the API socket path. It passes the configured attach token
-to trusted session APIs as their `hubToken` context. These values are for trusted child and package code;
-the server does not send either value to a browser or put either value in a registry record.
+- keep session transports off public network interfaces
+- avoid placing the attach token in process arguments or registry records
+- let the web hub attach without giving the token to browser JavaScript
+- make discovery records owner-only and atomically replaceable
+- isolate a broken optional package API from the agent and other APIs
 
-Package APIs are executable code loaded from generated synchronization output. Treat them like other
-extensions. A package API can see its session context and can choose to use the internal or hub token;
-the host does not turn those values into automatic HTTP authorization.
+It does not attempt to:
+
+- contain the agent or trusted package code
+- protect data from the account running the server
+- encrypt local Unix-socket traffic
+- authorize arbitrary TCP forwarding of a socket
+
+## Capability map
+
+| Asset                 | Protection                                                               | Remaining trust                                                                     |
+| --------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| Framed session socket | Created under a `0177` umask with mode `0600`; attach token required     | Owner, root, token holder, and anyone able to replace a socket in a writable parent |
+| Attach token          | Read from a file and compared with a timing-safe equal-length check      | Caller creates and protects the file                                                |
+| Registry record       | Session directory `0700`; atomic record mode `0600`; token value omitted | Paths remain sensitive; existing custom directories are not tightened               |
+| Pi protocol socket    | Requested mode `0600`                                                    | Filesystem access is the authorization boundary; there is no token handshake        |
+| Package API socket    | Local Unix socket beside the session socket                              | Creation permissions follow the process umask; handlers are trusted executable code |
+| Agent process         | Child of the server with the session working directory and environment   | Command, configuration, repository, and dependencies are trusted inputs             |
+
+Use a private parent directory and a restrictive umask. Changing `--registry-dir` or `DOOMPI_RUNTIME_DIR` changes a location, not the authorization model.
+
+## Why the framed socket also has a token
+
+The framed socket is the lowest-level control path. After attachment, a client can send Pi RPC commands directly to the agent. Requiring both filesystem reachability and a random token gives the hub a deliberate capability to present rather than treating any process that discovers the path as attached.
+
+The server reads and trims `--auth-token-file` during startup and rejects an empty value. The token never needs to appear in the command line. An attached connection is authenticated once, not on every frame. Rotating the token therefore requires stopping the server, replacing the protected file, and starting the session again.
+
+The server does not create or chmod the token file. Create it before launch with an owner-only umask:
+
+```bash
+(umask 077; openssl rand -base64 32 > "$runtime_dir/token")
+```
+
+Do not store it in the repository, a shared runtime directory, a public environment variable, or an argument list.
+
+## Registry records are capabilities by reference
+
+A session record does not contain the token bytes, but it names `tokenFile`, `socketPath`, `protocolSocketPath`, optional `apiSocketPath`, `cwd`, and the server process ID. DoomPi Web trusts these values after confirming that the recorded process is alive.
+
+The registry must therefore remain private. Reading it reveals where the session and its credential live; modifying it can redirect a watcher toward attacker-chosen paths. Atomic owner-only records prevent partial reads, but they do not make a writable custom parent safe.
+
+## Internal API credentials
+
+The server creates an internal API token and passes it to the child as `DOOMPI_SESSION_API_INTERNAL_TOKEN` with the API socket path. Trusted session APIs also receive the attach token as `hubToken` context.
+
+These values coordinate trusted child and package code. They are not automatic HTTP authorization, and the server does not send them to a browser or write them into the registry. A package API can still misuse its context, so generated API modules must be treated like extensions: executable code with the owner's authority.
 
 ## Browser and remote access
 
-The session server exposes only Unix sockets. With `--web`, it asks `@agimon-ai/doompi-web` to host a
-loopback cockpit or joins an existing DoomPi cockpit on the selected port. The cockpit reads session
-token files on the host and keeps the Unix attach token server-side; a browser does not receive that
-token or perform the Unix handshake itself.
+With `--web`, the server either joins an existing DoomPi Web hub or starts one on loopback. The hub reads the token file and owns the one framed session attachment. Browser pages do not receive the Unix attach token and cannot perform that handshake themselves.
 
-Remote browser access is a separate web-cockpit boundary. Remote browsers carry bearer cookies issued
-by the cockpit, not the session's Unix attach token. A bearer cookie is still authority to use the
-cockpit and, through it, the agent. Apply the web package's origin, pairing, remote-access, and
-container guidance before putting a cockpit on a tunnel or public interface. Do not expose `session.sock`,
-`<listen>.pi`, or `api.sock` through an unauthenticated TCP forwarder.
+A remote browser receives a separate DoomPi Web device cookie. That cookie authorizes the cockpit, which can in turn control the agent. The distinction prevents exposing the session credential to browser JavaScript, but it does not make remote cockpit access less powerful.
 
-A trusted SSH or local process tunnel changes reachability, not the session's trust model. The receiving
-user still needs a deliberate authorization path to the socket and should not receive the token file
-unless they are meant to control the session.
+Before putting the cockpit behind a tunnel, review the web package's pairing, origin, cookie, passkey, sealed transport, signed bundle, and optional container design. Do not publish `session.sock`, `<listen>.pi`, or `api.sock` through an unauthenticated TCP forwarder.
+
+An SSH or local process tunnel changes reachability, not authority. Anyone given a path and token should be treated as a session controller.
 
 ## Data and diagnostics
 
-The framed socket forwards Pi RPC frames without redaction. The transcript projection keeps session
-state and transcript content in memory for the routed service. Server telemetry records lifecycle,
-transport, and coarse assistant usage events; its transcript aggregate deliberately omits message and
-tool content. Agent stderr is inherited by the terminal that started the server, so treat that terminal
-and any captured logs as trusted output.
+The framed socket forwards Pi RPC content without redaction. The routed service keeps transcript and session state in memory. Agent stderr is inherited by the launching terminal and may contain diagnostics produced by the agent or extensions.
 
-## Operational checklist
+Server telemetry records lifecycle, transport, and coarse assistant usage events. Its transcript aggregate omits message and tool content. This is a telemetry property, not a guarantee that terminals, clients, extensions, or package APIs do not log their own data.
 
-- Create the token with `umask 077` and store it outside the repository.
-- Keep the socket parent, registry directory, generated API directory, and token file owner-only.
-- Treat `DOOMPI_AGENT_COMMAND`, repository-local DoomPi packages, generated API modules, and agent
-  configuration as executable code.
-- Give the protocol socket and package API socket only to trusted local processes.
-- Use the web cockpit's documented remote controls instead of publishing a Unix socket directly.
-- Rotate the token by stopping the server, replacing the owner-only token file, and starting it again.
-- Do not rely on a registry path, `DOOMPI_RUNTIME_DIR`, or a custom port as an authorization check.
+## Operating posture
+
+1. Create the runtime and token under an owner-only directory.
+2. Keep socket parents, registry files, token files, and generated API directories private.
+3. Treat `DOOMPI_AGENT_COMMAND`, repository-local DoomPi packages, generated API modules, and agent configuration as executable inputs.
+4. Give the protocol and package API sockets only to trusted local processes.
+5. Use DoomPi Web's documented controls for browser and remote access.
+6. Rotate the attach token by replacing the file while the server is stopped.
+7. Do not rely on an obscure path, custom registry, or non-default port as authentication.
 
 ## Known limits
 
-Filesystem permissions do not defend against root, a compromised owner account, or a process that has
-already been granted the token. Unix sockets have no built-in TLS. Package API handlers and the agent
-are trusted code, not a sandbox. The web cockpit's bearer-cookie and remote-access controls are outside
-this package and must be reviewed separately.
+Unix permissions do not defend against root or the owner account. Unix sockets have no built-in TLS. A holder of the attach token can control the session. Package APIs and agent extensions run as trusted code. The reconnect backlog and transcript projection keep data in process memory. None of these controls contain what the agent can do inside its working environment.
 
-See [IPC](ipc.md) for the exact handshake and socket behavior and [Lifecycle](lifecycle.md) for cleanup
-and crash handling.
+See [IPC](ipc.md) for exact socket behavior and [Lifecycle](lifecycle.md) for startup, cleanup, and crash recovery.

--- a/packages/clients/doompi-server/llms.txt
+++ b/packages/clients/doompi-server/llms.txt
@@ -4,4 +4,8 @@ Package-owned guidance for the headless DoomPi session server.
 
 ## Resources
 
-- [Package README](./README.md): Running the server, socket transport, authentication, and client attachment.
+- [Package README](./README.md): Purpose, installation, quick start, command options, and limits.
+- [Session lifecycle](./docs/lifecycle.md): Startup, agent selection, major-mode relaunches, registry, and shutdown.
+- [IPC and wire protocols](./docs/ipc.md): Unix sockets, framing, attach and replay, and Pi's routed protocol.
+- [Session APIs](./docs/api.md): Mounted package APIs and the TypeScript export surface.
+- [Security](./docs/security.md): Filesystem permissions, token handling, trust boundaries, and remote access.

--- a/packages/clients/doompi-server/llms.txt
+++ b/packages/clients/doompi-server/llms.txt
@@ -4,8 +4,9 @@ Package-owned guidance for the headless DoomPi session server.
 
 ## Resources
 
-- [Package README](./README.md): Purpose, installation, quick start, command options, and limits.
-- [Session lifecycle](./docs/lifecycle.md): Startup, agent selection, major-mode relaunches, registry, and shutdown.
+- [Package README](./README.md): Purpose, quick start, how the process works, and security summary.
+- [Getting started](./docs/getting-started.md): Installation, command options, agent selection, registry, and web integration.
+- [Session lifecycle](./docs/lifecycle.md): Startup, major-mode relaunches, registry, and shutdown.
 - [IPC and wire protocols](./docs/ipc.md): Unix sockets, framing, attach and replay, and Pi's routed protocol.
 - [Session APIs](./docs/api.md): Mounted package APIs and the TypeScript export surface.
 - [Security](./docs/security.md): Filesystem permissions, token handling, trust boundaries, and remote access.

--- a/packages/clients/doompi-server/package.json
+++ b/packages/clients/doompi-server/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist",
+    "docs",
     "llms.txt",
     "README.md",
     "LICENSE",

--- a/packages/clients/doompi-web/README.md
+++ b/packages/clients/doompi-web/README.md
@@ -1,305 +1,83 @@
 # @agimon-ai/doompi-web
 
-Web cockpit for DoomPi. It discovers running [doompi-server](https://www.npmjs.com/package/@agimon-ai/doompi-server) sessions, multiplexes their authenticated sockets, and serves them through one browser connection.
+DoomPi Web is a standalone Node.js process that serves the DoomPi browser cockpit. It discovers registered `doompi-server` sessions, keeps their attach credentials on the host, and presents them through one browser connection.
 
-This package is a composable [DoomPi](https://www.npmjs.com/package/@agimon-ai/doompi) subsystem.
-It registers no Pi extension and adds nothing to an interactive session.
-
-## How it runs
-
-`doompi-web` is a standalone process, not a Pi extension. Do not add it to `.doom/modes.yaml`. Run it directly, or start it through `doompi-server --web`.
+This package is not a Pi extension. Do not add it to `.doom/modes.yaml`.
 
 ## Requirements
 
 - Node.js 22.19.0 or newer
-- `doompi-server` sessions to attach to. The cockpit can start them itself.
+- A DoomPi installation with at least one synchronized configuration
 
-## Install
+The cockpit can start `doompi-server` processes itself. Existing servers are discovered through the session registry.
+
+## Install and run
 
 ```bash
 npm install -g @agimon-ai/doompi-web
-```
-
-## Run
-
-```bash
 doompi-web
 ```
 
-Open `http://127.0.0.1:7433`. With no flags, the hub watches `~/.doompi/run`, attaches to registered sessions, and resolves the union of their synchronized cockpit compositions from `~/.pi/.doom/sync/registrations`. The directory that launches `doompi-web` does not select the bundle. Sessions started by the cockpit use the server and agent from the same installation.
+Open <http://127.0.0.1:7433>. The default listener is loopback. If the personal DoomPi directory does not exist, startup runs the bundled `doompi init` before serving.
 
-If `~/.pi/.doom` does not exist, the command runs its bundled `doompi init` before starting. If a hub already answers on the port, a second `doompi-web` process prints its URL and exits.
+With no `--dir`, the hub uses the global synchronized configuration as its default and watches that global configuration for completed syncs. Each session still resolves its web composition from its own repository first, with the global composition as fallback. A repository passed with `--dir` must be inside a repository. It is synchronized before launch and before a new or restarted session, but it is not watched. Run `doompi sync` and restart or create a session to adopt repository changes.
 
-To run this repository's build with its composition pinned and watched:
+### Command options
 
-```bash
-pnpm cockpit:build
-pnpm doompi-web --dir="$PWD"
-```
+| Option                      | Default                  | Purpose                                                                      |
+| --------------------------- | ------------------------ | ---------------------------------------------------------------------------- |
+| `--dir <path>`              | none                     | Select and synchronize one repository composition                            |
+| `--registry-dir <path>`     | `~/.doompi/run`          | Session registry; `DOOMPI_RUNTIME_DIR` is an equivalent environment override |
+| `--spawn-command <command>` | bundled server           | Command used for sessions created from the cockpit                           |
+| `--port <number>`           | `7433`                   | Loopback HTTP port                                                           |
+| `--host <address>`          | `127.0.0.1`              | Bind address; a non-loopback address is not paired or authenticated          |
+| `--assets <path>`           | packaged or synchronized | Override the host shell assets                                               |
+| `--state-dir <path>`        | `~/.doompi/web`          | Remote-access state and cockpit cache                                        |
+| `--cloudflared <path>`      | `PATH`                   | Explicit `cloudflared` binary                                                |
 
-`--dir` accepts `--dir <path>` too. It synchronizes that repository before launch and watches it for development rebuilds.
+`--assets` can also be set with `DOOMPI_WEB_DIST`. `DOOMPI_API_DIR` overrides the default generated package API directory. Use `doompi-web --help` for the complete command help.
 
-| Flag              | Default                  | Meaning                                          |
-| ----------------- | ------------------------ | ------------------------------------------------ |
-| `--dir`           | live-session union       | Pin, sync, and watch one repository composition  |
-| `--registry-dir`  | `~/.doompi/run`          | Registry to watch (also `DOOMPI_RUNTIME_DIR`)    |
-| `--spawn-command` | this install             | Command launching sessions created from the page |
-| `--port`          | `7433`                   | HTTP port                                        |
-| `--host`          | `127.0.0.1`              | Bind address                                     |
-| `--assets`        | synchronized or packaged | Override the built SPA directory                 |
-| `--state-dir`     | `~/.doompi/web`          | Remote-access settings and cockpit cache         |
-| `--cloudflared`   | from `PATH`              | Tunnel binary (also `DOOMPI_CLOUDFLARED`)        |
-| `-h`, `--help`    |                          | Print command help                               |
-| `-v`, `--version` |                          | Print the installed package version              |
+## How it works
 
-Install [doompi-server](https://www.npmjs.com/package/@agimon-ai/doompi-server) when you also want to run a session server directly. The hub does not require `doompi-server` on `PATH` to create sessions.
+The hub watches the session registry and attaches to each registered `doompi-server` using the token file named by that record. Attach tokens remain in the hub process. A browser page uses one WebSocket, while hub and session frames remain keyed by session ID. The hub buffers a bounded history for reconnects and rejects browser-supplied attach frames.
 
-## Security
+The host shell is packaged with this module. Synchronized repositories contribute per-session plugin compositions, hub channels, and package API routes. A selected composition is complete or it is not used, and repository and global artifacts are never mixed inside one session. See [bundle resolution](docs/bundle.md) and [architecture](docs/architecture.md).
 
-The hub reads session attach tokens from registry token files; browsers do not receive those tokens.
-It binds loopback by default and checks HTTP requests and WebSocket upgrades against an origin and
-host allowlist. `DOOMPI_WEB_ALLOW_ORIGIN` adds comma-separated origins for custom setups.
+The cockpit also serves a PWA install shell and service worker. After a paired device installs the PWA, the worker verifies signed host and plugin assets before putting them in the active cache. Optional closed-app Web Push notifications are generic, zero-TTL alerts kept in memory by the running hub. They are not a durable notification queue.
 
-These checks defend against hostile web pages and DNS rebinding, not hostile local programs.
-The local listener allows requests without an `Origin` header, and a local program can supply its own headers.
-Do not expose the local listener publicly. Use the paired remote-access listener described below
-or a trusted SSH tunnel.
+## Extending the cockpit
 
-## What the cockpit shows
+A DoomPi package can declare a browser plugin in `package.json` under `doompiWeb`. Its client entry exports `webPlugin`; an optional hub entry exports `webHubChannels`. Plugins can add tabs, dock and activity sections, settings, session channels, slots, Leader bindings, context actions, and tool renderers. Plugins are independent and optional. See [web plugins](docs/plugins.md) and the typed [web plugin contracts](https://www.npmjs.com/package/@agimon-ai/doompi-web-contracts).
 
-Everything comes from Pi's RPC protocol, so a bare Pi session and a DoomPi session both work and
-neither is shown facts it did not report:
+A package can expose HTTP endpoints under `doompiApi`. Session APIs run with a session server. Hub APIs run with the cockpit hub. Both use the package API `basePath` and `start(context)` contract. See [package APIs](docs/package-apis.md).
 
-- **Sessions rail:** every registered session with its live status line, git branch, and working
-  directory. Cards switch focus (digits `1`-`9` too), `ctrl+t` or the button creates a session in a
-  directory you pick, and the hub launches a `doompi-server` there.
-- **Timeline:** user prompts, streamed assistant text and reasoning, and tool calls from running to
-  result, including failures. Scoped to the focused session; the others keep streaming into the
-  hub's ring for when you switch.
-- **Composer:** prompts while idle, steering while a run is in flight, queued follow-ups, and abort.
-- **Status rail:** connection state with replay and drop counts, model, thinking level, context
-  usage, cost, and session identity.
-- **Dialogs:** the extension UI sub-protocol (`select`, `confirm`, `input`, `editor`), which is how
-  a permission prompt reaches the browser. Cancelling answers the agent rather than stranding it.
-- **Notifications:** live `doom-notification` entries from every attached session, including sessions
-  that are not focused. Browser permission is requested only after the user clicks **allow notifications**
-  in Settings. Replayed backlog and historical pages update the timeline but never notify.
-- **Leader Space:** `ctrl+k`, `ctrl+space`, or space in an empty composer. Keys walk the tree the
-  installed web plugins declared (`SPC w r` opens the workflows tab, `SPC g e` toggles goal mode),
-  backspace climbs, and `/` searches whatever `get_commands` reported to run it as a slash prompt.
-- **Settings:** the gear at the foot of the rail opens the settings pages. Notifications shows this
-  browser's permission and provides the user-click permission action. Providers lists every model
-  provider Pi knows with whether it is authenticated, signs in with an API key or OAuth through the
-  hub, and signs out. The hub uses the same `auth.json` as the sessions, so a login here is a login for
-  every session on the machine.
-
-## Attach and reattach
-
-The hub, not the page, holds each session: it is the one client `doompi-server` allows, and every
-browser tab multiplexes behind it, so two tabs on one session work. Losing the browser changes
-nothing for the agent; the hub keeps a bounded ring of each session's frames and replays it when a
-page subscribes, reporting how many frames the ring had to drop. If another client holds a socket,
-the rail says so and the hub keeps retrying with backoff until it can take over. A page cannot
-perform the handshake itself: `attach` frames sent from the browser are refused.
-
-## Current limits
-
-- One agent per `doompi-server` process; the hub presents many such servers as one working set.
-- The four DoomPi selection axes (profile, major mode, domains, minor modes) are not exposed over
-  Pi RPC, so the rail does not display them. The palette can still invoke the commands that change
-  them.
-- Subagent, workflow, and runner surfaces report summaries only; per-run detail has no RPC source
-  to render from yet.
-- Open pages show full live browser notifications. An installed paired PWA can also receive a generic
-  zero-TTL Web Push alert while closed. There is no durable subscription database, outbox, replay, or
-  historical delivery.
-
-## iPhone Home Screen app
-
-Use a stable named HTTPS tunnel on a hostname you control. Quick-tunnel hostnames rotate, so they cannot
-provide durable PWA identity, passkeys, or reliable Push subscriptions. Open `/pair` in Safari, add it to the
-Home Screen, then launch the installed app and scan the QR shown by the host.
-
-The install shell, scanner, manifest, and verifier worker are package-owned. The QR pins the host signing key
-and minimum bundle revision. The worker verifies every host and plugin asset before committing it to the
-active cache, and the host never serves its SPA directly. A failed update keeps the last-known-good bundle.
-Signer loss, signer rotation, or a host/container transition requires explicit fingerprint confirmation and
-re-pairing. Session file previews remain sealed `no-store` HTTP Blob URLs and never enter the application
-cache, IndexedDB, a signed manifest, or a Push payload.
-
-Closed-app alerts are opt-in under settings. The server keeps subscriptions only in memory and sends fixed
-generic copy with `TTL: 0` only when the device has no connected cockpit socket. Opening the app after a host
-restart re-registers the browser subscription. Disabling alerts, revoking or expiring the device, switching
-off remote access, or rotating process credentials removes it.
-
-## Remote access
-
-Working from a phone means putting the cockpit on the internet, and the cockpit's socket carries
-prompts to an agent holding a `bash` tool. Reaching it is therefore equivalent to a shell on this
-machine, and the whole design follows from that.
-
-Switching it on binds a **second loopback listener** on an ephemeral port and points `cloudflared`
-at it. Port 7433 is untouched, so working at the keyboard is exactly as before, while everything
-arriving on the tunnel listener has to prove it holds a paired session. The two listeners are the
-mechanism, not an implementation detail: a tunnel connects from `127.0.0.1` like every local client,
-so the socket a connection arrived on is the only thing about it that cannot be forged.
-
-Pairing takes **two** things, not one:
-
-1. The host shows a QR encoding `https://<tunnel-host>/pair#c=<code>&k=<channel-key>&s=<signer>&r=<revision>`.
-   Every value rides in the URL fragment, which no browser sends to a server, so the relay cannot replace the
-   channel or bundle key without changing what was shown on the host. Manual pairing requires comparing the
-   signing-key fingerprint shown on both devices.
-2. Scanning raises an approve or deny prompt **on the host**. Nothing is paired until someone at the machine
-   answers. A screen is visible over a shoulder and in a screenshare, so the code alone is one factor for a
-   credential that ends in shell access.
-
-A paired device then has the same powers as the person at the keyboard, with one exception: it
-cannot mint pairing codes, approve devices, or change these settings. A device able to approve
-devices could make its own access permanent, which is precisely what host confirmation prevents.
-Turning remote access off and revoking a device are allowed remotely, because a panic button is
-worth more from the couch than from the desk.
-
-Two optional time limits, both **off by default** and both in the dialog:
-
-- Close the tunnel automatically, after 60 minutes.
-- Expire paired sessions, after 30 minutes idle or 12 hours total.
-
-Either switch takes effect retroactively in both directions, because expiry is evaluated against the
-setting in force at the moment of the check rather than stamped onto a session when it was made.
-Turning expiry on therefore drops sessions that are already idle, and turning it off brings them
-back.
-
-With both off, a paired device keeps its session until it is revoked, remote access is switched off, or
-the hub restarts. Switching remote access off always revokes every paired session, and that is not a
-toggle.
-
-Before reporting success, the tunnel is self-tested through its public URL: the pairing page must
-answer 200 and `/api/health` must answer 401. A failed probe stops the tunnel. This checks those
-routes, not every possible access path.
-
-Requires `cloudflared` on `PATH` (`brew install cloudflared`). A quick tunnel needs no account but gets a new
-hostname on every start. It does not provide a durable PWA, passkey, or Push identity, and Cloudflare does not
-support SSE on quick tunnels, which breaks workflow and runner-log plugin surfaces. Use a stable named tunnel
-for the Home Screen app.
-
-If a named tunnel's connector exits unexpectedly, the hub makes three backoff restart attempts and
-self-tests every replacement. The existing listener and paired sessions stay valid while recovery is
-in progress. A quick tunnel cannot recover transparently because its origin changes, so it still fails
-closed immediately. Exhausting named-tunnel recovery also switches remote access off and revokes the
-paired sessions.
-
-### Passkeys and step-up
-
-On a named tunnel, a device can enrol a passkey once and then sign in with a gesture instead of
-another QR. Two actions need a fresh gesture even from a live session: writing or clearing a model
-provider's credential, and spawning a session in a directory of the caller's choosing. Both are
-escalation paths out of "drive the agent" and into "own the machine". Ordinary prompting and tool
-approval are deliberately ungated, because a biometric check in that loop gets trained away in a day.
-
-A quick tunnel cannot carry a passkey: `rpID` is bound to the hostname and a quick tunnel's rotates
-on every start, so a credential enrolled today would silently stop working tomorrow. The cockpit says
-so rather than letting the ceremony fail in the browser.
-
-### Tunnel-provider trust and payload privacy
-
-Cloudflare terminates TLS and delivers the package-owned pairing and verifier bootstrap. A browser cannot
-independently authenticate that first executable shell against the same edge that served it: a malicious
-replacement could omit the worker and steal a QR fragment. DoomPi does not claim protection from a malicious
-code-delivery edge.
-
-After that bootstrap, **bundle signing is mandatory**. The QR pins the host ECDSA key and revision floor. The
-worker verifies the signed manifest plus every raw asset before any host JavaScript executes, serves only the
-atomically committed verified cache, and retains the last-known-good revision on failure. Cloudflare may
-alter the raw bytes, but altered bytes do not execute.
-
-**The payload is also sealed.** A QR carries an ephemeral P-256 public key in the fragment. A returning
-passkey device restores its channel only after the pinned bundle worker accepts the same signer. Both paths
-complete ECDH and derive separate AES-256-GCM keys per direction. Socket frames and API bodies travel as
-ciphertext.
-
-The channel implementation lives in `@agimon-ai/doompi-web-security`, which ships the envelope contract,
-a `node:crypto` half, and a WebCrypto half. **A web plugin that calls `fetch` directly sends plaintext to
-the relay**, so plugins use `sealedTransport.fetch` from that package's `./browser` subpath. The host
-cannot enforce this, which is why the import allowlist admits the helper and why it is said here.
-
-Cloudflare can still observe the served page and assets, timing, message sizes, connection patterns, and
-tunnel metadata. Do not enable this transport if Cloudflare is outside your trust boundary. Protect a
-named-tunnel account with a passkey or hardware MFA.
-
-### What a paired device may browse
-
-While a tunnel is up, the new-session picker answers a request arriving on it from one subtree only:
-the directory `doompi-web` was started in. Unpinned, that route hands a paired device a map of the
-machine, every project and client name and checkout, which is worth more to an attacker than most of
-what the cockpit shows.
-
-Only that request is pinned. The person at the keyboard already has a shell, so pinning them would
-cost the picker its usefulness and buy nothing, and a contained cockpit needs none of it because its
-mounts are already the boundary.
-
-Session creation itself is not narrowed by this. `POST /api/sessions` still accepts any absolute path
-a caller already knows, which is why the container below exists: it is the boundary, this is only the
-end of casual enumeration.
-
-### Running the cockpit in a container
-
-Off by default. A second switch in the same dialog moves the whole cockpit into a container when
-remote access is turned on: the hub, every session server it spawns, every agent, and `cloudflared`
-itself. This is the answer to the blunt fact that a paired device drives an agent holding a shell,
-which every layer above narrows access to but none of them contains.
-
-The list of workspaces is the boundary, and it is the only thing on the host the container can see.
-A hub inside the container cannot create a session in a path that is not mounted, so spawning in an
-arbitrary directory is closed by construction rather than by a check. Not mounted, and deliberately
-so: your home directory, `~/.ssh`, `~/.gitconfig`, the container socket, and every repository you
-did not list.
-
-What happens when you turn it on:
-
-1. The image is built if this DoomPi version has not built it before, which takes minutes the first
-   time. Progress is printed in the terminal that started the cockpit.
-2. The host cockpit answers the request, then stops serving and releases its port.
-3. The container starts, publishing the same port on loopback, and becomes the cockpit. Your browser
-   reconnects on its own; there is no new address to remember.
-4. Sessions working inside a mounted workspace are stopped on the host and recreated inside. Sessions
-   working anywhere else are named in the terminal and stay on the host, where the contained cockpit
-   cannot see them.
-
-If the container fails to start, the host cockpit comes back and its sessions are recreated there, so
-a failed move never leaves you with nothing listening. `Ctrl-C` stops the container. A cockpit killed
-outright leaves the container running; the next start finds it through `~/.doompi/web/cockpit-container.json`
-and stops it.
-
-Provider credentials use the broker's per-session token rather than forwarding host API keys.
-Git identity is passed as `GIT_AUTHOR_*` and `GIT_COMMITTER_*`; host SSH keys are not mounted.
-This does not prevent pushes using credentials already present in a mounted workspace or obtained
-inside the container.
-
-What this does not defend against, stated plainly: anyone who can talk to the container daemon can
-escape any container it runs, so the engine is part of the trusted base. Sessions share one container
-and can read each other's mounted workspaces. A mounted workspace is fully writable, so the agent can
-still destroy the repository you gave it. Network access is unrestricted, exactly as it already is for
-`doompi --sandbox`. And plugin tabs fall back to the built-in set until a bundle is synced inside.
-
-Requires `@agimon-ai/doompi-sandbox` in the composition and a container engine on the host.
-
-## Transport limits
-
-The cockpit uses WebSockets for session traffic. WebRTC is not implemented. Browser Voice uses
-its authenticated session media transport, with VAD and Whisper on the agent host and browser
-speech synthesis for narration.
-
-## Public API
+For direct programmatic use:
 
 ```ts
 import { serveWeb } from '@agimon-ai/doompi-web';
 import { bundleCockpitWeb } from '@agimon-ai/doompi-web/bundler';
 ```
 
+## Remote access and security
+
+Remote access is intentionally an authenticated path to an agent that can hold shell tools. Enabling it creates a second loopback listener for the tunnel and leaves the normal local listener unchanged. Pairing requires a code and approval on the host. A paired browser receives a device bearer cookie, not a session attach token.
+
+Remote session traffic, protocol traffic, and API bodies use a sealed channel after pairing. Pairing, passkey, and PWA bootstrap routes are intentionally unsealed. Signed bundle verification protects asset delivery only after the signing key and the initial bootstrap are trusted. The tunnel provider can still observe the page, asset requests, timing, sizes, and connection metadata.
+
+The default loopback origin and host checks help against hostile web pages and DNS rebinding. They do not protect against a hostile local process. Do not publish the listener with `--host 0.0.0.0`; use the paired remote-access flow or a trusted SSH tunnel. See [remote security](docs/security.md), including passkeys, step-up actions, sealed transport, signed bundles, and the optional container boundary.
+
+## Documentation
+
+- [Getting started](docs/getting-started.md): installation, sync, sessions, and development setup
+- [Architecture](docs/architecture.md): process boundaries, sockets, lifecycle, and browser composition
+- [Web plugins](docs/plugins.md): manifests, client and hub entries, contributions, and compatibility
+- [Package APIs](docs/package-apis.md): `doompiApi`, route mounting, selectors, and caller context
+- [Bundle resolution](docs/bundle.md): synchronized generations, fallback, publication, and overrides
+- [Remote security](docs/security.md): pairing, passkeys, sealing, bundle trust, and containment limits
+
 ## Development
 
-Run from this package directory in the workspace:
+Run from this package directory:
 
 ```bash
 pnpm build
@@ -307,76 +85,10 @@ pnpm typecheck
 pnpm test
 pnpm test:e2e
 pnpm lint
-pnpm exec vibe-lint check .
-npm pack --dry-run
 ```
 
-### Plugin dev loop
-
-Two servers, so two terminals, and neither takes a flag. `pnpm dev` serves the cockpit from source
-on port 7434 and proxies `/api` (including the socket) to the hub on 7433. Point it at plugin
-packages and their `web/` sources hot-reload too, generated into `.dev/` and aliased over the empty
-committed registry exactly as `doompi sync` does:
-
-```bash
-pnpm cockpit                                   # terminal one, at the repository root: the hub on 7433
-pnpm dev                                       # terminal two, here: the composition the last doompi sync bundled
-DOOMPI_WEB_PLUGIN_ROOTS=/path/to/pkg pnpm dev  # or an explicit list, path-delimiter separated
-```
-
-The roots come from `pluginRoots.json`, which `doompi sync` writes beside its bundle under
-`~/.doompi/web/current`, unless the environment names them. The hub side is unchanged: a plugin's
-hub channel is still the built `dist/webHub.mjs` the synced registry names, so a hub-side change
-needs `pnpm build` in that package and a hub restart.
-
-`pnpm test:e2e` drives the built executable in a real browser against a scripted session socket, so
-run `pnpm build` first.
-
-Maintained by [Agimon](https://agimon.ai/about).
-
-## Web plugins
-
-Tabs beyond the conversation are plugins, and no plugin package is a dependency of this one. A
-package declares a `doompiWeb` block in its package.json naming a client entry (a `webPlugin`
-definition: tab, panel, badge, session data channels, tool renderers for the timeline cards of
-the tools the package registers, slots it opens for other plugins, fills into slots others open,
-and the host's own slot contributions) and an optional hub entry (`webHubChannels` plus its built
-dist). This package's own bundle carries no plugins; the full set is assembled on your machine.
-`doompi sync` discovers the installed composition's manifests, generates the import entries, and builds
-the SPA through the `./bundler` subpath inside the repository/worktree's immutable sync generation.
-By default, the shared server resolves the union of live-session registrations; `--dir` pins one
-repository. `--assets` and `DOOMPI_WEB_DIST` override registered assets, then packaged assets provide the fallback. Server-only
-`webPlugins.server.json` sits beside the public `web/` directory, never inside the signed or served
-bundle. It names each plugin's built hub entry, imported lazily. A missing plugin package logs a notice
-and its tab is omitted. Session package API routes use the session `cwd` registration, while
-`DOOMPI_API_DIR` remains the explicit API override. `@agimon-ai/doompi-team` is the reference plugin;
-the workflows tab ships with `@agimon-ai/doompi-workflow`. Contracts come from
-`@agimon-ai/doompi-web-contracts`.
-
-A tool call's timeline item belongs to the plugin that registers the tool: its `toolRenderers`
-entry names the tool (or claims it with `matches` when the name is only known at runtime) and
-supplies one `message` component that owns the whole item, composed from the components package's
-`MessageItem` so it looks like every other item; the host only marks the row, catches a renderer
-that throws (the item falls back to the host's own and the rest of the timeline survives), and
-stands in for a tool nobody claims. Tool messages receive the same actions as every other plugin
-component (`sendSessionFrame`, `openTab`, `renderSlot`), so a card can act, MCP-app style.
-
-Plugins are independent. A manifest names no other plugin and `registrationOrder` is only an
-optional tiebreak (default 1000, then plugin id): every relation between two plugins resolves by
-name once all of them are installed. A plugin opens slots named `<pluginId>.<name>` and renders
-them with the `renderSlot` and `slotData` props its components receive; any plugin fills them, and
-the host's `overlay`, `rail`, `selection-bar`, `composer-actions`, `activity`, and
-`activity.<group>` slots, without
-knowing whether the owner is installed. A fill into a slot nobody declares, or two plugins wanting
-one tab id, tool name, group name, or Leader Space leaf, never fails the page: the install resolves
-it (the first plugin keeps a shared name, a later binding takes a leaf over as the TUI documents)
-and records an install diagnostic, which `webPluginDiagnostics()` lists and the page logs once with
-`console.warn`. `doompi sync` treats a malformed or half-installed plugin package the same way, as a
-notice that skips that package. The repository's own composition is held to zero notices and zero
-diagnostics by `tests/contract/workspaceWebPlugins.test.ts`.
+Build before running the end-to-end suite. The package is maintained by [Agimon](https://agimon.ai/about).
 
 ## License
 
-Source available under the DoomPi Web License (see LICENSE). Use is free for any purpose, including
-production and commercial use, and you may modify it and publish patches. Redistributing the
-software, or offering it to third parties as a hosted or managed service, is not permitted.
+Source is available under the [DoomPi Web License](LICENSE). Use is free for production and commercial purposes, but redistribution and offering the software as a hosted or managed service are not permitted.

--- a/packages/clients/doompi-web/README.md
+++ b/packages/clients/doompi-web/README.md
@@ -1,93 +1,64 @@
 # @agimon-ai/doompi-web
 
-DoomPi Web is a standalone Node.js process that serves the DoomPi browser cockpit. It discovers registered `doompi-server` sessions, keeps their attach credentials on the host, and presents them through one browser connection.
+**A browser cockpit for your DoomPi sessions.**
 
-This package is not a Pi extension. Do not add it to `.doom/modes.yaml`.
+DoomPi Web finds running [`doompi-server`](../doompi-server) sessions, keeps their attach credentials on the host, and presents them through one browser connection. It is a standalone process, not a Pi extension. Do not add it to `.doom/modes.yaml`.
 
-## Requirements
+## Install
 
-- Node.js 22.19.0 or newer
-- A DoomPi installation with at least one synchronized configuration
-
-The cockpit can start `doompi-server` processes itself. Existing servers are discovered through the session registry.
-
-## Install and run
+Requires Node.js 22.19.0 or newer and a synchronized DoomPi configuration.
 
 ```bash
 npm install -g @agimon-ai/doompi-web
 doompi-web
 ```
 
-Open <http://127.0.0.1:7433>. The default listener is loopback. If the personal DoomPi directory does not exist, startup runs the bundled `doompi init` before serving.
+Open <http://127.0.0.1:7433>. The cockpit can discover existing session servers or start one when you create a session from the page.
 
-With no `--dir`, the hub uses the global synchronized configuration as its default and watches that global configuration for completed syncs. Each session still resolves its web composition from its own repository first, with the global composition as fallback. A repository passed with `--dir` must be inside a repository. It is synchronized before launch and before a new or restarted session, but it is not watched. Run `doompi sync` and restart or create a session to adopt repository changes.
+Use `doompi-web --dir "$PWD"` when working with a repository-specific composition. It synchronizes that repository before launch and before new or restarted sessions. It does not watch the repository for later changes.
 
-### Command options
-
-| Option                      | Default                  | Purpose                                                                      |
-| --------------------------- | ------------------------ | ---------------------------------------------------------------------------- |
-| `--dir <path>`              | none                     | Select and synchronize one repository composition                            |
-| `--registry-dir <path>`     | `~/.doompi/run`          | Session registry; `DOOMPI_RUNTIME_DIR` is an equivalent environment override |
-| `--spawn-command <command>` | bundled server           | Command used for sessions created from the cockpit                           |
-| `--port <number>`           | `7433`                   | Loopback HTTP port                                                           |
-| `--host <address>`          | `127.0.0.1`              | Bind address; a non-loopback address is not paired or authenticated          |
-| `--assets <path>`           | packaged or synchronized | Override the host shell assets                                               |
-| `--state-dir <path>`        | `~/.doompi/web`          | Remote-access state and cockpit cache                                        |
-| `--cloudflared <path>`      | `PATH`                   | Explicit `cloudflared` binary                                                |
-
-`--assets` can also be set with `DOOMPI_WEB_DIST`. `DOOMPI_API_DIR` overrides the default generated package API directory. Use `doompi-web --help` for the complete command help.
+See [Getting started](docs/getting-started.md) for command options, environment variables, remote setup, and the plugin development loop.
 
 ## How it works
 
-The hub watches the session registry and attaches to each registered `doompi-server` using the token file named by that record. Attach tokens remain in the hub process. A browser page uses one WebSocket, while hub and session frames remain keyed by session ID. The hub buffers a bounded history for reconnects and rejects browser-supplied attach frames.
+The hub watches the session registry and attaches to each server over its authenticated Unix socket. The browser talks to the hub through one WebSocket, with every frame keyed by session. Closing a tab does not stop the agent, and the hub keeps a bounded replay window for reconnects.
 
-The host shell is packaged with this module. Synchronized repositories contribute per-session plugin compositions, hub channels, and package API routes. A selected composition is complete or it is not used, and repository and global artifacts are never mixed inside one session. See [bundle resolution](docs/bundle.md) and [architecture](docs/architecture.md).
+DoomPi first resolves repository configuration into the ordered extension composition used by the TUI. `doompi sync` publishes that composition and its related artifacts as one immutable generation. DoomPi Web reads the same generation, but loads browser plugins, hub channels, and APIs instead of the TUI runtime bundle. The browser shell itself ships with this package.
 
-The cockpit also serves a PWA install shell and service worker. After a paired device installs the PWA, the worker verifies signed host and plugin assets before putting them in the active cache. Optional closed-app Web Push notifications are generic, zero-TTL alerts kept in memory by the running hub. They are not a durable notification queue.
+Packages extend the cockpit in two ways:
 
-## Extending the cockpit
+- `doompiWeb` adds browser UI and optional hub channels. See [Web plugins](docs/plugins.md).
+- `doompiApi` adds HTTP handlers in the hub or session server. See [Package APIs](docs/package-apis.md).
 
-A DoomPi package can declare a browser plugin in `package.json` under `doompiWeb`. Its client entry exports `webPlugin`; an optional hub entry exports `webHubChannels`. Plugins can add tabs, dock and activity sections, settings, session channels, slots, Leader bindings, context actions, and tool renderers. Plugins are independent and optional. See [web plugins](docs/plugins.md) and the typed [web plugin contracts](https://www.npmjs.com/package/@agimon-ai/doompi-web-contracts).
+See [Composition and runtime bundling](../../../docs/bundling.md) for the TUI path. [Web bundling and serving](docs/bundle.md) explains why the shell and plugins are separate, what sync builds, how a session selects its artifacts, and how the hub serves them.
 
-A package can expose HTTP endpoints under `doompiApi`. Session APIs run with a session server. Hub APIs run with the cockpit hub. Both use the package API `basePath` and `start(context)` contract. See [package APIs](docs/package-apis.md).
+## Remote access
 
-For direct programmatic use:
+Remote access is access to an agent that may have shell tools. Keep the normal listener on loopback. Do not publish it with `--host 0.0.0.0` and assume it is protected.
+
+The remote flow uses a separate tunnel listener, host-approved pairing, and a device cookie. After pairing, session traffic and API payloads use sealed channels. Pairing, passkey, and PWA bootstrap routes remain unsealed so a device can establish trust. Signed bundles protect later asset delivery, but cannot authenticate the first verifier page served by the tunnel.
+
+Passkeys and step-up checks require a stable named tunnel. Quick tunnels have rotating hostnames and skip those checks. The optional container boundary limits which host workspaces the remote cockpit can reach, but it does not make mounted workspaces read-only or remove trust from the container engine.
+
+Read [Remote security](docs/security.md) before enabling a tunnel. It covers cookies, passkeys, sealing, signed bundles, Push, containment, and the limits of each control.
+
+## Guides
+
+| Guide                                      | What it covers                                                        |
+| ------------------------------------------ | --------------------------------------------------------------------- |
+| [Getting started](docs/getting-started.md) | Installation, sessions, sync, options, and development                |
+| [Architecture](docs/architecture.md)       | Hub, session servers, sockets, and lifecycle ownership                |
+| [Web plugins](docs/plugins.md)             | Plugin manifests, browser entries, hub channels, and UI contributions |
+| [Package APIs](docs/package-apis.md)       | API scopes, route selectors, and caller context                       |
+| [Web bundling and serving](docs/bundle.md) | Design choices, build outputs, per-session selection, and serving     |
+| [Remote security](docs/security.md)        | Pairing, cookies, passkeys, sealed transport, and containment         |
+
+## Programmatic use
 
 ```ts
 import { serveWeb } from '@agimon-ai/doompi-web';
 import { bundleCockpitWeb } from '@agimon-ai/doompi-web/bundler';
 ```
-
-## Remote access and security
-
-Remote access is intentionally an authenticated path to an agent that can hold shell tools. Enabling it creates a second loopback listener for the tunnel and leaves the normal local listener unchanged. Pairing requires a code and approval on the host. A paired browser receives a device bearer cookie, not a session attach token.
-
-Remote session traffic, protocol traffic, and API bodies use a sealed channel after pairing. Pairing, passkey, and PWA bootstrap routes are intentionally unsealed. Signed bundle verification protects asset delivery only after the signing key and the initial bootstrap are trusted. The tunnel provider can still observe the page, asset requests, timing, sizes, and connection metadata.
-
-The default loopback origin and host checks help against hostile web pages and DNS rebinding. They do not protect against a hostile local process. Do not publish the listener with `--host 0.0.0.0`; use the paired remote-access flow or a trusted SSH tunnel. See [remote security](docs/security.md), including passkeys, step-up actions, sealed transport, signed bundles, and the optional container boundary.
-
-## Documentation
-
-- [Getting started](docs/getting-started.md): installation, sync, sessions, and development setup
-- [Architecture](docs/architecture.md): process boundaries, sockets, lifecycle, and browser composition
-- [Web plugins](docs/plugins.md): manifests, client and hub entries, contributions, and compatibility
-- [Package APIs](docs/package-apis.md): `doompiApi`, route mounting, selectors, and caller context
-- [Bundle resolution](docs/bundle.md): synchronized generations, fallback, publication, and overrides
-- [Remote security](docs/security.md): pairing, passkeys, sealing, bundle trust, and containment limits
-
-## Development
-
-Run from this package directory:
-
-```bash
-pnpm build
-pnpm typecheck
-pnpm test
-pnpm test:e2e
-pnpm lint
-```
-
-Build before running the end-to-end suite. The package is maintained by [Agimon](https://agimon.ai/about).
 
 ## License
 

--- a/packages/clients/doompi-web/docs/architecture.md
+++ b/packages/clients/doompi-web/docs/architecture.md
@@ -1,0 +1,58 @@
+# Architecture
+
+DoomPi Web separates the browser shell, the session hub, and the `doompi-server` processes that own agent sessions.
+
+```text
+Browser
+  | one cockpit WebSocket
+  v
+DoomPi Web hub
+  | one authenticated socket per registered session
+  v
+Session servers
+  | Pi protocol and package APIs
+  v
+Agents and extensions
+```
+
+## Hub process
+
+`doompi-web` owns the HTTP server, the browser WebSocket, the session registry watcher, and the remote-access state machine. It watches the registry at `~/.doompi/run` by default, or the directory selected by `--registry-dir` or `DOOMPI_RUNTIME_DIR`.
+
+The hub reads each registry record's attach token file and connects to the named Unix socket. The token remains in the hub process. The browser does not perform the session handshake and an `attach` frame sent from the browser is refused.
+
+One browser WebSocket carries hub events, session frames, channel frames, history requests, and commands for many sessions. Every session message includes its session ID. The hub keeps a bounded in-memory ring per session and replays available frames when a page subscribes again. A disconnected browser does not stop an agent.
+
+## Session servers
+
+Each `doompi-server` process owns one agent session and registers its socket, token file, working directory, and API socket. The hub may attach to an existing server or start one when the cockpit creates a session. Stopping the hub does not stop a server that it spawned.
+
+A session server reads its package and extension composition when it starts. Rebuilding a synchronized composition does not change an already running process. Create a new session or restart the existing one after synchronization to load new session extensions and package API routes.
+
+## Browser composition
+
+The host shell is the packaged SPA. Web plugins are compiled into a separate composition and loaded for each session. The hub resolves that composition from the session's repository configuration root first, then the global configuration root. A registration is usable only when its web directory, plugin composition entry, plugin manifest, and API directory are present. The host never merges repository artifacts with global artifacts for one session.
+
+The selected composition also determines the hub channel entries and the package API bundle associated with that session. The browser receives plugin metadata and signed asset URLs through the hub. See [bundle resolution](bundle.md) for generation and fallback rules.
+
+## API boundaries
+
+Package APIs are mounted by the hub under `/api/plugin/<basePath>`. A session-scoped API is served by the session server and reached through a hub proxy. A hub-scoped API runs in the hub process. The hub strips the package mount and routing selector before invoking a package handler.
+
+The hub also owns built-in routes for health, sessions, files, settings, provider authentication, remote access, PWA bootstrap, and bundle assets. Session file routes are bounded to the session working directory. Repository settings use opaque repository IDs that the hub resolves, rather than trusting browser-supplied filesystem paths.
+
+## Lifecycle
+
+1. Startup ensures the global DoomPi configuration is initialized and attempts a global synchronization.
+2. Existing registry records are read. Their configuration roots are synchronized on demand before attachment.
+3. The hub attaches to discovered session servers and loads their selected web channels.
+4. A browser connects to the hub and receives the session snapshot, channel list, and session frames.
+5. A new session request synchronizes its working directory's configuration root before starting the server.
+6. A restart synchronizes first, then replaces the session server while preserving the session identity where the server supports resume.
+7. Closing the browser only removes that page's subscriptions. Closing the hub closes remote access, browser sockets, channels, and API handlers.
+
+Only the global synchronization guard watches for later changes. A repository selected by `--dir` is synchronized on demand, not watched. A completed global sync reloads channels for sessions using the global composition without replacing the stable shell.
+
+## Remote path
+
+Remote access uses a second loopback listener. The tunnel listener is tagged separately from the local listener before the shared guard runs. Pairing and PWA bootstrap routes are served directly. Remote session sockets and protocol sockets require a paired device and a purpose-specific sealed channel. Other remote HTTP requests use the sealed gateway. See [remote security](security.md).

--- a/packages/clients/doompi-web/docs/architecture.md
+++ b/packages/clients/doompi-web/docs/architecture.md
@@ -1,58 +1,123 @@
 # Architecture
 
-DoomPi Web separates the browser shell, the session hub, and the `doompi-server` processes that own agent sessions.
+DoomPi Web is a hub, not a browser wrapper around one agent. It keeps agent processes independent of browser tabs, joins many session servers behind one cockpit, and resolves the UI that belongs to each session.
+
+That shape solves three problems:
+
+- a browser may disconnect without stopping the agent
+- one cockpit may show sessions from different repositories
+- session credentials and server modules must stay off the browser
+
+## The system in one picture
 
 ```text
-Browser
+Browser shell
   | one cockpit WebSocket
+  | session id on every session frame
   v
 DoomPi Web hub
-  | one authenticated socket per registered session
+  | registry discovery
+  | one authenticated Unix socket per session
+  | hub channels and hub package APIs
   v
-Session servers
-  | Pi protocol and package APIs
+DoomPi session servers
+  | one agent per server
+  | Pi protocol and session package APIs
   v
 Agents and extensions
 ```
 
-## Hub process
+The browser, hub, and session server have different lifetimes. Closing a page removes that page's subscriptions. It does not stop the hub, session server, or agent. Closing the hub disconnects browser clients and hub-owned services, but independently running session servers continue until their own agents exit.
 
-`doompi-web` owns the HTTP server, the browser WebSocket, the session registry watcher, and the remote-access state machine. It watches the registry at `~/.doompi/run` by default, or the directory selected by `--registry-dir` or `DOOMPI_RUNTIME_DIR`.
+## Ownership boundaries
 
-The hub reads each registry record's attach token file and connects to the named Unix socket. The token remains in the hub process. The browser does not perform the session handshake and an `attach` frame sent from the browser is refused.
+| Component               | Owns                                                                                                                      | Does not own                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Browser shell           | Navigation, session focus, timeline, composer, plugin UI, verified asset activation                                       | Session attach tokens, agent processes, server modules |
+| DoomPi Web hub          | HTTP and WebSocket listeners, registry watch, session attachments, browser fan-out, hub channels, hub APIs, remote access | Agent lifetime, session API implementation             |
+| `doompi-server`         | One agent, session socket, Pi protocol socket, session APIs, registry record                                              | Browser tabs, remote device authentication             |
+| Synchronized generation | Runtime state, web plugin artifacts, hub registry, API registries                                                         | Live processes or mutable session state                |
 
-One browser WebSocket carries hub events, session frames, channel frames, history requests, and commands for many sessions. Every session message includes its session ID. The hub keeps a bounded in-memory ring per session and replays available frames when a page subscribes again. A disconnected browser does not stop an agent.
+Keeping these responsibilities separate prevents a browser reconnect from becoming an agent restart and prevents a plugin client from receiving host credentials merely because its server half needs them.
 
-## Session servers
+## Session discovery and attachment
 
-Each `doompi-server` process owns one agent session and registers its socket, token file, working directory, and API socket. The hub may attach to an existing server or start one when the cockpit creates a session. Stopping the hub does not stop a server that it spawned.
+Each `doompi-server` writes a record under `~/.doompi/run` by default. The record names its process, working directory, Unix sockets, and attach-token file. `--registry-dir` or `DOOMPI_RUNTIME_DIR` moves the registry.
 
-A session server reads its package and extension composition when it starts. Rebuilding a synchronized composition does not change an already running process. Create a new session or restart the existing one after synchronization to load new session extensions and package API routes.
+The hub watches those records, confirms the server process is live, reads the token file, and performs the socket handshake. The token remains in the hub process. Browser-supplied `attach` frames are rejected because the browser is not part of this trust boundary.
 
-## Browser composition
+The registry is deliberately simple filesystem coordination. It lets independently started servers appear without a central daemon. The tradeoff is that the registry contains trusted paths. It must remain owner-only even though it stores the token path rather than the token value.
 
-The host shell is the packaged SPA. Web plugins are compiled into a separate composition and loaded for each session. The hub resolves that composition from the session's repository configuration root first, then the global configuration root. A registration is usable only when its web directory, plugin composition entry, plugin manifest, and API directory are present. The host never merges repository artifacts with global artifacts for one session.
+## Browser multiplexing
 
-The selected composition also determines the hub channel entries and the package API bundle associated with that session. The browser receives plugin metadata and signed asset URLs through the hub. See [bundle resolution](bundle.md) for generation and fallback rules.
+One browser WebSocket carries hub events, commands, histories, plugin channel frames, and traffic for many sessions. Session traffic is tagged with its session ID so the focused session can change without opening a new connection.
 
-## API boundaries
+The hub keeps a bounded in-memory frame ring for each attached server. When a page subscribes again, it receives what remains in that ring and a dropped-frame count. This is reconnect assistance, not durable event storage. The session server and Pi protocol own authoritative session state.
 
-Package APIs are mounted by the hub under `/api/plugin/<basePath>`. A session-scoped API is served by the session server and reached through a hub proxy. A hub-scoped API runs in the hub process. The hub strips the package mount and routing selector before invoking a package handler.
+This arrangement allows several tabs to observe one session without competing for the server's single authenticated client slot. The hub occupies that slot and fans traffic out to browser pages.
 
-The hub also owns built-in routes for health, sessions, files, settings, provider authentication, remote access, PWA bootstrap, and bundle assets. Session file routes are bounded to the session working directory. Repository settings use opaque repository IDs that the hub resolves, rather than trusting browser-supplied filesystem paths.
+## Per-session composition
+
+The shell is part of the installed `@agimon-ai/doompi-web` package. Plugin UI is not baked permanently into that shell. For each session, the hub uses the session working directory to select one synchronized plugin composition:
+
+1. Try the complete registration for the session's repository or worktree.
+2. Fall back to the complete global web registration when the repository has no usable web output.
+3. Keep the package-owned shell with built-in surfaces when no plugin composition is available.
+
+A selected generation supplies the client plugin composition, hub channels, and package APIs together. Repository and global artifacts are not mixed inside one session.
+
+This is why the cockpit can focus a session from repository A, load its UI, then focus repository B and activate a different UI without replacing the hub. [Web bundling and serving](bundle.md) covers the build and signed publication design.
+
+## Extension paths
+
+DoomPi packages extend the system along two independent paths:
+
+```text
+doompiWeb
+  +-- browser webPlugin ------> compiled client composition
+  +-- webHubChannels ---------> modules loaded in the hub
+
+doompiApi
+  +-- hub API ----------------> handler running in the hub
+  +-- session API ------------> handler running beside the agent
+```
+
+A browser plugin controls presentation and page state. A hub channel maintains live host-side data for that presentation. A package API handles request-response work in the process that owns the required resources.
+
+These are separate contracts on purpose. Not every panel needs a channel, not every channel needs an HTTP route, and a session API should not move into the hub merely to become reachable from the browser. See [Web plugins](plugins.md) and [Package APIs](package-apis.md).
+
+## API routing boundary
+
+All package routes use `/api/plugin/<basePath>`. The selector determines where the request goes:
+
+- `session=<session-id>` proxies to the API socket owned by that session server.
+- `hubSession=<session-id>` selects the hub API registry associated with that session's composition.
+- no selector uses the hub's deterministic default API registry.
+
+The hub removes routing selectors before invoking the package handler. It also removes caller-supplied identity headers and writes trusted locality, device, and step-up context. Package handlers still own input validation and authorization for their operation.
+
+Built-in routes remain hub-owned. They cover health, session management, files, settings, provider authentication, remote access, PWA bootstrap, and signed publications.
 
 ## Lifecycle
 
-1. Startup ensures the global DoomPi configuration is initialized and attempts a global synchronization.
-2. Existing registry records are read. Their configuration roots are synchronized on demand before attachment.
-3. The hub attaches to discovered session servers and loads their selected web channels.
-4. A browser connects to the hub and receives the session snapshot, channel list, and session frames.
-5. A new session request synchronizes its working directory's configuration root before starting the server.
-6. A restart synchronizes first, then replaces the session server while preserving the session identity where the server supports resume.
-7. Closing the browser only removes that page's subscriptions. Closing the hub closes remote access, browser sockets, channels, and API handlers.
+```text
+start hub
+  -> initialize and synchronize the global cockpit root
+  -> read existing session records
+  -> synchronize session roots on demand
+  -> attach to live servers
+  -> load each session's hub channels and web composition
+  -> accept browser connections
+```
 
-Only the global synchronization guard watches for later changes. A repository selected by `--dir` is synchronized on demand, not watched. A completed global sync reloads channels for sessions using the global composition without replacing the stable shell.
+Creating or restarting a session synchronizes its configuration root before launching the server. An already running session server does not replace its extensions or session APIs when files on disk change. Restart that session after synchronization when server-side composition changes.
 
-## Remote path
+Only the global synchronization guard remains watched. A completed global sync reloads channels for sessions using the global composition without replacing the shell. A repository passed with `--dir` is synchronized on demand, not watched.
 
-Remote access uses a second loopback listener. The tunnel listener is tagged separately from the local listener before the shared guard runs. Pairing and PWA bootstrap routes are served directly. Remote session sockets and protocol sockets require a paired device and a purpose-specific sealed channel. Other remote HTTP requests use the sealed gateway. See [remote security](security.md).
+## Local and remote listeners
+
+The normal listener binds loopback. Remote access creates a second loopback listener and points `cloudflared` at it. Both reach the same application, but the accepted socket marks whether a request arrived through the local or tunnel listener before authorization runs.
+
+This distinction cannot be delegated to a proxy header because a tunnel connection also arrives from loopback and a remote caller can forge headers. Tunnel WebSockets require a paired device and a purpose-specific sealed channel. Remote HTTP operations use the sealed gateway except for the small bootstrap allowlist.
+
+See [Remote security](security.md) for the threat model, authentication, code-delivery protection, and containment limits.

--- a/packages/clients/doompi-web/docs/bundle.md
+++ b/packages/clients/doompi-web/docs/bundle.md
@@ -1,42 +1,64 @@
-# DoomPi bundle resolution
+# Bundle resolution
 
-DoomPi Web resolves one complete bundle for each session. A bundle is an immutable sync generation containing:
+DoomPi Web treats synchronized output as immutable generations. A usable web registration contains a complete set of artifacts for one configuration root:
 
-- the precompiled DoomPi runtime and sync state
-- the cockpit web assets
-- the generated web plugin composition and manifest
-- the generated package API route directory
+- synchronized DoomPi runtime and state
+- the host web asset directory
+- a generated plugin composition entry and Vite manifest
+- a server registry for built hub channel entries
+- generated `hub.routes.mjs` and `session.routes.mjs` package API modules
 
-A registration is usable by DoomPi Web only when all required artifacts exist. A registration with no web directory is a CLI-only generation, not a web bundle.
+A registration with no web directory is a CLI-only generation and is not a web bundle. A registration is usable only when its web entry, plugin composition entry, plugin manifest, and API directory are present. The hub does not serve a partially published generation.
 
-## Resolution order
+## Per-session resolution
 
-Bundle resolution is session-scoped:
+The selected web composition is resolved for each session:
 
 1. Resolve the session working directory to its Doom configuration root.
-2. Try the synchronized bundle registered for that repository or worktree.
-3. If the repository bundle is missing, incomplete, invalid, or fails to synchronize, use the synchronized global bundle from `~/.pi/.doom`.
-4. If neither bundle is usable, report the synchronization failure. Never select a partially published generation.
+2. Read the synchronized registration for that repository or worktree.
+3. Use it when the web and API artifacts are complete.
+4. Otherwise use the complete global registration from `~/.pi/.doom`.
+5. If no complete registration is available, report the synchronization failure and continue with the packaged host shell when it can be served.
 
-This order applies consistently to the DoomPi runtime, web plugins, hub channels, and package APIs. Repository artifacts must not be mixed with global artifacts inside one selected bundle. The global bundle is the fallback, not an additional repository layer.
+The repository registration wins over the global registration even when it is the result of an explicit `--dir` selection. Repository artifacts are never combined with global artifacts inside one session. The global registration is a fallback, not an additional plugin layer.
 
-Session-associated hub API requests carry a separate `hubSession` selector. The hub resolves that session through the same repository-first/global-fallback registration used by its web plugins, then dispatches only within that registration's API directory. It does not borrow an API missing from the selected bundle. The existing `session` selector remains reserved for proxying session-scoped APIs.
+This selection applies together to the session's plugin client composition, hub channels, and package API bundle. A request with `hubSession=<session-id>` resolves the same registration and dispatches only within its API directory. It cannot borrow an API that is missing from that selected bundle. The `session` query remains the selector for forwarding to the session server's own APIs.
 
-Hub APIs used outside a session, including machine and repository settings surfaces, use the process's deterministic default API bundle: an explicit API directory override when configured, otherwise the selected global registration.
+## Synchronization and publication
 
-## Optional package contributions
+`doompi sync` stages the runtime, web assets, generated plugin files, hub registry, and API routes in a new generation. It publishes the registration only after the generation is complete. Readers continue using the previous complete registration while the replacement is built.
 
-A package is not required to provide a web plugin or a package API.
+The hub ensures the global configuration is synchronized at startup and watches only the global synchronization guard. A repository configuration selected by `--dir` is synchronized before launch and before a new or restarted session, but it is not watched. A running session server reads its composition at startup, so restart it after changing synchronized server or API entries.
 
-- Missing `doompiWeb` means the package contributes no browser plugin or hub channel.
-- Missing package API metadata means the package contributes no hub or session API.
-- An empty composition still produces valid plugin composition and manifest files.
-- An empty API composition still produces valid `hub.routes.mjs` and `session.routes.mjs` files.
+Optional plugin and API contributions do not make the whole generation invalid:
 
-Malformed optional metadata or a declared entry that is unavailable is reported with the owning package and skipped when it is safe to isolate. It must not prevent unrelated package contributions or the base cockpit from being bundled. A failure in the DoomPi Web host package itself remains fatal because the base cockpit would not be valid.
+- no `doompiWeb` field means no web plugin or hub channel
+- no `doompiApi` field means no package API
+- malformed metadata or an unavailable optional entry is reported and skipped when it can be isolated
+- empty plugin and API compositions still have valid generated output
+- a failure in the DoomPi Web host package or an incomplete base shell remains a host failure
 
-## Publication invariant
+## Host shell and plugin routes
 
-Synchronization stages every artifact in a new generation before publishing its registration. Publication is atomic. Readers continue using the previous complete generation until the replacement is ready.
+The packaged host shell is selected separately from the per-session plugin composition. Asset selection is:
 
-DoomPi Web asks drift detection to require a web bundle. This prevents the sync pipeline from treating a CLI-only generation as current. If repository synchronization still cannot produce a complete bundle, session launch continues with the complete global bundle.
+1. `--assets <path>`
+2. `DOOMPI_WEB_DIST`
+3. a synchronized host asset directory when available
+4. the package's own built assets
+
+The host signs the active shell publication for the PWA. It exposes its signed manifest at `/bundle-manifest.json`. Raw shell assets are served at `/bundle-assets/<revision>/<asset-path>` and are accepted only for the current signed revision.
+
+Each selected session plugin composition is copied into an immutable publication and signed with a composition ID and revision. Its routes are distinct from raw host assets:
+
+- `/api/web-plugins/<composition-id>/<revision>/manifest` returns the signed plugin manifest
+- `/api/web-plugins/<composition-id>/<revision>/assets/...` returns raw plugin assets listed by that manifest
+- `/verified-plugins/<composition-id>/<revision>/...` is the service worker's local verified-cache path, not a raw server asset route
+
+Signed manifests include an increasing revision and a SHA-256 digest, byte length, and content type for every asset. The service worker verifies the manifest, then fetches and verifies every raw asset before committing the composition to its cache. Failed updates keep the last verified revision. See [remote security](security.md) for what this proves and what it does not prove.
+
+## Overrides
+
+`DOOMPI_API_DIR` overrides the generated API directory used for the default hub API bundle. The standard generated location is `~/.doompi/api/current`. A session-associated hub API request still uses the selected session registration, unless its registration is replaced by the normal repository-first/global-fallback resolution.
+
+`DOOMPI_WEB_PACKAGE_ROOT` is available to bundled launchers whose built assets do not retain the normal npm package layout. It points the launcher at a package root containing `dist/web` and `dist/pwa`.

--- a/packages/clients/doompi-web/docs/bundle.md
+++ b/packages/clients/doompi-web/docs/bundle.md
@@ -1,64 +1,164 @@
-# Bundle resolution
+# Web bundling and serving
 
-DoomPi Web treats synchronized output as immutable generations. A usable web registration contains a complete set of artifacts for one configuration root:
+DoomPi Web does not bundle the TUI. The TUI loads a Node.js runtime composition prepared by DoomPi. The web build uses the same selected packages to produce browser plugins, hub channels, and HTTP APIs for the cockpit.
 
-- synchronized DoomPi runtime and state
-- the host web asset directory
-- a generated plugin composition entry and Vite manifest
-- a server registry for built hub channel entries
-- generated `hub.routes.mjs` and `session.routes.mjs` package API modules
+Read [Composition and runtime bundling](../../../../docs/bundling.md) first if the DoomPi composition, fingerprint, or synchronized generation is unfamiliar.
 
-A registration with no web directory is a CLI-only generation and is not a web bundle. A registration is usable only when its web entry, plugin composition entry, plugin manifest, and API directory are present. The hub does not serve a partially published generation.
+## The design in one picture
 
-## Per-session resolution
+```text
+DoomPi composition for a repository
+                |
+                v
+          doompi sync
+                |
+        +-------+--------+
+        |       |        |
+        v       v        v
+ browser plugin JS   hub channels   package APIs
+ and CSS              registry       route modules
+        |                  |              |
+        +--------- immutable generation --+
+                           |
+                 selected per session
+                           |
+        +------------------+------------------+
+        |                                     |
+        v                                     v
+ package-owned browser shell              DoomPi Web hub
+ loads verified plugin assets             loads server modules
+```
 
-The selected web composition is resolved for each session:
+There are two deliberately separate browser pieces:
 
-1. Resolve the session working directory to its Doom configuration root.
-2. Read the synchronized registration for that repository or worktree.
-3. Use it when the web and API artifacts are complete.
-4. Otherwise use the complete global registration from `~/.pi/.doom`.
-5. If no complete registration is available, report the synchronization failure and continue with the packaged host shell when it can be served.
+- **The shell** is the cockpit application shipped by `@agimon-ai/doompi-web`. It owns navigation, sessions, the timeline, the composer, settings, and the plugin runtime.
+- **The plugin composition** is generated from the DoomPi packages selected for one repository. It contributes the tabs, renderers, channels, settings, and other surfaces those packages declare.
 
-The repository registration wins over the global registration even when it is the result of an explicit `--dir` selection. Repository artifacts are never combined with global artifacts inside one session. The global registration is a fallback, not an additional plugin layer.
+The shell stays stable while the plugin composition changes with the focused session.
 
-This selection applies together to the session's plugin client composition, hub channels, and package API bundle. A request with `hubSession=<session-id>` resolves the same registration and dispatches only within its API directory. It cannot borrow an API that is missing from that selected bundle. The `session` query remains the selector for forwarding to the session server's own APIs.
+## Why it is built this way
 
-## Synchronization and publication
+### One hub can serve different repositories
 
-`doompi sync` stages the runtime, web assets, generated plugin files, hub registry, and API routes in a new generation. It publishes the registration only after the generation is complete. Readers continue using the previous complete registration while the replacement is built.
+A DoomPi Web hub can attach to several `doompi-server` processes. Each session has its own working directory, and those directories may belong to repositories with different modes and package sets.
 
-The hub ensures the global configuration is synchronized at startup and watches only the global synchronization guard. A repository configuration selected by `--dir` is synchronized before launch and before a new or restarted session, but it is not watched. A running session server reads its composition at startup, so restart it after changing synchronized server or API entries.
+Building plugins into the shell selected at hub startup would give every session the same UI. Instead, the hub resolves a plugin composition from each session's repository and tells the browser which composition belongs to the focused session.
 
-Optional plugin and API contributions do not make the whole generation invalid:
+### Browser code is compiled ahead of time
 
-- no `doompiWeb` field means no web plugin or hub channel
-- no `doompiApi` field means no package API
-- malformed metadata or an unavailable optional entry is reported and skipped when it can be isolated
-- empty plugin and API compositions still have valid generated output
-- a failure in the DoomPi Web host package or an incomplete base shell remains a host failure
+A plugin client entry may contain TypeScript, React, CSS, and Tailwind classes. The browser should not discover packages or compile source code. `doompi sync` does that work ahead of time with Vite and writes ordinary JavaScript and CSS into the synchronized generation.
 
-## Host shell and plugin routes
+This also gives sync one place to validate plugin manifests and client imports. A malformed optional plugin can be reported and skipped before a user opens the cockpit.
 
-The packaged host shell is selected separately from the per-session plugin composition. Asset selection is:
+### Client and server code stay apart
 
-1. `--assets <path>`
-2. `DOOMPI_WEB_DIST`
-3. a synchronized host asset directory when available
-4. the package's own built assets
+A web plugin can have two entries:
 
-The host signs the active shell publication for the PWA. It exposes its signed manifest at `/bundle-manifest.json`. Raw shell assets are served at `/bundle-assets/<revision>/<asset-path>` and are accepted only for the current signed revision.
+- `webPlugin` is browser code and is compiled into the client composition.
+- `webHubChannels` is Node.js code and remains a built server module loaded by the hub.
 
-Each selected session plugin composition is copied into an immutable publication and signed with a composition ID and revision. Its routes are distinct from raw host assets:
+Package APIs are server modules too. They are generated into separate hub and session route registries. Server paths and implementations never need to be placed in the public browser asset directory.
 
-- `/api/web-plugins/<composition-id>/<revision>/manifest` returns the signed plugin manifest
-- `/api/web-plugins/<composition-id>/<revision>/assets/...` returns raw plugin assets listed by that manifest
-- `/verified-plugins/<composition-id>/<revision>/...` is the service worker's local verified-cache path, not a raw server asset route
+### Shared browser runtimes have one owner
 
-Signed manifests include an increasing revision and a SHA-256 digest, byte length, and content type for every asset. The service worker verifies the manifest, then fetches and verifies every raw asset before committing the composition to its cache. Failed updates keep the last verified revision. See [remote security](security.md) for what this proves and what it does not prove.
+The plugin composition does not ship its own copies of React, TanStack Store, CodeMirror, the web component library, or the browser security runtime. Vite marks those packages as external and the shell supplies its copies through the plugin runtime global.
 
-## Overrides
+This is more than a size optimization. React and CodeMirror objects must come from compatible singletons, and the sealed transport must keep one set of nonce counters. Loading a private copy per plugin would break those contracts.
 
-`DOOMPI_API_DIR` overrides the generated API directory used for the default hub API bundle. The standard generated location is `~/.doompi/api/current`. A session-associated hub API request still uses the selected session registration, unless its registration is replaced by the normal repository-first/global-fallback resolution.
+### Publication is complete before selection
 
-`DOOMPI_WEB_PACKAGE_ROOT` is available to bundled launchers whose built assets do not retain the normal npm package layout. It points the launcher at a package root containing `dist/web` and `dist/pwa`.
+Sync writes a new immutable generation and publishes its registration only after all required artifacts validate. The hub therefore selects one complete generation for a session. It never combines a repository's client code with a global hub registry or API directory.
+
+## What `doompi sync` builds
+
+For the selected package roots, the web bundler scans each `doompiWeb` manifest and generates client imports and a server registry. Vite then creates:
+
+```text
+<generation>/
+  web/                       full synchronized SPA retained for compatibility
+  plugins/
+    composition.js           browser plugin definitions
+    manifest.json            Vite output manifest
+    assets/...               plugin CSS and other emitted assets
+  generated/...              generated source entries used during the build
+  webPlugins.server.json     built hub entry paths, not a public browser asset
+  pluginRoots.json           roots used by the development server
+  api/
+    hub.routes.mjs           generated hub API registry
+    session.routes.mjs       generated session API registry
+```
+
+The current runtime serves the package-owned shell by default. The synchronized `web/` directory remains part of the generated contract and can be selected explicitly, but it is not automatically substituted for the shell. The session-specific output is `plugins/`, `webPlugins.server.json`, and the API directory.
+
+An empty plugin or API composition is valid. Missing optional metadata means the package contributes nothing to that surface. Invalid optional entries produce notices and are skipped when they can be isolated. A missing host shell or incomplete required generation is not treated as an optional plugin failure.
+
+## How a session selects its composition
+
+When a session appears, the hub uses its working directory to find the nearest DoomPi configuration root:
+
+1. Read the synchronized registration for that repository or worktree.
+2. Confirm that its plugin entry and manifest exist.
+3. Use that complete repository generation when available.
+4. Otherwise try the hub's complete global synchronized generation.
+5. If neither has plugin artifacts, keep the package-owned shell with its built-in surfaces.
+
+The global generation is a web fallback, not another layer. Once a repository generation wins, its client composition, hub channels, and package APIs stay together.
+
+The hub derives a composition ID from the registration root, generation, and state hash. Sessions with the same synchronized composition can share the same published browser assets, while different generations receive different identities.
+
+## How the hub serves it
+
+### The shell
+
+The normal listener serves the shell built into `@agimon-ai/doompi-web`. `--assets <path>` or `DOOMPI_WEB_DIST` is an explicit operator override. `DOOMPI_WEB_PACKAGE_ROOT` exists for packaged launchers whose files do not have the normal npm layout.
+
+### Browser plugins
+
+The hub copies the selected `plugins/` output into its immutable publication store and signs a manifest containing each path, content type, byte length, and SHA-256 digest. It exposes raw publication bytes under composition- and revision-specific routes.
+
+The browser does not execute those raw URLs directly. Its service worker verifies the signature and every asset, commits the complete composition to Cache Storage, and exposes a verified local route. Only then does the shell load `composition.js` and its styles. Switching sessions activates the verified composition assigned to that session and disposes the previous session's plugin UI.
+
+A failed verification or download leaves the previous verified revision in place. Assets from two revisions are not mixed.
+
+### Hub channels
+
+`webPlugins.server.json` sits beside the public build output. It names each plugin's built hub module by absolute path. The hub imports those modules lazily for the selected session composition. A missing or broken optional module produces a notice and omits its channel instead of crashing the cockpit.
+
+### Package APIs
+
+`hub.routes.mjs` runs package APIs in the web hub. `session.routes.mjs` is loaded by `doompi-server`. A request with `hubSession=<session-id>` selects the hub API registry belonging to that session's web composition. A request with `session=<session-id>` is proxied to that session server. See [Package APIs](package-apis.md) for the routing contract.
+
+## Local and remote serving
+
+Local and remote clients use the same selected composition, but remote delivery has an extra trust problem: the tunnel provider terminates TLS.
+
+For an installed remote PWA, the QR pins the host signing key and a minimum shell revision. The service worker verifies both the package-owned shell publication and each per-session plugin publication before execution. Pairing pages and the first service worker still come from the tunnel origin, so this is not independent authentication of the initial bootstrap. See [Remote security](security.md) for that boundary.
+
+The server-side registry and API modules are never signed for browser delivery because they are never served as browser assets.
+
+## When changes take effect
+
+| Change                               | Required action                                                                          |
+| ------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Web plugin client source or manifest | Build the package, run `doompi sync`, then create or restart the session                 |
+| Hub channel entry                    | Build the package, run `doompi sync`, and restart the hub or affected session attachment |
+| Session package API                  | Build, sync, and restart the session server                                              |
+| Hub package API                      | Build, sync, and reload the selected hub API composition                                 |
+| Package-owned shell                  | Rebuild or upgrade `@agimon-ai/doompi-web`, then restart the hub                         |
+| Global synchronized composition      | Run `doompi sync`; the global watcher adopts completed generations                       |
+| Repository selected with `--dir`     | Run `doompi sync`, then create or restart a session; `--dir` is not a file watcher       |
+
+For client development, the Vite server can generate the composition from `DOOMPI_WEB_PLUGIN_ROOTS` and hot reload browser entries. Hub entries remain built Node.js modules and require a package build plus a hub restart.
+
+## The terms to keep separate
+
+| Term                   | Meaning                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| DoomPi composition     | Ordered Pi extension activation plan for a repository and selection            |
+| Runtime bundle         | Node.js entry loaded by Pi for the TUI                                         |
+| Web plugin composition | Browser JavaScript and CSS generated from packages with `doompiWeb`            |
+| Hub registry           | Private list of server-side `webHubChannels` modules                           |
+| Package API registry   | Generated hub or session HTTP handler modules                                  |
+| Signed publication     | Immutable shell or plugin bytes offered to the service worker for verification |
+
+They share a synchronized generation so they cannot drift independently, but they are different artifacts loaded by different runtimes.

--- a/packages/clients/doompi-web/docs/getting-started.md
+++ b/packages/clients/doompi-web/docs/getting-started.md
@@ -1,103 +1,131 @@
 # Getting started
 
-DoomPi Web is a standalone cockpit process. It is not loaded by Pi and must not be added to `.doom/modes.yaml`.
+DoomPi Web is a long-lived cockpit hub. It is not loaded into Pi and must not be added to `.doom/modes.yaml`.
+
+Before starting it, choose the topology you want:
+
+| Topology                 | Use it when                                        |
+| ------------------------ | -------------------------------------------------- |
+| Standalone `doompi-web`  | Several sessions should share one durable cockpit  |
+| `doompi-server --web`    | One session should start a cockpit with itself     |
+| Hub plus Vite dev server | You are developing browser plugins with hot reload |
+| Tunnel listener          | A paired phone or remote browser needs access      |
+
+In every case, session agents remain in `doompi-server` processes. The hub discovers those processes through a local registry and keeps their attach tokens out of the browser.
 
 ## Requirements
 
 - Node.js 22.19.0 or newer
 - A DoomPi installation with a synchronized global or repository configuration
-- `cloudflared` only when remote access is enabled
+- `cloudflared` only for remote access
 
-The cockpit can start `doompi-server` itself. You do not need a `doompi-server` executable on `PATH` for sessions created from the page when the bundled server is available.
+The cockpit can start its bundled `doompi-server`. The executable does not need to be on `PATH` unless `--spawn-command` selects it explicitly.
 
-## Install
-
-For a published install:
+## Install and start
 
 ```bash
 npm install -g @agimon-ai/doompi-web
-```
-
-For a workspace checkout, install dependencies at the repository root and build the package:
-
-```bash
-pnpm install
-pnpm --filter @agimon-ai/doompi-web build
-```
-
-## Start a local cockpit
-
-```bash
 doompi-web
 ```
 
-Open <http://127.0.0.1:7433>. Startup runs the bundled `doompi init` when the personal DoomPi directory is missing. A second process using the same package version reports the existing URL and exits. A different version replaces an idle loopback hub, but does not interrupt a hub with live sessions.
+Open <http://127.0.0.1:7433>. The loopback bind is deliberate: the local listener has browser-origin defenses but no device authentication. Do not replace it with `0.0.0.0` for remote use.
 
-The hub watches the default session registry at `~/.doompi/run`. Set `DOOMPI_RUNTIME_DIR` or pass `--registry-dir <path>` to use another registry. Existing `doompi-server` records in that registry appear in the sessions rail. New sessions created in the cockpit are launched through the bundled server unless `--spawn-command` is set.
+On first start, the command runs its bundled `doompi init` when the personal DoomPi directory is missing. It then synchronizes the global cockpit root, watches the session registry, and attaches to live server records.
 
-## Select a repository composition
+A second process using the same package version reports the existing URL and exits. A different version may replace an idle loopback hub, but it does not interrupt a hub with live sessions.
 
-A session's web plugin composition is selected from its working directory. The repository's synchronized registration is tried first. If it is missing, incomplete, invalid, or cannot be synchronized, the global synchronized registration is used. The selected repository and global artifacts are never combined.
+## How sessions appear
 
-Use `--dir` to pin and synchronize one repository for a development cockpit:
+The default registry is `~/.doompi/run`. Each `doompi-server` record names its process, working directory, socket, and token file. The hub reads the token and occupies the server's authenticated client slot, then multiplexes browser pages behind that connection.
+
+Existing live records appear automatically. Creating a session in the cockpit starts the bundled server unless `--spawn-command` changes the launcher.
+
+Use `--registry-dir <path>` or `DOOMPI_RUNTIME_DIR` when the servers use another registry. The directory and token paths are a trust boundary, so keep a custom registry owner-only.
+
+## Choose the web composition
+
+A session's working directory selects its repository configuration. The hub tries that repository's complete synchronized web generation first, then the complete global generation. It never combines repository client code with global hub channels or APIs.
+
+Use `--dir` when the cockpit should be anchored to one repository during development:
 
 ```bash
 doompi-web --dir "$PWD"
 ```
 
-The path must be inside a repository. This synchronization happens before launch and before a new or restarted session. `--dir` does not watch the repository. Run `doompi sync` after changing its configuration, then create or restart the relevant session. The global synchronization guard is the only bundle watcher.
+The path must be inside a repository. The hub synchronizes it before launch and before creating or restarting a session. `--dir` is not a file watcher. After changing repository configuration or built plugin code, run `doompi sync` and create or restart the affected session.
 
-The current working directory does not select the bundle when `--dir` is absent. Use the repository containing the session, or use `--dir`, when testing repository-specific web plugins.
+Without `--dir`, the directory used to start the command does not choose every session's plugin set. Each session still resolves from its own working directory. Only the global synchronization guard remains watched after startup.
 
-## Useful options and environment variables
-
-| Option or variable          | Default                         | Effect                                                              |
-| --------------------------- | ------------------------------- | ------------------------------------------------------------------- |
-| `--dir <path>`              | none                            | Pin one repository composition and synchronize it on demand         |
-| `--registry-dir <path>`     | `~/.doompi/run`                 | Change the session registry                                         |
-| `DOOMPI_RUNTIME_DIR`        | unset                           | Environment equivalent of the registry default override             |
-| `--spawn-command <command>` | bundled server                  | Choose the command used for cockpit-created sessions                |
-| `--port <number>`           | `7433`                          | Choose the HTTP port                                                |
-| `--host <address>`          | `127.0.0.1`                     | Choose the bind address; non-loopback addresses are unauthenticated |
-| `--assets <path>`           | synced or packaged              | Override the host shell asset directory                             |
-| `DOOMPI_WEB_DIST`           | unset                           | Environment override for host shell assets                          |
-| `DOOMPI_API_DIR`            | generated current API directory | Override generated package API routes                               |
-| `--state-dir <path>`        | `~/.doompi/web`                 | Store remote-access state and cockpit cache                         |
-| `--cloudflared <path>`      | `PATH`                          | Choose the tunnel binary                                            |
-| `DOOMPI_WEB_ALLOW_ORIGIN`   | unset                           | Comma-separated additional local origins for development            |
-
-`doompi-web --help` prints the command's current option text. The `DOOMPI_WEB_ALLOW_ORIGIN` setting changes the local origin allowlist only. It does not make a public listener safe.
+See [Web bundling and serving](bundle.md) for why the package shell and per-session plugins are separate.
 
 ## Start remote access
 
-Remote access is configured from the cockpit settings page. Install `cloudflared` first, then choose a quick tunnel or a stable named tunnel. A quick tunnel is suitable for a temporary connection. Its hostname changes on every start and cannot provide a stable passkey or PWA identity. Use a named tunnel for a Home Screen PWA, passkeys, or reliable Web Push subscriptions.
+Remote access is configured in the cockpit settings page rather than by rebinding the local listener.
 
-Enabling remote access creates a second loopback listener on an ephemeral port for the tunnel. The local listener remains on its normal port. The hub self-tests the public URL before reporting success. Pair a device by opening `/pair`, scanning the host-generated QR, and approving the request on the host. See [remote security](security.md) for the threat model and limits.
+1. Install `cloudflared`.
+2. Choose a quick tunnel for temporary access or a stable named tunnel for durable identity.
+3. Enable remote access in Settings.
+4. Open `/pair` on the device, scan the QR, and approve the request on the host.
 
-## Run from the workspace
+The hub creates a second loopback listener for the tunnel and leaves port 7433 local. It probes the public pairing page and confirms that the public health route rejects an unauthenticated request before reporting success.
 
-From the repository root, build the cockpit composition and run the package with that repository selected:
+A quick tunnel gets a new hostname when restarted. It cannot provide durable passkeys, passkey step-up, installed-PWA identity, or reliable Push identity. Use a named tunnel for those controls.
+
+Remote access reaches an agent that may hold shell tools. Read [Remote security](security.md) before enabling it. Pairing authenticates a device; it does not contain the agent or make plugins untrusted-safe.
+
+## Command and environment reference
+
+| Option or variable          | Default           | Effect                                                     |
+| --------------------------- | ----------------- | ---------------------------------------------------------- |
+| `--dir <path>`              | none              | Anchor one repository and synchronize it on demand         |
+| `--registry-dir <path>`     | `~/.doompi/run`   | Select the session registry                                |
+| `DOOMPI_RUNTIME_DIR`        | unset             | Override the default registry directory                    |
+| `--spawn-command <command>` | bundled server    | Select the command used for cockpit-created sessions       |
+| `--port <number>`           | `7433`            | Select the local HTTP port                                 |
+| `--host <address>`          | `127.0.0.1`       | Select the local bind; a non-loopback bind is not paired   |
+| `--assets <path>`           | packaged shell    | Override host shell assets explicitly                      |
+| `DOOMPI_WEB_DIST`           | unset             | Environment equivalent of the shell asset override         |
+| `DOOMPI_API_DIR`            | generated default | Override the default hub package API directory             |
+| `--state-dir <path>`        | `~/.doompi/web`   | Store signing material, remote settings, and cockpit state |
+| `--cloudflared <path>`      | `PATH`            | Select the tunnel binary                                   |
+| `DOOMPI_CLOUDFLARED`        | unset             | Environment equivalent of the tunnel binary override       |
+| `DOOMPI_WEB_ALLOW_ORIGIN`   | unset             | Add comma-separated local development origins              |
+
+`doompi-web --help` prints the current command syntax. `DOOMPI_WEB_ALLOW_ORIGIN` changes browser-origin policy for known development setups. It does not authenticate a public listener.
+
+## Run from this workspace
+
+From the repository root:
 
 ```bash
+pnpm install
 pnpm cockpit:build
 pnpm doompi-web --dir="$PWD"
 ```
 
-For plugin client development, run the hub and Vite dev server in separate terminals from the package directory:
+`cockpit:build` builds the hub, shell, session server, and packages used by the repository composition. The `--dir` launch synchronizes that repository before serving it.
+
+## Develop a browser plugin
+
+Use two terminals:
 
 ```bash
-# repository root
+# repository root: build and run the real hub on 7433
 pnpm cockpit
 
-# packages/clients/doompi-web
+# packages/clients/doompi-web: run Vite on 7434
 pnpm dev
 ```
 
-The dev server uses port `7434` and proxies `/api` to the hub on `7433`. Set `DOOMPI_WEB_PLUGIN_ROOTS` to a path-delimited list of plugin package roots when testing a plugin that is not in the last synchronized composition. Client changes hot reload. Hub channel changes require rebuilding the plugin and restarting the hub.
+The Vite server proxies `/api`, including the browser socket, to the hub. Set `DOOMPI_WEB_PLUGIN_ROOTS` to a path-delimited list of package roots when the plugin is not in the last synchronized composition.
 
-## Verify a change
+Client entries hot reload because Vite compiles their source. Hub channel entries and package APIs are built Node.js modules. Rebuild the owning package and restart the hub or session after changing them.
 
-Run these commands from `packages/clients/doompi-web`:
+The production bundler deduplicates shared browser runtimes and signs immutable plugin publications. The dev server optimizes iteration and should not be used as evidence for the production remote-security boundary.
+
+## Verify a package change
+
+Run from `packages/clients/doompi-web`:
 
 ```bash
 pnpm build
@@ -107,4 +135,4 @@ pnpm test:e2e
 pnpm lint
 ```
 
-Build before `pnpm test:e2e`; the end-to-end suite drives the built executable in a real browser.
+Build before `pnpm test:e2e`; the browser suite drives the built executable. See [Web plugins](plugins.md) for contribution contracts and [Architecture](architecture.md) for process ownership.

--- a/packages/clients/doompi-web/docs/getting-started.md
+++ b/packages/clients/doompi-web/docs/getting-started.md
@@ -1,0 +1,110 @@
+# Getting started
+
+DoomPi Web is a standalone cockpit process. It is not loaded by Pi and must not be added to `.doom/modes.yaml`.
+
+## Requirements
+
+- Node.js 22.19.0 or newer
+- A DoomPi installation with a synchronized global or repository configuration
+- `cloudflared` only when remote access is enabled
+
+The cockpit can start `doompi-server` itself. You do not need a `doompi-server` executable on `PATH` for sessions created from the page when the bundled server is available.
+
+## Install
+
+For a published install:
+
+```bash
+npm install -g @agimon-ai/doompi-web
+```
+
+For a workspace checkout, install dependencies at the repository root and build the package:
+
+```bash
+pnpm install
+pnpm --filter @agimon-ai/doompi-web build
+```
+
+## Start a local cockpit
+
+```bash
+doompi-web
+```
+
+Open <http://127.0.0.1:7433>. Startup runs the bundled `doompi init` when the personal DoomPi directory is missing. A second process using the same package version reports the existing URL and exits. A different version replaces an idle loopback hub, but does not interrupt a hub with live sessions.
+
+The hub watches the default session registry at `~/.doompi/run`. Set `DOOMPI_RUNTIME_DIR` or pass `--registry-dir <path>` to use another registry. Existing `doompi-server` records in that registry appear in the sessions rail. New sessions created in the cockpit are launched through the bundled server unless `--spawn-command` is set.
+
+## Select a repository composition
+
+A session's web plugin composition is selected from its working directory. The repository's synchronized registration is tried first. If it is missing, incomplete, invalid, or cannot be synchronized, the global synchronized registration is used. The selected repository and global artifacts are never combined.
+
+Use `--dir` to pin and synchronize one repository for a development cockpit:
+
+```bash
+doompi-web --dir "$PWD"
+```
+
+The path must be inside a repository. This synchronization happens before launch and before a new or restarted session. `--dir` does not watch the repository. Run `doompi sync` after changing its configuration, then create or restart the relevant session. The global synchronization guard is the only bundle watcher.
+
+The current working directory does not select the bundle when `--dir` is absent. Use the repository containing the session, or use `--dir`, when testing repository-specific web plugins.
+
+## Useful options and environment variables
+
+| Option or variable          | Default                         | Effect                                                              |
+| --------------------------- | ------------------------------- | ------------------------------------------------------------------- |
+| `--dir <path>`              | none                            | Pin one repository composition and synchronize it on demand         |
+| `--registry-dir <path>`     | `~/.doompi/run`                 | Change the session registry                                         |
+| `DOOMPI_RUNTIME_DIR`        | unset                           | Environment equivalent of the registry default override             |
+| `--spawn-command <command>` | bundled server                  | Choose the command used for cockpit-created sessions                |
+| `--port <number>`           | `7433`                          | Choose the HTTP port                                                |
+| `--host <address>`          | `127.0.0.1`                     | Choose the bind address; non-loopback addresses are unauthenticated |
+| `--assets <path>`           | synced or packaged              | Override the host shell asset directory                             |
+| `DOOMPI_WEB_DIST`           | unset                           | Environment override for host shell assets                          |
+| `DOOMPI_API_DIR`            | generated current API directory | Override generated package API routes                               |
+| `--state-dir <path>`        | `~/.doompi/web`                 | Store remote-access state and cockpit cache                         |
+| `--cloudflared <path>`      | `PATH`                          | Choose the tunnel binary                                            |
+| `DOOMPI_WEB_ALLOW_ORIGIN`   | unset                           | Comma-separated additional local origins for development            |
+
+`doompi-web --help` prints the command's current option text. The `DOOMPI_WEB_ALLOW_ORIGIN` setting changes the local origin allowlist only. It does not make a public listener safe.
+
+## Start remote access
+
+Remote access is configured from the cockpit settings page. Install `cloudflared` first, then choose a quick tunnel or a stable named tunnel. A quick tunnel is suitable for a temporary connection. Its hostname changes on every start and cannot provide a stable passkey or PWA identity. Use a named tunnel for a Home Screen PWA, passkeys, or reliable Web Push subscriptions.
+
+Enabling remote access creates a second loopback listener on an ephemeral port for the tunnel. The local listener remains on its normal port. The hub self-tests the public URL before reporting success. Pair a device by opening `/pair`, scanning the host-generated QR, and approving the request on the host. See [remote security](security.md) for the threat model and limits.
+
+## Run from the workspace
+
+From the repository root, build the cockpit composition and run the package with that repository selected:
+
+```bash
+pnpm cockpit:build
+pnpm doompi-web --dir="$PWD"
+```
+
+For plugin client development, run the hub and Vite dev server in separate terminals from the package directory:
+
+```bash
+# repository root
+pnpm cockpit
+
+# packages/clients/doompi-web
+pnpm dev
+```
+
+The dev server uses port `7434` and proxies `/api` to the hub on `7433`. Set `DOOMPI_WEB_PLUGIN_ROOTS` to a path-delimited list of plugin package roots when testing a plugin that is not in the last synchronized composition. Client changes hot reload. Hub channel changes require rebuilding the plugin and restarting the hub.
+
+## Verify a change
+
+Run these commands from `packages/clients/doompi-web`:
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm test
+pnpm test:e2e
+pnpm lint
+```
+
+Build before `pnpm test:e2e`; the end-to-end suite drives the built executable in a real browser.

--- a/packages/clients/doompi-web/docs/package-apis.md
+++ b/packages/clients/doompi-web/docs/package-apis.md
@@ -1,0 +1,91 @@
+# Package APIs
+
+A DoomPi package can expose HTTP handlers through `doompiApi` in `package.json`. The generated route modules are part of the synchronized composition. The package entry exports one named `api` value implementing the `DoomApi` contract.
+
+## Manifest
+
+```json
+{
+  "doompiApi": {
+    "basePath": "example",
+    "session": {
+      "entry": "./src/exports/sessionApi.ts",
+      "dist": "./dist/sessionApi.mjs"
+    },
+    "hub": {
+      "entry": "./src/exports/hubApi.ts",
+      "dist": "./dist/hubApi.mjs"
+    }
+  }
+}
+```
+
+The field may contain one object or an array of objects. `basePath` is kebab-case and globally unique among loaded APIs. Each declared entry has a package-relative source `entry` and a built `dist` path. The host imports the built entry, not source code.
+
+A package can declare only `session`, only `hub`, or both. Missing metadata means that the package has no package API. Malformed metadata or an unavailable entry is reported and skipped when it can be isolated.
+
+## API implementation
+
+The entry exports `api` with a mount name and a `start` factory:
+
+```ts
+import type { DoomApi, DoomApiContext, DoomApiHandler } from '@agimon-ai/doompi-extension-contracts/package-api';
+
+export const api: DoomApi = {
+  basePath: 'example',
+  start(context: DoomApiContext): DoomApiHandler {
+    return {
+      async fetch(request) {
+        return new Response(JSON.stringify({ scope: context.scope }), {
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+      close() {},
+    };
+  },
+};
+```
+
+Routes are relative to the API mount. For a Hono application, return `fetch: (request) => app.fetch(request)`. `close()` must release any timers, watchers, streams, or other resources created by `start`.
+
+`DoomApiContext` includes the API scope, and session APIs receive the session ID, working directory, and session-only internal credentials as applicable. Hub APIs can receive an opaque repository resolver and synchronized repository view. Use the resolver with a hub-issued `repositoryId`; do not accept a browser filesystem path as authority.
+
+## Request routing
+
+The public prefix is `/api/plugin/<basePath>`. The hub strips that prefix before invoking the handler.
+
+### Session APIs
+
+A session API is mounted in the session server and reached through the hub's Unix-socket proxy:
+
+```text
+GET /api/plugin/runner/runners/run-1/log?session=<session-id>
+```
+
+The hub removes `session` before forwarding the request, so the handler receives a relative path and no session selector. The session server owns session data and its package API socket. The browser does not receive the session attach token.
+
+The hub stamps the proxy request with the caller locality, paired device ID when remote, and step-up result. A session API that needs this identity can use `doomApiCallerFrom(request.headers)` from `@agimon-ai/doompi-extension-contracts/package-api`. Incoming copies of those headers are discarded before the hub writes the trusted values.
+
+### Hub APIs
+
+A hub API runs in the cockpit hub. Add `hubSession=<session-id>` when the request must use the hub API bundle selected for a session:
+
+```text
+GET /api/plugin/mcp/repository?repositoryId=<repository-id>&hubSession=<session-id>
+```
+
+`hubSession` selects the session-associated bundle. It does not turn the API into a session-scoped handler or supply `sessionId` in its `DoomApiContext`. The hub removes the selector before calling the handler.
+
+Without `hubSession`, the hub uses its deterministic default API bundle. `DOOMPI_API_DIR` takes precedence when set. Otherwise the default is the generated global API directory, normally `~/.doompi/api/current`.
+
+A request cannot include both `session` and `hubSession`; the hub returns `400`. An unknown session bundle or missing API returns `404`. An API exception is isolated to that API and returns `500` rather than stopping the cockpit.
+
+## Composition and synchronization
+
+`doompi sync` discovers `doompiApi` declarations from the resolved package roots and writes `hub.routes.mjs` and `session.routes.mjs` in the generated API directory. An empty API composition still produces both modules. The hub loads hub entries for the selected composition and session servers load session entries when they start.
+
+Session composition follows the repository-first, global-fallback rule in [bundle resolution](bundle.md). A session's `hubSession` request cannot borrow an API from a different registration. Restart a session after synchronization when its server-side API entry changed.
+
+## Security requirements for handlers
+
+A package API is executable server code. Validate request bodies, bound reads and streams, and keep file paths inside the intended scope. Use opaque repository IDs and host-provided context instead of trusting paths or authorization headers from the browser. Remote requests pass through the host guard and, except for direct pairing and socket routes, the sealed HTTP gateway. See [remote security](security.md).

--- a/packages/clients/doompi-web/docs/package-apis.md
+++ b/packages/clients/doompi-web/docs/package-apis.md
@@ -1,8 +1,65 @@
 # Package APIs
 
-A DoomPi package can expose HTTP handlers through `doompiApi` in `package.json`. The generated route modules are part of the synchronized composition. The package entry exports one named `api` value implementing the `DoomApi` contract.
+A package API is server code contributed by a package in the active DoomPi composition. It gives a web plugin an HTTP-shaped boundary without putting filesystem access, process control, credentials, or long-running server resources in browser code.
 
-## Manifest
+The first design choice is placement. Run the handler in the process that owns the data.
+
+## Two execution scopes
+
+```text
+Browser plugin
+      |
+      | /api/plugin/<basePath>
+      v
+DoomPi Web hub
+      |
+      +-- hub API --------------------> hub-owned machine or repository state
+      |
+      +-- session proxy over api.sock -> session API beside one agent
+```
+
+| Scope     | Runs in                 | Use it for                                                                        |
+| --------- | ----------------------- | --------------------------------------------------------------------------------- |
+| `hub`     | DoomPi Web process      | Repository discovery, machine settings, provider state, or work spanning sessions |
+| `session` | `doompi-server` process | State and operations owned by one agent session or its working directory          |
+
+A session API remains beside the agent even though the browser reaches it through the hub. The hub authenticates the browser, selects the session, and proxies the request over a Unix socket. Moving the handler into the hub would blur lifecycle and filesystem ownership.
+
+Hub APIs have the opposite problem: a session ID alone is not authority to read an arbitrary repository. They use host-issued repository identities and resolvers instead of accepting browser filesystem paths.
+
+## Routing model
+
+All package APIs share one public prefix:
+
+```text
+/api/plugin/<basePath>/<package route>
+```
+
+The query selector chooses the execution scope and composition:
+
+| Selector          | Destination                      | Composition used                                     |
+| ----------------- | -------------------------------- | ---------------------------------------------------- |
+| `session=<id>`    | That session server's API socket | Session APIs loaded when the server started          |
+| `hubSession=<id>` | Hub process                      | Hub APIs from that session's selected web generation |
+| none              | Hub process                      | Deterministic default hub API generation             |
+
+The hub removes `session` or `hubSession` before calling the package handler. A request cannot contain both. That returns `400`. An unknown session, unavailable API, or missing selected generation returns `404`. A handler exception returns a generic `500` without stopping other APIs or the cockpit.
+
+`hubSession` selects a composition. It does not make a hub handler session-scoped and does not add a `sessionId` to its context.
+
+## Why APIs follow the composition
+
+`doompi sync` discovers `doompiApi` declarations from the same package roots used for the TUI and web plugins. It generates `hub.routes.mjs` and `session.routes.mjs` inside the immutable synchronized generation.
+
+This keeps UI and server capabilities aligned. A plugin from repository A cannot silently borrow an API that exists only in repository B or in the global fallback. A session-associated hub request selects the complete generation already assigned to that session.
+
+An empty API composition is valid and still produces both route modules. Missing metadata means a package contributes no API. Invalid optional declarations can be reported and skipped without removing unrelated packages.
+
+See [Web bundling and serving](bundle.md) for generation selection and publication.
+
+## Declare an API
+
+Add `doompiApi` to the package manifest:
 
 ```json
 {
@@ -20,13 +77,13 @@ A DoomPi package can expose HTTP handlers through `doompiApi` in `package.json`.
 }
 ```
 
-The field may contain one object or an array of objects. `basePath` is kebab-case and globally unique among loaded APIs. Each declared entry has a package-relative source `entry` and a built `dist` path. The host imports the built entry, not source code.
+The field accepts one declaration or an array. `basePath` is kebab-case and must be unique among loaded APIs. A package may declare only `hub`, only `session`, or both.
 
-A package can declare only `session`, only `hub`, or both. Missing metadata means that the package has no package API. Malformed metadata or an unavailable entry is reported and skipped when it can be isolated.
+Each scope names a package-relative source `entry` and built `dist` file. Paths cannot traverse outside the package. Sync uses the source entry to understand the build and the host imports the built module at runtime.
 
-## API implementation
+## Implement the handler
 
-The entry exports `api` with a mount name and a `start` factory:
+The built entry exports one `api` value:
 
 ```ts
 import type { DoomApi, DoomApiContext, DoomApiHandler } from '@agimon-ai/doompi-extension-contracts/package-api';
@@ -36,9 +93,7 @@ export const api: DoomApi = {
   start(context: DoomApiContext): DoomApiHandler {
     return {
       async fetch(request) {
-        return new Response(JSON.stringify({ scope: context.scope }), {
-          headers: { 'content-type': 'application/json' },
-        });
+        return Response.json({ scope: context.scope });
       },
       close() {},
     };
@@ -46,46 +101,61 @@ export const api: DoomApi = {
 };
 ```
 
-Routes are relative to the API mount. For a Hono application, return `fetch: (request) => app.fetch(request)`. `close()` must release any timers, watchers, streams, or other resources created by `start`.
+`start(context)` runs once when the host mounts that API. It returns a Fetch-compatible handler and `close()`. A Hono application can return `fetch: (request) => app.fetch(request)`. `close()` releases everything created by `start`, including timers, file watchers, streams, and child resources.
 
-`DoomApiContext` includes the API scope, and session APIs receive the session ID, working directory, and session-only internal credentials as applicable. Hub APIs can receive an opaque repository resolver and synchronized repository view. Use the resolver with a hub-issued `repositoryId`; do not accept a browser filesystem path as authority.
+The host strips `/api/plugin/<basePath>` before calling `fetch`. A request to:
 
-## Request routing
+```text
+/api/plugin/runner/runners/run-1/log
+```
 
-The public prefix is `/api/plugin/<basePath>`. The hub strips that prefix before invoking the handler.
+arrives at the `runner` handler as `/runners/run-1/log` with the original method, body, and ordinary headers.
 
-### Session APIs
+## Host context
 
-A session API is mounted in the session server and reached through the hub's Unix-socket proxy:
+`DoomApiContext` identifies the execution scope and provides only host-owned capabilities relevant to that placement.
+
+A session context may include the session ID, working directory, internal session credential, hub credential, and notice callback. These credentials are process capabilities for trusted package code. They are not automatically applied as route authorization and are never sent to the browser.
+
+A hub context may include an opaque repository resolver and synchronized repository view. Use the resolver with a `repositoryId` issued by the hub. Do not reinterpret a path or repository ID from the request as authority.
+
+## Caller identity and step-up
+
+Before forwarding a browser request, the hub discards incoming copies of its trusted caller headers. It then stamps locality, paired-device identity when remote, and the result of any required passkey step-up.
+
+A handler can read that context with `doomApiCallerFrom(request.headers)` from `@agimon-ai/doompi-extension-contracts/package-api`.
+
+This metadata answers who reached the handler and through which boundary. It does not replace operation-specific authorization. A package that writes credentials, starts processes, or opens new paths must still validate the request and enforce its own scope.
+
+## Session request example
 
 ```text
 GET /api/plugin/runner/runners/run-1/log?session=<session-id>
 ```
 
-The hub removes `session` before forwarding the request, so the handler receives a relative path and no session selector. The session server owns session data and its package API socket. The browser does not receive the session attach token.
+The hub classifies the caller as local or remote and authenticates a remote device. A local caller has passed the listener's Host and Origin policy but has no device identity. The hub removes `session`, stamps this trusted caller context, and forwards the request to that server's `api.sock`. The session server selects the `runner` handler and passes `/runners/run-1/log` to it. The browser never receives the session attach token.
 
-The hub stamps the proxy request with the caller locality, paired device ID when remote, and step-up result. A session API that needs this identity can use `doomApiCallerFrom(request.headers)` from `@agimon-ai/doompi-extension-contracts/package-api`. Incoming copies of those headers are discarded before the hub writes the trusted values.
+A session server loads its API registry at startup. Build and run `doompi sync`, then restart the session when a session API changes.
 
-### Hub APIs
-
-A hub API runs in the cockpit hub. Add `hubSession=<session-id>` when the request must use the hub API bundle selected for a session:
+## Hub request example
 
 ```text
 GET /api/plugin/mcp/repository?repositoryId=<repository-id>&hubSession=<session-id>
 ```
 
-`hubSession` selects the session-associated bundle. It does not turn the API into a session-scoped handler or supply `sessionId` in its `DoomApiContext`. The hub removes the selector before calling the handler.
+The hub uses `hubSession` only to select the matching hub API generation. It removes the selector, then invokes the MCP handler in the hub process. Without `hubSession`, `DOOMPI_API_DIR` takes precedence, followed by the generated global API directory.
 
-Without `hubSession`, the hub uses its deterministic default API bundle. `DOOMPI_API_DIR` takes precedence when set. Otherwise the default is the generated global API directory, normally `~/.doompi/api/current`.
+A hub module is built server code. Build and sync it before restarting or reloading the hub composition.
 
-A request cannot include both `session` and `hubSession`; the hub returns `400`. An unknown session bundle or missing API returns `404`. An API exception is isolated to that API and returns `500` rather than stopping the cockpit.
+## Failure and trust boundaries
 
-## Composition and synchronization
+Package APIs are trusted executable code, not remote sandboxes. Keep the failure boundary narrow:
 
-`doompi sync` discovers `doompiApi` declarations from the resolved package roots and writes `hub.routes.mjs` and `session.routes.mjs` in the generated API directory. An empty API composition still produces both modules. The hub loads hub entries for the selected composition and session servers load session entries when they start.
+- validate bodies, methods, identifiers, and content types before side effects
+- bound file reads, response bodies, logs, and streams
+- resolve paths against host-provided roots, never raw browser authority
+- do not accept caller identity or authorization headers supplied by the browser
+- make `close()` safe after partial startup
+- report a package-scoped notice instead of taking down unrelated APIs
 
-Session composition follows the repository-first, global-fallback rule in [bundle resolution](bundle.md). A session's `hubSession` request cannot borrow an API from a different registration. Restart a session after synchronization when its server-side API entry changed.
-
-## Security requirements for handlers
-
-A package API is executable server code. Validate request bodies, bound reads and streams, and keep file paths inside the intended scope. Use opaque repository IDs and host-provided context instead of trusting paths or authorization headers from the browser. Remote requests pass through the host guard and, except for direct pairing and socket routes, the sealed HTTP gateway. See [remote security](security.md).
+Remote requests still pass through the web guard and sealed transport, but those layers do not make a handler correct. A direct browser `fetch` from a plugin may expose its payload to the tunnel relay unless it uses the sealed transport helper. See [Remote security](security.md).

--- a/packages/clients/doompi-web/docs/plugins.md
+++ b/packages/clients/doompi-web/docs/plugins.md
@@ -1,0 +1,110 @@
+# Web plugins
+
+DoomPi Web plugins are package contributions to the browser cockpit. A package can provide a client entry, an optional hub entry, or both. The package does not need to depend on another plugin.
+
+The typed contract is [@agimon-ai/doompi-web-contracts](https://www.npmjs.com/package/@agimon-ai/doompi-web-contracts). The host uses the same package set for the client composition and for the server-side channel registry.
+
+## Declare a plugin
+
+Add a `doompiWeb` block to `package.json`:
+
+```json
+{
+  "doompiWeb": {
+    "pluginId": "example",
+    "channels": ["example_status"],
+    "client": "./src/exports/webClient.ts",
+    "hub": {
+      "entry": "./src/exports/webHub.ts",
+      "dist": "./dist/webHub.mjs"
+    }
+  }
+}
+```
+
+`pluginId` is kebab-case and identifies the client contribution. `channels` lists globally unique wire frame types. The client entry is a package-relative source entry and must export `webPlugin`. A non-host hub entry must include a package-relative built `dist` entry and must export `webHubChannels`.
+
+The optional `registrationOrder` is a non-negative integer. It orders independent plugins before `pluginId` breaks ties. It does not create a dependency between packages.
+
+Examples in the repository include:
+
+- `doompi-plan`, which contributes a minor mode, activity section, settings fields, and plan tool renderers.
+- `doompi-runner`, which contributes a session channel, runner activity UI, and `bash` tool rendering.
+- `doompi-mcp`, which contributes repository settings, session context UI, and matcher-based MCP tool rendering.
+
+## Client entry
+
+A client entry normally re-exports a definition:
+
+```ts
+import { defineWebPlugin } from '@agimon-ai/doompi-web-contracts';
+
+export const webPlugin = defineWebPlugin({
+  id: 'example',
+  tabs: [],
+  channels: [],
+  toolRenderers: [],
+});
+```
+
+A definition can contribute:
+
+- tabs, dock faces, overlays, rail sections, selection bar items, and composer actions
+- session channels backed by a parser and per-session state
+- activity groups and sections, minor modes, and selection axes
+- settings sections rendered by the host, or package-owned settings panels
+- repository settings panels
+- slots and fills for named cross-plugin composition
+- palette commands, context actions, and Leader Space bindings
+- file links for paths shown in messages
+- tool renderers and optional tool prompt components
+- a page-lifetime `start(runtime)` function
+
+Use `defineGlobalStore` for page-wide state and `defineSessionStore` for records keyed by session ID. A session channel must validate wire data before applying it. Components receive host actions such as `openTab`, `openTransientTab`, `renderThread`, `renderSlot`, `sendSessionFrame`, and composer context helpers.
+
+The host resolves slots by name after all installed plugins load. Plugin-owned slots are namespaced as `<pluginId>.<name>`. A fill into an undeclared slot is an install diagnostic, not a page failure.
+
+## Hub entry and channels
+
+A hub entry exports an array of `WebHubChannel` values:
+
+```ts
+import type { WebHubChannel } from '@agimon-ai/doompi-web-contracts';
+
+export const webHubChannels: readonly WebHubChannel[] = [
+  {
+    frameType: 'example_status',
+    start(host) {
+      return {
+        payloadFor: (scope) => ({ cwd: scope.cwd }),
+        close: () => undefined,
+      };
+    },
+  },
+];
+```
+
+A channel starts with a host that can list sessions, publish a payload to a session, send targeted frames, request a session package API, and report a notice. `payloadFor` supplies a subscription snapshot. A channel can react to sessions being added or removed and can receive frames from authenticated browser sockets. `close()` must release timers, watchers, and other resources.
+
+The channel's `frameType` must match a name in the plugin's `channels` declaration. The browser-side session channel parses the payload and updates its session store. Unknown frame types are dropped.
+
+## Build and load behavior
+
+`doompi sync` scans the installed package composition, validates each manifest, generates import modules, and builds:
+
+- the host SPA and plugin client source
+- the plugin composition entry and Vite manifest
+- the server registry for built hub entries
+- package API route modules
+
+The hub loads built non-host hub entries lazily for the selected session composition. The browser composition is compiled with shared React, TanStack Store, CodeMirror, web components, and web security runtimes deduplicated. This includes one sealed-transport singleton and one set of nonce counters.
+
+Client code may import the contract, React, TanStack Store, `@agimon-ai/doompi-web-components`, the browser security helper, and its own `web/` and `src/types` modules. Do not import Node built-ins, a server framework, or another plugin from client code. Tailwind classes must be complete literal strings so the host scanner can see them.
+
+For local client work, use `DOOMPI_WEB_PLUGIN_ROOTS` with `pnpm dev` as described in [Getting started](getting-started.md). A client edit hot reloads through Vite. A hub entry edit requires a package build and hub restart.
+
+## Missing packages and collisions
+
+Plugin metadata is optional. A package without `doompiWeb` contributes no browser plugin or hub channel. A malformed block or unavailable entry produces a notice and is skipped when it can be isolated. The base cockpit remains available.
+
+Duplicate plugin IDs, channel names, tab IDs, tool names, activity groups, or Leader leaves are install diagnostics. Resolution is deterministic and the page continues with the winning contribution. `webPluginDiagnostics()` exposes client diagnostics, and sync notices identify packages skipped on the server side.

--- a/packages/clients/doompi-web/docs/plugins.md
+++ b/packages/clients/doompi-web/docs/plugins.md
@@ -1,12 +1,49 @@
 # Web plugins
 
-DoomPi Web plugins are package contributions to the browser cockpit. A package can provide a client entry, an optional hub entry, or both. The package does not need to depend on another plugin.
+A DoomPi web plugin adds browser behavior for a package already selected by the DoomPi composition. It does not install itself, discover other plugins, or create a second application shell.
 
-The typed contract is [@agimon-ai/doompi-web-contracts](https://www.npmjs.com/package/@agimon-ai/doompi-web-contracts). The host uses the same package set for the client composition and for the server-side channel registry.
+The host owns navigation, session transport, shared UI primitives, and plugin activation. A plugin contributes definitions to those surfaces. This keeps the cockpit usable when an optional package is missing and lets two sessions use different plugin sets in the same browser.
 
-## Declare a plugin
+## The plugin model
 
-Add a `doompiWeb` block to `package.json`:
+```text
+package.json doompiWeb manifest
+              |
+      +-------+-------+
+      |               |
+      v               v
+ client entry      optional hub entry
+ exports           exports
+ webPlugin         webHubChannels
+      |               |
+      v               v
+ Vite composition  DoomPi Web hub
+      |               |
+      +-- session-scoped UI and data --+
+```
+
+The client entry describes presentation and page state. The optional hub entry owns host-side watchers, aggregation, or communication that should not run in the browser. A package may provide either side or both.
+
+Plugins are independent. They refer to host surfaces and named slots rather than importing one another. `registrationOrder` is only a deterministic ordering hint, not a dependency graph.
+
+The typed contract lives in [@agimon-ai/doompi-web-contracts](https://www.npmjs.com/package/@agimon-ai/doompi-web-contracts).
+
+## Choose the smallest contribution
+
+Use a client-only plugin when Pi RPC or an existing host action already supplies the data. Add a hub channel when the browser needs live host-side state that is not part of Pi RPC. Add a [package API](package-apis.md) when the operation is naturally request-response or belongs beside session-owned resources.
+
+| Need                                               | Contract                             |
+| -------------------------------------------------- | ------------------------------------ |
+| Render a tab, tool call, setting, badge, or action | `webPlugin` contribution             |
+| Maintain a live session-scoped stream or snapshot  | client channel plus `webHubChannels` |
+| Read or mutate data through HTTP semantics         | `doompiApi` package API              |
+| Change the base cockpit lifecycle or transport     | host code, not a plugin              |
+
+This separation prevents panels from opening private sockets or inventing their own authorization path.
+
+## Declare the package boundary
+
+Add `doompiWeb` to the package manifest:
 
 ```json
 {
@@ -22,19 +59,13 @@ Add a `doompiWeb` block to `package.json`:
 }
 ```
 
-`pluginId` is kebab-case and identifies the client contribution. `channels` lists globally unique wire frame types. The client entry is a package-relative source entry and must export `webPlugin`. A non-host hub entry must include a package-relative built `dist` entry and must export `webHubChannels`.
+`pluginId` is kebab-case and identifies the client contribution. `channels` declares globally unique frame types shared by the browser and hub halves. `client` is a package-relative source entry. A non-host hub entry has both a source `entry` and a built `dist` module because the hub imports built Node.js code.
 
-The optional `registrationOrder` is a non-negative integer. It orders independent plugins before `pluginId` breaks ties. It does not create a dependency between packages.
+The optional `registrationOrder` is a non-negative integer. Lower values install first, then `pluginId` breaks ties.
 
-Examples in the repository include:
+## Client composition
 
-- `doompi-plan`, which contributes a minor mode, activity section, settings fields, and plan tool renderers.
-- `doompi-runner`, which contributes a session channel, runner activity UI, and `bash` tool rendering.
-- `doompi-mcp`, which contributes repository settings, session context UI, and matcher-based MCP tool rendering.
-
-## Client entry
-
-A client entry normally re-exports a definition:
+A client entry exports one `webPlugin` definition:
 
 ```ts
 import { defineWebPlugin } from '@agimon-ai/doompi-web-contracts';
@@ -47,26 +78,41 @@ export const webPlugin = defineWebPlugin({
 });
 ```
 
-A definition can contribute:
+The definition is declarative so the host can resolve all contributions before rendering. It can add:
 
-- tabs, dock faces, overlays, rail sections, selection bar items, and composer actions
-- session channels backed by a parser and per-session state
+- tabs, dock faces, overlays, rail sections, selection bars, and composer actions
 - activity groups and sections, minor modes, and selection axes
-- settings sections rendered by the host, or package-owned settings panels
+- host-rendered setting fields or package-owned settings panels
 - repository settings panels
-- slots and fills for named cross-plugin composition
-- palette commands, context actions, and Leader Space bindings
-- file links for paths shown in messages
-- tool renderers and optional tool prompt components
-- a page-lifetime `start(runtime)` function
+- palette commands, context actions, file links, and Leader Space bindings
+- tool renderers and optional tool-prompt components
+- named slots and fills
+- session channels with parsers and state stores
+- a page-lifetime `start(runtime)` hook
 
-Use `defineGlobalStore` for page-wide state and `defineSessionStore` for records keyed by session ID. A session channel must validate wire data before applying it. Components receive host actions such as `openTab`, `openTransientTab`, `renderThread`, `renderSlot`, `sendSessionFrame`, and composer context helpers.
+The host supplies actions such as `openTab`, `openTransientTab`, `renderThread`, `renderSlot`, and `sendSessionFrame`. Reuse those actions rather than reaching around the host transport.
 
-The host resolves slots by name after all installed plugins load. Plugin-owned slots are namespaced as `<pluginId>.<name>`. A fill into an undeclared slot is an install diagnostic, not a page failure.
+### State ownership
 
-## Hub entry and channels
+Use `defineGlobalStore` for state that belongs to the browser page and `defineSessionStore` for records keyed by session ID. A plugin may be installed for several sessions with different compositions, so module globals are rarely the right place for session state.
 
-A hub entry exports an array of `WebHubChannel` values:
+A session channel validates every payload before applying it. Unknown frame types are dropped. Validation belongs at this boundary because the browser may be reattaching to a different package version or receiving stale buffered data.
+
+### Slots instead of plugin dependencies
+
+A plugin opens a slot named `<pluginId>.<name>`. The host also exposes common slots such as overlays, rail regions, composer actions, and activity groups. Any installed plugin may contribute a fill by name without importing the slot owner.
+
+Resolution happens after all definitions load. A fill whose slot is absent becomes an install diagnostic, not a page failure. This lets optional packages compose without making their install order a runtime dependency.
+
+### Tool renderers
+
+The package that registers a Pi tool should also claim its browser rendering. A renderer may name a fixed tool or use a matcher when the tool name is dynamic. It owns the complete message item and composes the shared `MessageItem` primitive so actions and visual behavior remain consistent.
+
+If a renderer throws or no plugin claims the tool, the host uses its generic renderer. One broken tool view does not stop the timeline.
+
+## Hub channels
+
+A hub entry exports `webHubChannels`:
 
 ```ts
 import type { WebHubChannel } from '@agimon-ai/doompi-web-contracts';
@@ -84,27 +130,36 @@ export const webHubChannels: readonly WebHubChannel[] = [
 ];
 ```
 
-A channel starts with a host that can list sessions, publish a payload to a session, send targeted frames, request a session package API, and report a notice. `payloadFor` supplies a subscription snapshot. A channel can react to sessions being added or removed and can receive frames from authenticated browser sockets. `close()` must release timers, watchers, and other resources.
+`start(host)` creates the channel's process-side resources. The host can list sessions, publish session payloads, send targeted frames, call a session package API, and report notices. `payloadFor(scope)` supplies the current snapshot when a browser subscribes. Optional session-added, session-removed, and inbound-frame handlers maintain live state.
 
-The channel's `frameType` must match a name in the plugin's `channels` declaration. The browser-side session channel parses the payload and updates its session store. Unknown frame types are dropped.
+`close()` must release watchers, timers, streams, and other resources. The hub may reload a session's selected composition without exiting the process.
 
-## Build and load behavior
+The channel `frameType` must appear in the manifest's `channels` list and in the client channel definition. This explicit three-part agreement keeps undeclared wire protocols out of the cockpit.
 
-`doompi sync` scans the installed package composition, validates each manifest, generates import modules, and builds:
+## Build and activation
 
-- the host SPA and plugin client source
-- the plugin composition entry and Vite manifest
-- the server registry for built hub entries
-- package API route modules
+`doompi sync` scans the selected packages, validates manifests, generates imports, and compiles all client definitions for one composition. The server registry records built hub modules separately. See [Web bundling and serving](bundle.md) for the complete pipeline.
 
-The hub loads built non-host hub entries lazily for the selected session composition. The browser composition is compiled with shared React, TanStack Store, CodeMirror, web components, and web security runtimes deduplicated. This includes one sealed-transport singleton and one set of nonce counters.
+The client composition shares the shell's React, TanStack Store, CodeMirror, web components, contracts, and browser security runtime. Plugin client code may import those allowed runtimes plus its own `web/` and `src/types` modules. It must not import Node built-ins, a server framework, or another plugin.
 
-Client code may import the contract, React, TanStack Store, `@agimon-ai/doompi-web-components`, the browser security helper, and its own `web/` and `src/types` modules. Do not import Node built-ins, a server framework, or another plugin from client code. Tailwind classes must be complete literal strings so the host scanner can see them.
+The hub loads server entries lazily for the selected session. The browser verifies and activates the matching client composition when that session is focused. Switching focus disposes the active plugin UI and activates the target session's composition.
 
-For local client work, use `DOOMPI_WEB_PLUGIN_ROOTS` with `pnpm dev` as described in [Getting started](getting-started.md). A client edit hot reloads through Vite. A hub entry edit requires a package build and hub restart.
+## Failure policy
 
-## Missing packages and collisions
+Optional plugin failure should remove one contribution, not the cockpit:
 
-Plugin metadata is optional. A package without `doompiWeb` contributes no browser plugin or hub channel. A malformed block or unavailable entry produces a notice and is skipped when it can be isolated. The base cockpit remains available.
+- no `doompiWeb` means no browser plugin or hub channel
+- malformed metadata or a missing optional entry produces a sync notice and is skipped when isolatable
+- duplicate plugin IDs, channel names, tabs, tools, activity groups, or Leader leaves resolve deterministically and produce diagnostics
+- a broken hub module omits its channels and leaves its panels empty
+- a broken renderer falls back to the generic timeline item
 
-Duplicate plugin IDs, channel names, tab IDs, tool names, activity groups, or Leader leaves are install diagnostics. Resolution is deterministic and the page continues with the winning contribution. `webPluginDiagnostics()` exposes client diagnostics, and sync notices identify packages skipped on the server side.
+`webPluginDiagnostics()` exposes client-side installation diagnostics. Repository contract tests hold the shipped composition to zero notices and diagnostics.
+
+## Development loop
+
+Run the hub and Vite client in separate terminals. Set `DOOMPI_WEB_PLUGIN_ROOTS` to a path-delimited list of plugin package roots when the package is not in the last synchronized composition.
+
+Client edits hot reload because Vite compiles source. Hub entries are built Node.js modules, so a hub-side change requires a package build and hub restart. Tailwind class names in plugin source must be complete string literals so the build scanner can find them.
+
+See [Getting started](getting-started.md) for commands and [Package APIs](package-apis.md) when a contribution needs HTTP semantics.

--- a/packages/clients/doompi-web/docs/security.md
+++ b/packages/clients/doompi-web/docs/security.md
@@ -1,0 +1,105 @@
+# Remote security
+
+DoomPi Web can expose a browser cockpit to a phone through a tunnel. Treat this as access to a local agent that may run `bash`, not as a read-only dashboard. A paired device can drive the agent with the permissions of the account running DoomPi Web.
+
+The controls below reduce accidental exposure and cross-site attacks. They do not turn an untrusted host, user account, tunnel provider, or workspace into a trusted one.
+
+## Local listener
+
+The default listener is `127.0.0.1:7433`. The host and origin guard runs before HTTP routes and WebSocket upgrades. It checks the actual listener, the `Host` header, and an `Origin` when one is present. This helps prevent DNS rebinding and hostile web pages from driving a local cockpit.
+
+A missing `Origin` is accepted for local requests so command-line clients and health probes work. A local program can send its own headers, so these checks are not an authorization boundary against another process running as the same user. Do not use `--host 0.0.0.0` or another public bind as a substitute for remote access. A non-loopback bind is warned about and does not require pairing.
+
+`DOOMPI_WEB_ALLOW_ORIGIN` adds explicit origins to the local development allowlist. It does not authorize a public listener or bypass remote device authentication.
+
+## Tunnel listener
+
+Enabling remote access binds a second loopback listener on an ephemeral port and points `cloudflared` at it. The normal local listener stays separate. The listener split lets the hub identify tunnel traffic even though `cloudflared` connects from loopback.
+
+The tunnel policy accepts the tunnel's reported origin and host. Before the tunnel is considered ready, the hub probes the public pairing page and expects `/api/health` to return `401`. This confirms those routes, not every route or every property of the tunnel provider.
+
+The tunnel listener's unauthenticated allowlist is limited to package-owned pairing, PWA bootstrap, passkey ceremony, and sealed-channel establishment routes. Some handlers on that allowlist still perform their own checks, such as requiring an existing paired device for passkey registration. Direct remote session and protocol WebSocket upgrades require both a device authorization and a purpose-specific sealed channel. Other remote HTTP requests must use the sealed HTTP gateway. A remote request cannot select arbitrary internal routes by bypassing that gateway.
+
+Quick tunnels are temporary. Their hostname rotates on every start, so they cannot provide a stable passkey relying-party ID, durable PWA identity, or reliable Push identity. Use a named tunnel for those features and protect the tunnel account with hardware MFA or a passkey.
+
+## Pairing and device sessions
+
+The host shows a QR URL such as:
+
+```text
+https://tunnel.example/pair#c=<code>&k=<channel-key>&s=<signing-key>&r=<revision>
+```
+
+The code, ephemeral channel public key, signing public key, and minimum bundle revision are in the URL fragment. Browsers do not send the fragment to the tunnel provider. Manual pairing requires comparing the signing-key fingerprint on both devices.
+
+A code is claimable for 120 seconds. A successful claim creates a pending request that the person at the host must approve or deny within 180 seconds. Approval is required because a QR can be visible in a screen share or over a shoulder. A request is consumed once, and invalid claims are rate limited.
+
+After approval, the browser receives a device bearer cookie named `__Host-doompi_device`. It is `HttpOnly`, `Secure`, `SameSite=Strict`, and `Path=/`, with no `Domain` attribute. Its browser `Max-Age` is capped at 30 days, and optional idle or absolute session expiry can shorten that lifetime. This is not a `doompi-server` attach token. The hub stores a hash of the device token, updates its last-seen time after authenticated requests, and can revoke it. Revocation removes that device's sealed channels and closes its tracked sockets.
+
+Hashing protects persisted state if the state file is copied, but it does not protect against a hostile host owner or process controlling the hub, state directory, browser, or tunnel. Such an owner can observe or alter the running service and should be treated as having access.
+
+Device sessions and pairing requests are process-local. Restarting the hub, disabling remote access, or revoking a device removes active remote access. Optional session expiry is disabled by default. When enabled, the configured idle and absolute limits are evaluated at each request and can invalidate sessions that are already idle.
+
+## Passkeys and step-up actions
+
+Passkeys are available only when the tunnel has a stable named hostname. The relying-party ID is derived from that hostname. Quick tunnel hostnames, IP addresses, and non-public hostnames are refused for passkey enrollment.
+
+Registration and authentication ceremonies expire after 120 seconds. A step-up challenge expires after 60 seconds. When passkey support is available, a fresh gesture is required for these action classes:
+
+- `provider.login`
+- `provider.logout`
+- `session.create`
+- `settings.write`
+- `mcp.discover`
+- `mcp.authorize`
+- `computer-use.activate`
+
+Quick tunnels skip passkey step-up because their rotating hostname cannot provide a stable relying-party ID. These remote actions therefore have the device session as their remaining remote authorization check. Ordinary prompts and tool approvals remain in the normal session flow rather than asking for a biometric gesture on every turn.
+
+## Sealed transport
+
+After pairing or passkey sign-in, the browser and hub establish separate channels for session traffic, protocol traffic, and HTTP requests. The handshake uses ephemeral P-256 ECDH. Keys are derived with HKDF-SHA-256, and messages use AES-256-GCM with separate directional keys and monotonic counters. Altered, unauthenticated, or replayed envelopes are rejected.
+
+The session and protocol WebSockets carry sealed envelopes for remote devices. The sealed HTTP gateway carries the request method, root-relative target, headers, body, status, and response body inside the encrypted exchange. Pairing, passkey, channel bootstrap, `/pair`, `/sw.js`, and other PWA bootstrap assets are intentionally unsealed so a device can establish trust.
+
+A client plugin that calls browser `fetch` directly sends plaintext to the tunnel relay. Plugin code that needs HTTP must use `sealedTransport.fetch` from `@agimon-ai/doompi-web-security/browser`. The host cannot enforce that choice for arbitrary plugin code.
+
+Sealing hides post-handshake payload content from a tunnel provider. It does not hide the page and bootstrap assets, the fact that a device is connected, timing, message sizes, request patterns, or tunnel metadata. Do not use this mode when the tunnel provider is outside the trust boundary.
+
+## Signed bundles and bootstrap trust
+
+The host keeps a signing key in its state directory. A QR pins the public signing key and a minimum bundle revision. The host manifest contains a revision and a SHA-256 digest, byte length, and content type for each asset. The service worker verifies the signed manifest, downloads each raw asset, checks its digest, and commits the complete result to a cache. A failed update keeps the last verified host or plugin composition. Plugin compositions are signed with the host publication key and verified in the same way.
+
+This is a delivery-integrity guarantee after the browser has a trusted signer key and a trusted verifier bootstrap. The initial executable bootstrap, including the pairing page and `/sw.js`, is served by the tunnel origin before the worker can verify anything. A malicious host or edge that replaces that bootstrap can omit the verifier or steal the fragment. Bundle signatures do not independently authenticate the first code delivery. Confirm the displayed key fingerprint through an out-of-band channel when the tunnel or host is not already trusted.
+
+Raw bundle assets and raw plugin assets are served only for the signed revision and manifest entries:
+
+- `/bundle-manifest.json` and `/bundle-assets/<revision>/...` are the host bundle routes.
+- `/api/web-plugins/<composition-id>/<revision>/manifest` and `/assets/...` are the raw plugin composition routes.
+- `/verified-plugins/<composition-id>/<revision>/...` is a service worker cache path for already verified plugin assets.
+
+Session file previews are bounded and served as no-store responses. They are not placed in the application cache, IndexedDB, signed manifests, or Push payloads.
+
+## Optional container boundary
+
+When the sandbox layer is installed, remote access can hand the cockpit to a container. The hub, spawned session servers, agents, and `cloudflared` run inside it. Only explicitly configured absolute workspace paths are mounted. The host home directory, SSH keys, Git configuration, container socket, and unlisted repositories are not mounted by the cockpit handoff. Provider credentials use the broker's per-session token rather than forwarding host API keys.
+
+The container is a boundary, not a complete sandbox:
+
+- the container engine and anyone who can control its daemon are trusted
+- sessions share one container and can read each other's mounted workspaces
+- mounted workspaces are writable, so an agent can alter or delete them
+- network access is unrestricted
+- credentials already present in a mounted workspace can still be used
+- plugin tabs use the built-in set until a composition is synchronized inside the container
+
+Choose the workspace list as if it grants full write access to every agent in the contained cockpit.
+
+## Before enabling remote access
+
+1. Keep the main listener on loopback.
+2. Use a stable named tunnel only when a durable PWA or passkey is needed.
+3. Approve each pairing request on the host and revoke devices that are no longer needed.
+4. Enable idle and absolute session expiry for unattended access.
+5. Use a passkey or hardware MFA for the tunnel provider and enable step-up support.
+6. Use the container boundary for remote work that must not see the rest of the host, while retaining the limits above.

--- a/packages/clients/doompi-web/docs/security.md
+++ b/packages/clients/doompi-web/docs/security.md
@@ -1,50 +1,125 @@
 # Remote security
 
-DoomPi Web can expose a browser cockpit to a phone through a tunnel. Treat this as access to a local agent that may run `bash`, not as a read-only dashboard. A paired device can drive the agent with the permissions of the account running DoomPi Web.
+A DoomPi Web session is not a dashboard. It can prompt an agent that may hold `bash`, filesystem, provider, MCP, and computer-use capabilities. Giving a phone access to the cockpit can therefore approach giving it a shell as the account running DoomPi.
 
-The controls below reduce accidental exposure and cross-site attacks. They do not turn an untrusted host, user account, tunnel provider, or workspace into a trusted one.
+The security design answers four different questions:
 
-## Local listener
+1. Which network path did the request use?
+2. Which device is making it?
+3. Can the tunnel provider read or replace the payload and code?
+4. What can the agent reach after the request is accepted?
 
-The default listener is `127.0.0.1:7433`. The host and origin guard runs before HTTP routes and WebSocket upgrades. It checks the actual listener, the `Host` header, and an `Origin` when one is present. This helps prevent DNS rebinding and hostile web pages from driving a local cockpit.
+No single control answers all four. Authentication does not contain the agent. Encryption does not authenticate the first page. A container does not make a mounted repository read-only.
 
-A missing `Origin` is accepted for local requests so command-line clients and health probes work. A local program can send its own headers, so these checks are not an authorization boundary against another process running as the same user. Do not use `--host 0.0.0.0` or another public bind as a substitute for remote access. A non-loopback bind is warned about and does not require pairing.
+## Boundaries in one picture
 
-`DOOMPI_WEB_ALLOW_ORIGIN` adds explicit origins to the local development allowlist. It does not authorize a public listener or bypass remote device authentication.
+```text
+Local browser or process
+        |
+        | loopback listener
+        v
+DoomPi Web hub --------------------> session server ----> agent
+        ^                                  Unix sockets
+        |
+        | tunnel listener
+        |
+cloudflared / tunnel provider
+        |
+        | TLS to device
+        v
+Paired remote browser
+  +-- device cookie identifies the device
+  +-- sealed channels protect post-pairing payloads
+  +-- verified bundles protect later code delivery
+```
 
-## Tunnel listener
+An optional container can move the hub, session servers, agents, and `cloudflared` behind a mount boundary. It changes what the accepted agent can reach. It does not change who may authenticate.
 
-Enabling remote access binds a second loopback listener on an ephemeral port and points `cloudflared` at it. The normal local listener stays separate. The listener split lets the hub identify tunnel traffic even though `cloudflared` connects from loopback.
+## Threats, controls, and limits
 
-The tunnel policy accepts the tunnel's reported origin and host. Before the tunnel is considered ready, the hub probes the public pairing page and expects `/api/health` to return `401`. This confirms those routes, not every route or every property of the tunnel provider.
+| Threat                                          | Primary control                           | Limit                                                                        |
+| ----------------------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------- |
+| A hostile page drives a local cockpit           | Host and Origin checks                    | A hostile local process can send its own headers                             |
+| An internet caller reaches the tunnel           | Host-approved pairing and device sessions | A paired device has broad cockpit authority                                  |
+| A stolen device cookie performs sensitive setup | Passkey step-up on named tunnels          | Quick tunnels skip step-up; ordinary prompts remain cookie-authorized        |
+| The tunnel provider reads prompts and responses | Sealed WebSocket and HTTP payloads        | Bootstrap assets, traffic shape, timing, and sizes remain visible            |
+| The provider alters cockpit JavaScript          | Signed, verified, atomic publications     | The initial verifier page is still trust-on-first-use from the tunnel origin |
+| A remote user enumerates the host               | Remote directory picker is pinned         | A caller may still request a known absolute path without containment         |
+| An accepted agent reads the rest of the host    | Optional container and explicit mounts    | Mounted workspaces are writable; engine and network remain trusted           |
 
-The tunnel listener's unauthenticated allowlist is limited to package-owned pairing, PWA bootstrap, passkey ceremony, and sealed-channel establishment routes. Some handlers on that allowlist still perform their own checks, such as requiring an existing paired device for passkey registration. Direct remote session and protocol WebSocket upgrades require both a device authorization and a purpose-specific sealed channel. Other remote HTTP requests must use the sealed HTTP gateway. A remote request cannot select arbitrary internal routes by bypassing that gateway.
+The controls target remote and browser-driven access. They do not defend against root, a compromised owner account, a hostile process already running as that account, a compromised container engine, or a model misusing capabilities it was deliberately given.
 
-Quick tunnels are temporary. Their hostname rotates on every start, so they cannot provide a stable passkey relying-party ID, durable PWA identity, or reliable Push identity. Use a named tunnel for those features and protect the tunnel account with hardware MFA or a passkey.
+## Listener separation
 
-## Pairing and device sessions
+DoomPi Web runs one application behind two sockets:
 
-The host shows a QR URL such as:
+- the normal listener binds `127.0.0.1:7433` by default
+- enabling remote access creates a second loopback listener on an ephemeral port for `cloudflared`
+
+The accepted socket identifies whether a request is local or tunneled. This cannot safely come from a header because `cloudflared` itself connects from loopback and remote callers can forge forwarded headers.
+
+### Local listener
+
+The first middleware checks the `Host` header and any supplied `Origin` before HTTP routes or WebSocket upgrades. This blocks common DNS-rebinding and hostile-page paths.
+
+A missing `Origin` is accepted locally so command-line clients and health probes work. That is the limit: a local program can omit or forge those headers. Loopback is a reachability default, not authorization against code running as the same user.
+
+`DOOMPI_WEB_ALLOW_ORIGIN` adds explicit origins for development. It does not authenticate callers. A non-loopback `--host` only emits a warning and does not turn on pairing, so do not publish `0.0.0.0` as a remote-access shortcut.
+
+### Tunnel listener
+
+The tunnel listener serves nothing until its public origin is known. It then requires the expected Host and Origin where the browser should supply one. Before reporting readiness, the hub checks the public pairing page and expects `/api/health` to return `401`. That proves those probes behaved correctly, not that every possible route or provider behavior was inspected.
+
+The unauthenticated allowlist contains only exact package-owned pairing, PWA bootstrap, and passkey ceremony routes. There is no open static prefix. Some allowlisted handlers add their own authorization, such as the paired-device requirement for passkey registration.
+
+Remote session and Pi protocol sockets need both a valid device session and a purpose-specific sealed channel. Other remote HTTP operations pass through the sealed gateway. Channel establishment has its own authenticated bootstrap route.
+
+## Device identity
+
+### Pairing is code plus host approval
+
+The host presents a URL like:
 
 ```text
 https://tunnel.example/pair#c=<code>&k=<channel-key>&s=<signing-key>&r=<revision>
 ```
 
-The code, ephemeral channel public key, signing public key, and minimum bundle revision are in the URL fragment. Browsers do not send the fragment to the tunnel provider. Manual pairing requires comparing the signing-key fingerprint on both devices.
+The fragment carries the pairing code, ephemeral channel public key, signing public key, and minimum bundle revision. Browsers do not send URL fragments in HTTP requests, so the tunnel does not receive those values as part of ordinary navigation.
 
-A code is claimable for 120 seconds. A successful claim creates a pending request that the person at the host must approve or deny within 180 seconds. Approval is required because a QR can be visible in a screen share or over a shoulder. A request is consumed once, and invalid claims are rate limited.
+The code is claimable for 120 seconds. Claiming it creates a pending request, not a device session. A person at the host must approve that request within 180 seconds. An approved request can be redeemed once, and invalid claims are rate limited.
 
-After approval, the browser receives a device bearer cookie named `__Host-doompi_device`. It is `HttpOnly`, `Secure`, `SameSite=Strict`, and `Path=/`, with no `Domain` attribute. Its browser `Max-Age` is capped at 30 days, and optional idle or absolute session expiry can shorten that lifetime. This is not a `doompi-server` attach token. The hub stores a hash of the device token, updates its last-seen time after authenticated requests, and can revoke it. Revocation removes that device's sealed channels and closes its tracked sockets.
+Host approval exists because a QR code may be visible over a shoulder or in a screen share. Its limit is equally important: a compromised host can approve anything, and manual pairing is only as strong as the fingerprint comparison performed by the operator.
 
-Hashing protects persisted state if the state file is copied, but it does not protect against a hostile host owner or process controlling the hub, state directory, browser, or tunnel. Such an owner can observe or alter the running service and should be treated as having access.
+The status poll carries its request ID in a URL query. That ID can redeem an approved request, so treat it as a temporary credential. Proxy and edge logs containing it are sensitive.
 
-Device sessions and pairing requests are process-local. Restarting the hub, disabling remote access, or revoking a device removes active remote access. Optional session expiry is disabled by default. When enabled, the configured idle and absolute limits are evaluated at each request and can invalidate sessions that are already idle.
+### The device cookie
 
-## Passkeys and step-up actions
+After approval, the browser receives `__Host-doompi_device`. It is:
 
-Passkeys are available only when the tunnel has a stable named hostname. The relying-party ID is derived from that hostname. Quick tunnel hostnames, IP addresses, and non-public hostnames are refused for passkey enrollment.
+- `HttpOnly`
+- `Secure`
+- `SameSite=Lax`
+- `Path=/`
+- written without a `Domain` attribute
 
-Registration and authentication ceremonies expire after 120 seconds. A step-up challenge expires after 60 seconds. When passkey support is available, a fresh gesture is required for these action classes:
+The `__Host-` prefix makes the browser enforce Secure, root path, and no Domain. The hub stores a hash of the token rather than its bearer value. The cookie has a browser ceiling of 30 days. Optional idle and absolute expiry can shorten the accepted server session.
+
+This cookie is not a `doompi-server` attach token. The hub retains the Unix attach token and acts as the one server client.
+
+`HttpOnly` prevents JavaScript from reading the cookie. It does not stop compromised same-origin code from issuing requests with it. `SameSite=Lax` reduces cross-site cookie attachment but does not replace Host and Origin checks. Token hashes exist only in the hub's in-memory device registry, so the hub does not retain reusable bearer values there. Hashing does not protect against a process controlling the live hub or browser.
+
+Device sessions and pairing state are process-local. Restarting the hub, disabling remote access, or revoking a device removes active remote access. Revocation also removes the device's sealed channels and closes its tracked sockets.
+
+## Passkeys and step-up
+
+A stable named tunnel may register a discoverable passkey. The relying-party ID comes from the configured public hostname, never a request header. Quick-tunnel hostnames, IP addresses, and hostnames without a dot are refused because they cannot provide a durable WebAuthn scope.
+
+A passkey serves two roles:
+
+- a returning device can establish a new session without another QR
+- a live remote session must make a fresh gesture before selected escalation actions
+
+Registration and authentication ceremonies expire after 120 seconds. Step-up challenges expire after 60 seconds. The protected action classes are:
 
 - `provider.login`
 - `provider.logout`
@@ -54,52 +129,83 @@ Registration and authentication ceremonies expire after 120 seconds. A step-up c
 - `mcp.authorize`
 - `computer-use.activate`
 
-Quick tunnels skip passkey step-up because their rotating hostname cannot provide a stable relying-party ID. These remote actions therefore have the device session as their remaining remote authorization check. Ordinary prompts and tool approvals remain in the normal session flow rather than asking for a biometric gesture on every turn.
+These actions can redirect credentials, change future configuration, start work in another directory, contact MCP servers, or activate control of another interface.
 
-## Sealed transport
+Ordinary prompts and tool approvals do not require a biometric gesture. Requiring one for every turn would encourage automatic approval and make the control less meaningful. The tradeoff is that a stolen valid device cookie can still drive the ordinary agent loop.
 
-After pairing or passkey sign-in, the browser and hub establish separate channels for session traffic, protocol traffic, and HTTP requests. The handshake uses ephemeral P-256 ECDH. Keys are derived with HKDF-SHA-256, and messages use AES-256-GCM with separate directional keys and monotonic counters. Altered, unauthenticated, or replayed envelopes are rejected.
+Quick tunnels skip passkey step-up because their hostname rotates. On a quick tunnel, the device session remains the remote authorization check for those actions. Use a named tunnel when step-up is part of the required boundary.
 
-The session and protocol WebSockets carry sealed envelopes for remote devices. The sealed HTTP gateway carries the request method, root-relative target, headers, body, status, and response body inside the encrypted exchange. Pairing, passkey, channel bootstrap, `/pair`, `/sw.js`, and other PWA bootstrap assets are intentionally unsealed so a device can establish trust.
+## Payload privacy
 
-A client plugin that calls browser `fetch` directly sends plaintext to the tunnel relay. Plugin code that needs HTTP must use `sealedTransport.fetch` from `@agimon-ai/doompi-web-security/browser`. The host cannot enforce that choice for arbitrary plugin code.
+After pairing or passkey sign-in, browser and hub establish separate channels for session traffic, Pi protocol traffic, and HTTP requests. They use ephemeral P-256 ECDH, derive directional keys with HKDF-SHA-256, and seal messages with AES-256-GCM.
 
-Sealing hides post-handshake payload content from a tunnel provider. It does not hide the page and bootstrap assets, the fact that a device is connected, timing, message sizes, request patterns, or tunnel metadata. Do not use this mode when the tunnel provider is outside the trust boundary.
+Each direction uses monotonic counters. Replayed, altered, or unauthenticated envelopes are rejected. Separate channels keep one protocol from reusing another protocol's nonce sequence or authority.
 
-## Signed bundles and bootstrap trust
+The session and protocol WebSockets carry sealed envelopes. The sealed HTTP gateway carries method, root-relative target, headers, body, status, and response body inside the encrypted exchange.
 
-The host keeps a signing key in its state directory. A QR pins the public signing key and a minimum bundle revision. The host manifest contains a revision and a SHA-256 digest, byte length, and content type for each asset. The service worker verifies the signed manifest, downloads each raw asset, checks its digest, and commits the complete result to a cache. A failed update keeps the last verified host or plugin composition. Plugin compositions are signed with the host publication key and verified in the same way.
+The bootstrap cannot be sealed before keys exist. Pairing, passkey ceremonies, channel setup, `/pair`, `/sw.js`, and other PWA bootstrap assets are intentionally visible to the tunnel provider. Sealing also leaves timing, sizes, connection patterns, and tunnel metadata visible.
 
-This is a delivery-integrity guarantee after the browser has a trusted signer key and a trusted verifier bootstrap. The initial executable bootstrap, including the pairing page and `/sw.js`, is served by the tunnel origin before the worker can verify anything. A malicious host or edge that replaces that bootstrap can omit the verifier or steal the fragment. Bundle signatures do not independently authenticate the first code delivery. Confirm the displayed key fingerprint through an out-of-band channel when the tunnel or host is not already trusted.
+A browser plugin that calls `fetch` directly sends plaintext through the relay. Plugin HTTP code must use `sealedTransport.fetch` from `@agimon-ai/doompi-web-security/browser`. The host cannot enforce that choice for arbitrary plugin code, so plugin packages remain trusted inputs.
 
-Raw bundle assets and raw plugin assets are served only for the signed revision and manifest entries:
+## Code-delivery integrity
 
-- `/bundle-manifest.json` and `/bundle-assets/<revision>/...` are the host bundle routes.
-- `/api/web-plugins/<composition-id>/<revision>/manifest` and `/assets/...` are the raw plugin composition routes.
-- `/verified-plugins/<composition-id>/<revision>/...` is a service worker cache path for already verified plugin assets.
+Payload encryption is insufficient if the provider can replace the JavaScript that performs encryption. DoomPi Web therefore signs the shell and each session plugin publication.
 
-Session file previews are bounded and served as no-store responses. They are not placed in the application cache, IndexedDB, signed manifests, or Push payloads.
+The QR pins the host ECDSA public key and a minimum revision. A signed manifest records the revision, path, content type, byte length, and SHA-256 digest for every asset. The service worker downloads assets into a staging cache, verifies every byte, and commits the complete revision only after all checks pass. A failed update leaves the previous verified revision active.
 
-## Optional container boundary
+The public routes are revision-specific:
 
-When the sandbox layer is installed, remote access can hand the cockpit to a container. The hub, spawned session servers, agents, and `cloudflared` run inside it. Only explicitly configured absolute workspace paths are mounted. The host home directory, SSH keys, Git configuration, container socket, and unlisted repositories are not mounted by the cockpit handoff. Provider credentials use the broker's per-session token rather than forwarding host API keys.
+- `/bundle-manifest.json` and `/bundle-assets/<revision>/...` publish the shell
+- `/api/web-plugins/<composition-id>/<revision>/manifest` and `/assets/...` publish a plugin composition
+- `/verified-plugins/<composition-id>/<revision>/...` is the service worker's verified cache path
 
-The container is a boundary, not a complete sandbox:
+This prevents the relay from modifying a later bundle without detection and prevents code from two revisions being mixed.
 
-- the container engine and anyone who can control its daemon are trusted
-- sessions share one container and can read each other's mounted workspaces
-- mounted workspaces are writable, so an agent can alter or delete them
+It does not authenticate the first executable bootstrap. The pairing page and initial `/sw.js` are served by the same tunnel origin before a worker can verify anything. A malicious edge can replace that first page, omit verification, or steal fragment values. Confirm the signing-key fingerprint out of band when the tunnel origin is not already trusted.
+
+Session file previews do not enter the application cache or signed bundle. They are bounded, sealed where remote, served `no-store`, and exposed through ephemeral Blob URLs. They are not placed in Push payloads.
+
+## Push notifications
+
+An installed paired PWA may subscribe to Web Push. The hub keeps subscriptions in process memory and sends only fixed generic copy with `TTL: 0` when that device has no connected cockpit socket.
+
+No prompt, response, session ID, or file content is included. There is no durable subscription database, outbox, replay, or historical delivery. After a hub restart, an open page must register the browser's existing subscription again.
+
+This reduces stored notification data but accepts best-effort delivery. Disabling Push, revoking or expiring the device, turning off remote access, or rotating process credentials removes the subscription.
+
+## Reachability and containment
+
+### Directory picker scope
+
+While a tunnel is active, the new-session picker lists only the subtree where `doompi-web` started. This avoids handing a paired device a casual inventory of projects and checkouts.
+
+It is not path containment. A session-creation request may still name an absolute path the caller already knows. The picker limits discovery, not authority.
+
+### Optional container boundary
+
+When the sandbox layer is installed, remote access can hand the whole cockpit to one container: hub, spawned session servers, agents, and `cloudflared`. Only configured absolute workspace paths are mounted. The host home directory, SSH keys, Git configuration, container socket, and unlisted repositories are omitted. Provider credentials use the broker's per-session token rather than copying host API keys.
+
+Putting the hub inside the same boundary matters. It makes an unmounted path unavailable by construction when the hub creates a session, rather than relying only on a validation check in a host process.
+
+The boundary has explicit limits:
+
+- the container engine and anyone controlling its daemon are trusted
+- all contained sessions share the mounted workspaces
+- mounted workspaces are writable and may be damaged or deleted
 - network access is unrestricted
-- credentials already present in a mounted workspace can still be used
+- credentials already present in a mount remain available
 - plugin tabs use the built-in set until a composition is synchronized inside the container
 
-Choose the workspace list as if it grants full write access to every agent in the contained cockpit.
+Choose mounts as if every contained agent receives full write access to them.
 
 ## Before enabling remote access
 
 1. Keep the main listener on loopback.
-2. Use a stable named tunnel only when a durable PWA or passkey is needed.
-3. Approve each pairing request on the host and revoke devices that are no longer needed.
-4. Enable idle and absolute session expiry for unattended access.
-5. Use a passkey or hardware MFA for the tunnel provider and enable step-up support.
-6. Use the container boundary for remote work that must not see the rest of the host, while retaining the limits above.
+2. Prefer a named tunnel when passkeys, step-up, or an installed PWA matter.
+3. Protect the tunnel account with a passkey or hardware MFA.
+4. Approve pairings at the host and revoke devices no longer in use.
+5. Enable idle and absolute expiry for unattended access.
+6. Treat every installed plugin and package API as trusted code.
+7. Use the container boundary when remote agents must not see the rest of the host, while retaining its stated limits.
+
+See [Architecture](architecture.md) for listener and process ownership and [Web bundling and serving](bundle.md) for signed publication mechanics.

--- a/packages/clients/doompi-web/llms.txt
+++ b/packages/clients/doompi-web/llms.txt
@@ -9,7 +9,7 @@ Package-owned guidance for the DoomPi Web cockpit.
 - [Architecture](./docs/architecture.md): hub, session servers, browser sockets, and lifecycle ownership.
 - [Web plugins](./docs/plugins.md): `doompiWeb` manifests, `webPlugin`, `webHubChannels`, and UI contributions.
 - [Package APIs](./docs/package-apis.md): `doompiApi`, route scopes, selectors, and request context.
-- [Bundle resolution](./docs/bundle.md): immutable sync generations, repository fallback, and publication.
+- [Web bundling and serving](./docs/bundle.md): relationship to the TUI composition, design choices, build outputs, per-session selection, and signed serving.
 - [Remote security](./docs/security.md): pairing, device cookies, passkeys, step-up actions, sealing, signed assets, and containment limits.
 
 ## Facts to preserve

--- a/packages/clients/doompi-web/llms.txt
+++ b/packages/clients/doompi-web/llms.txt
@@ -1,13 +1,24 @@
 # @agimon-ai/doompi-web
 
-Package-owned guidance for the DoomPi web cockpit.
+Package-owned guidance for the DoomPi Web cockpit.
 
-## Resources
+## Start here
 
-- [Package README](./README.md): Running the cockpit, the bridge's security stance, what each
-  surface renders, and the limits of what Pi RPC exposes. Its Notifications guidance covers
-  all-session live fanout, user-click browser permission, and the absence of service workers, Web Push,
-  replay, or durable delivery. Its Security section states why loopback binding is not on its own an
-  authorization boundary and what the origin and host guard refuses; its Planned section records why
-  a WebRTC transport is wanted, for realtime voice as much as for keeping a tunnel provider out of the
-  data path.
+- [README](./README.md): installation, command options, runtime behavior, extensions, and security summary.
+- [Getting started](./docs/getting-started.md): setup, synchronization, session discovery, and local development.
+- [Architecture](./docs/architecture.md): hub, session servers, browser sockets, and lifecycle ownership.
+- [Web plugins](./docs/plugins.md): `doompiWeb` manifests, `webPlugin`, `webHubChannels`, and UI contributions.
+- [Package APIs](./docs/package-apis.md): `doompiApi`, route scopes, selectors, and request context.
+- [Bundle resolution](./docs/bundle.md): immutable sync generations, repository fallback, and publication.
+- [Remote security](./docs/security.md): pairing, device cookies, passkeys, step-up actions, sealing, signed assets, and containment limits.
+
+## Facts to preserve
+
+- DoomPi Web is a standalone process, not a Pi extension and not a `.doom/modes.yaml` entry.
+- The default URL is `http://127.0.0.1:7433`. The default session registry is `~/.doompi/run`; `DOOMPI_RUNTIME_DIR` and `--registry-dir` override it.
+- Web compositions resolve per session: a usable repository registration wins, otherwise the usable global registration is selected. Artifacts are never merged across those registrations.
+- `--dir` synchronizes a selected repository on demand. Only the global synchronization guard watches for later changes.
+- The cockpit owns session attach tokens. Browser traffic is multiplexed over one hub WebSocket, and browser attach frames are refused.
+- The PWA has a package-owned service worker that verifies signed host and plugin assets before caching them. Optional closed-app Web Push is generic, zero-TTL, in-memory delivery, not a durable queue.
+- Remote access is not a sandbox. Pairing requires host approval, remote sockets and API bodies use sealed channels, and a paired device can drive an agent with shell access. Loopback origin and host checks do not defend against hostile local programs.
+- Bundle signatures provide delivery integrity only after the signer key and the initial executable bootstrap are trusted separately. A tunnel provider can observe bootstrap traffic, timing, sizes, and connection metadata.

--- a/packages/clients/doompi-web/package.json
+++ b/packages/clients/doompi-web/package.json
@@ -29,6 +29,7 @@
     "src",
     "llms.txt",
     "README.md",
+    "docs",
     "LICENSE",
     "package.json"
   ],

--- a/packages/clients/doompi-web/src/web/features/session/Composer.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/Composer.tsx
@@ -49,9 +49,8 @@ import { QueueSheet } from './QueueSheet.tsx';
 /** The input grows with the draft up to this many pixels, then scrolls. */
 const MAX_INPUT_HEIGHT_PX = 192;
 /**
- * The popup does not scroll, so this is also how tall it can get: high enough
- * that a bare `/` or `$` lists what the session actually has rather than the
- * first handful, low enough to stay on screen.
+ * Bound the result set so completion searches and their scrollable popup stay
+ * quick even in large workspaces.
  */
 const MAX_COMPLETION_ITEMS = 20;
 /** Pi names skill commands `skill:<name>`; the cockpit browses them under `$`. */
@@ -180,7 +179,6 @@ export function Composer() {
   const [completion, setCompletion] = useState<CompletionState | null>(null);
   const [draggingFiles, setDraggingFiles] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const searchTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
@@ -530,20 +528,6 @@ export function Composer() {
                   : 'border-doom-border'
             }`}
           >
-            {/* prefer-shared-primitive: ignore -- a hidden native file picker has no visual primitive. */}
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              accept={FILE_INPUT_ACCEPT}
-              tabIndex={-1}
-              className="hidden"
-              data-testid="composer-file-input"
-              onChange={(event) => {
-                void addFiles(Array.from(event.currentTarget.files ?? []));
-                event.currentTarget.value = '';
-              }}
-            />
             {completion ? (
               <PopoverContent
                 side="top"
@@ -558,29 +542,31 @@ export function Composer() {
                 onInteractOutside={(event) => {
                   if (containerRef.current?.contains(event.target as Node) === true) event.preventDefault();
                 }}
-                className="w-[420px] max-w-[85vw] rounded-md p-0 shadow-xl"
+                className="max-h-[min(16rem,40dvh,var(--radix-popover-content-available-height))] w-[420px] max-w-[85vw] rounded-md p-0 shadow-xl sm:max-h-[min(20rem,50dvh,var(--radix-popover-content-available-height))]"
               >
-                {completion.items.map((item, index) => (
-                  <OptionRow
-                    key={item.label}
-                    density="compact"
-                    active={index === completion.selected}
-                    data-testid={`composer-completion-item-${String(index)}`}
-                    onMouseEnter={() => setCompletion({ ...completion, selected: index })}
-                    onMouseDown={(event) => {
-                      event.preventDefault();
-                      accept(completion, index);
-                    }}
-                    className="w-full items-baseline gap-2.5 rounded-none px-3 py-1.5"
-                  >
-                    <span className="shrink-0 text-[12px] font-bold text-doom-blue">{item.label}</span>
-                    {item.detail ? (
-                      <OptionLabel density="compact" className="text-[10px] text-doom-dim">
-                        {item.detail}
-                      </OptionLabel>
-                    ) : null}
-                  </OptionRow>
-                ))}
+                <div className="min-h-0 overflow-y-auto overscroll-contain" data-testid="composer-completion-options">
+                  {completion.items.map((item, index) => (
+                    <OptionRow
+                      key={item.label}
+                      density="compact"
+                      active={index === completion.selected}
+                      data-testid={`composer-completion-item-${String(index)}`}
+                      onMouseEnter={() => setCompletion({ ...completion, selected: index })}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        accept(completion, index);
+                      }}
+                      className="w-full items-baseline gap-2.5 rounded-none px-3 py-1.5"
+                    >
+                      <span className="shrink-0 text-[12px] font-bold text-doom-blue">{item.label}</span>
+                      {item.detail ? (
+                        <OptionLabel density="compact" className="text-[10px] text-doom-dim">
+                          {item.detail}
+                        </OptionLabel>
+                      ) : null}
+                    </OptionRow>
+                  ))}
+                </div>
                 <PopoverFooter className="py-1">
                   <span className="flex items-center gap-1.5">
                     <Kbd>tab</Kbd> or <Kbd>enter</Kbd> completes · <Kbd>esc</Kbd> closes
@@ -714,16 +700,32 @@ export function Composer() {
                   : 'enter sends · shift+enter for a new line · space opens leader'}
               </span>
               <Button
+                asChild
                 variant="ghost"
                 size="icon"
                 data-testid="composer-attach"
-                disabled={!attached}
                 title="attach images or text files"
-                aria-label="attach images or text files"
-                onClick={() => fileInputRef.current?.click()}
-                className="shrink-0 text-doom-dim"
+                className={`relative shrink-0 overflow-hidden text-doom-dim focus-within:ring-2 focus-within:ring-doom-blue/50 ${
+                  attached ? '' : 'pointer-events-none opacity-40'
+                }`}
               >
-                <PlusIcon className="h-3 w-3" />
+                <label aria-disabled={!attached}>
+                  <PlusIcon className="h-3 w-3" />
+                  {/* prefer-shared-primitive: ignore -- iOS needs the native file input itself to cover the visible tap target. */}
+                  <input
+                    type="file"
+                    multiple
+                    accept={FILE_INPUT_ACCEPT}
+                    disabled={!attached}
+                    aria-label="attach images or text files"
+                    className="absolute inset-0 cursor-pointer opacity-0"
+                    data-testid="composer-file-input"
+                    onChange={(event) => {
+                      void addFiles(Array.from(event.currentTarget.files ?? []));
+                      event.currentTarget.value = '';
+                    }}
+                  />
+                </label>
               </Button>
               <span className="min-w-0 flex-1" />
               {streaming ? abortAction : null}

--- a/packages/clients/doompi-web/src/web/features/settings/ContributedSettings.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/ContributedSettings.tsx
@@ -9,6 +9,7 @@ import {
   SelectLabel,
   SelectTrigger,
   SelectValue,
+  Switch,
 } from '@agimon-ai/doompi-web-components';
 import type { SettingsFieldContribution, SettingsSectionContribution } from '@agimon-ai/doompi-web-contracts';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -124,6 +125,13 @@ function FieldRow({ field, view, scope, models, draft, busy, onDraft }: FieldRow
 
       {kind === 'info' ? (
         <span className="text-[11px] text-doom-text">{value || '—'}</span>
+      ) : kind === 'toggle' ? (
+        <Switch
+          data-testid={`settings-toggle-${field.id}`}
+          checked={value === 'true'}
+          disabled={busy || locked !== undefined}
+          onCheckedChange={(checked) => onDraft(field, String(checked))}
+        />
       ) : kind === 'select' ? (
         <Select
           value={value === '' ? INHERIT_VALUE : value}

--- a/packages/clients/doompi-web/src/web/lib/composition.ts
+++ b/packages/clients/doompi-web/src/web/lib/composition.ts
@@ -80,6 +80,7 @@ export interface MinorModeSource {
   keys: string;
   statusKey?: string;
   widgetKey?: string;
+  hideWhenMissing?: boolean;
 }
 
 /**
@@ -101,7 +102,13 @@ export const PACKAGED_MINOR_MODES: readonly MinorModeSource[] = [
   { name: 'workflow', keys: 'w e', widgetKey: 'workflow-mcp-progress' },
   // `v e` drives autonomous capture, which the runtime registers as 'voice-auto'.
   { name: 'voice', modeId: 'voice-auto', keys: 'v e', statusKey: 'doom-voice' },
-  { name: 'computer use', modeId: 'computer-use', keys: 'c e', statusKey: 'doom-computer-use-mode' },
+  {
+    name: 'computer use',
+    modeId: 'computer-use',
+    keys: 'c e',
+    statusKey: 'doom-computer-use-mode',
+    hideWhenMissing: true,
+  },
 ];
 
 /** The declared source a catalog mode corresponds to, by id, id stem, or label. */
@@ -138,6 +145,7 @@ function catalogMinorModes(sources: readonly MinorModeSource[], projection: Mino
   });
   const seen = new Set(rows.map((row) => row.name));
   for (const source of sources) {
+    if (source.hideWhenMissing === true) continue;
     if (!seen.has(source.name)) {
       rows.push({
         name: source.name,
@@ -160,18 +168,21 @@ export function minorModes(
   const declared = pluginMinorModes();
   const sources: readonly MinorModeSource[] = declared.length > 0 ? declared : PACKAGED_MINOR_MODES;
   if (projection) return catalogMinorModes(sources, projection);
-  return sources.map((source) => {
+  return sources.flatMap((source) => {
     if (source.statusKey !== undefined) {
       const raw = statuses[source.statusKey];
       if (raw === undefined) {
-        return {
-          name: source.name,
-          id: source.modeId ?? source.name,
-          keys: source.keys,
-          availability: 'unavailable' as const,
-          detail: '',
-          unavailableReason: 'This session has not reported the mode.',
-        };
+        if (source.hideWhenMissing === true) return [];
+        return [
+          {
+            name: source.name,
+            id: source.modeId ?? source.name,
+            keys: source.keys,
+            availability: 'unavailable' as const,
+            detail: '',
+            unavailableReason: 'This session has not reported the mode.',
+          },
+        ];
       }
       const detail = stripAnsi(raw).trim();
       return {

--- a/packages/clients/doompi-web/tests/e2e/composer.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/composer.spec.ts
@@ -235,7 +235,10 @@ test('attaches image payloads and inlines removable text files', async ({ page, 
 
   await picker.setInputFiles({ name: 'huge.txt', mimeType: 'text/plain', buffer: Buffer.alloc(100 * 1024 + 1) });
   await expect(page.getByTestId('composer-attachment-error')).toContainText('exceeds the 100 KB text file limit');
-  await picker.setInputFiles({ name: 'screen.png', mimeType: 'image/png', buffer: Buffer.from('image bytes') });
+  const chooserPromise = page.waitForEvent('filechooser');
+  await page.getByTestId('composer-attach').click();
+  const chooser = await chooserPromise;
+  await chooser.setFiles({ name: 'screen.png', mimeType: 'image/png', buffer: Buffer.from('image bytes') });
   await expect(page.getByTestId('composer-attachments')).toContainText('screen.png');
 
   await picker.setInputFiles({

--- a/packages/clients/doompi-web/tests/unit/composition.test.ts
+++ b/packages/clients/doompi-web/tests/unit/composition.test.ts
@@ -147,7 +147,7 @@ describe('minorModes', () => {
     expect(modes.find((mode) => mode.name === 'goal')?.detail).toBe('held');
   });
 
-  it('always reports every mode DoomPi ships', () => {
+  it('hides opt-in modes until the session reports them', () => {
     expect(minorModes({}, []).map((mode) => mode.name)).toEqual([
       'help',
       'plan',
@@ -156,8 +156,12 @@ describe('minorModes', () => {
       'author',
       'workflow',
       'voice',
-      'computer use',
     ]);
+    expect(minorModes({ 'doom-computer-use-mode': '' }, []).find((mode) => mode.name === 'computer use')).toMatchObject(
+      {
+        availability: 'off',
+      },
+    );
   });
 
   it('prefers plugin-declared modes over the packaged fallback, in declared order', () => {

--- a/packages/core/doompi-config/src/services/configPolicy.ts
+++ b/packages/core/doompi-config/src/services/configPolicy.ts
@@ -1,6 +1,7 @@
 import { parse as parseYaml } from 'yaml';
 import type {
   AutocompactModeConfig,
+  ComputerUseConfig,
   AutocompactThresholdConfig,
   DoomConfig,
   DoomSelectionConfig,
@@ -23,13 +24,14 @@ const DEFAULT_PROJECT_TRUST: ProjectTrust = 'ask';
 const DEFAULT_VOICE_ENGINE: VoiceEngine = 'auto';
 const DEFAULT_VOICE_LANGUAGE = 'auto';
 const DEFAULT_RECORDER_DEVICE = 'none:default';
-const ROOT_KEYS = ['modes', 'projectTrust', 'editor', 'voice', 'selection'] as const;
+const ROOT_KEYS = ['modes', 'computerUse', 'projectTrust', 'editor', 'voice', 'selection'] as const;
 const SELECTION_KEYS = ['majorMode', 'domains', 'profile'] as const;
 const MODE_KEYS = ['planning', 'autocompact'] as const;
 const PLANNING_KEYS = ['main', 'subagents', 'plansDirectory'] as const;
 const AGENT_KEYS = ['model', 'thinking'] as const;
 const AUTOCOMPACT_KEYS = ['enabled', 'model', 'thinking', 'thresholds'] as const;
 const AUTOCOMPACT_THRESHOLD_KEYS = ['pass1', 'pass2', 'pass3'] as const;
+const COMPUTER_USE_KEYS = ['enabled'] as const;
 /** A pass that fires below this is noise; one above it never fires before Pi compacts natively. */
 const MIN_AUTOCOMPACT_RATIO = 0.05;
 const MAX_AUTOCOMPACT_RATIO = 0.99;
@@ -525,6 +527,14 @@ function parseEditor(value: unknown, filePath: string): EditorConfig | undefined
   assertKeys(value, EDITOR_KEYS, 'editor', filePath);
   return { command: optionalString(value.command, 'editor.command', filePath) };
 }
+
+function parseComputerUse(value: unknown, filePath: string): ComputerUseConfig | undefined {
+  if (value === undefined) return undefined;
+  if (!isObject(value)) throw new Error(`Doom config at ${filePath} requires computerUse to be an object`);
+  assertKeys(value, COMPUTER_USE_KEYS, 'computerUse', filePath);
+  const enabled = parseFlexibleBoolean(value.enabled, 'computerUse.enabled', filePath);
+  return enabled === undefined ? {} : { enabled };
+}
 export function parseDoomConfig(content: string, filePath: string): DoomConfig {
   let parsed: unknown;
   try {
@@ -552,6 +562,7 @@ export function parseDoomConfig(content: string, filePath: string): DoomConfig {
     throw new Error(`Doom config at ${filePath} projectTrust must be ask, always, or never`);
   return {
     modes,
+    computerUse: parseComputerUse(parsed.computerUse, filePath),
     projectTrust: trust as ProjectTrust,
     editor: parseEditor(parsed.editor, filePath),
     voice: parseVoice(parsed.voice, filePath),
@@ -567,6 +578,8 @@ function mergeAgent(
 export function mergeDoomConfigs(globalConfig: DoomConfig, repositoryConfig: DoomConfig): DoomConfig {
   if (repositoryConfig.voice?.autoCapture)
     throw new Error('Repository Doom config voice.autoCapture is global-only; configure it in ~/.pi/.doom/config.yaml');
+  if (repositoryConfig.computerUse)
+    throw new Error('Repository Doom config computerUse is global-only; configure it in ~/.pi/.doom/config.yaml');
   const globalPlanning = globalConfig.modes?.planning;
   const repositoryPlanning = repositoryConfig.modes?.planning;
   const planning =
@@ -597,6 +610,7 @@ export function mergeDoomConfigs(globalConfig: DoomConfig, repositoryConfig: Doo
       planning || autocompact
         ? { ...(planning ? { planning } : {}), ...(autocompact ? { autocompact } : {}) }
         : undefined,
+    computerUse: globalConfig.computerUse,
     projectTrust: repositoryConfig.projectTrust,
     editor: globalConfig.editor,
     voice,
@@ -687,7 +701,7 @@ export function resolveVoiceConfig(config: VoiceConfig): ResolvedVoiceConfig {
 export type ConfigKeyScope = 'global' | 'repository' | 'both';
 
 /** Root keys the merge reads from one side only. */
-const GLOBAL_ONLY_ROOTS: readonly string[] = ['editor'];
+const GLOBAL_ONLY_ROOTS: readonly string[] = ['computerUse', 'editor'];
 const REPOSITORY_ONLY_ROOTS: readonly string[] = ['projectTrust'];
 /** The one nested exception; a repository declaration of it throws in the merge. */
 const GLOBAL_ONLY_PATHS: readonly (readonly string[])[] = [['voice', 'autoCapture']];

--- a/packages/core/doompi-config/src/types/config.ts
+++ b/packages/core/doompi-config/src/types/config.ts
@@ -35,6 +35,10 @@ export interface AutocompactModeConfig {
   thinking?: PlanningThinkingLevel;
   thresholds?: AutocompactThresholdConfig;
 }
+export interface ComputerUseConfig {
+  enabled?: boolean;
+}
+
 export interface EditorConfig {
   command?: string;
 }
@@ -135,6 +139,7 @@ export type DoomConfigPendingSelection = DoomConfigTransitionRecord & { readonly
 
 export interface DoomConfig {
   modes?: { planning?: PlanningModeConfig; autocompact?: AutocompactModeConfig };
+  computerUse?: ComputerUseConfig;
   projectTrust: ProjectTrust;
   editor?: EditorConfig;
   voice?: VoiceConfig;

--- a/packages/core/doompi-config/tests/configScope.test.ts
+++ b/packages/core/doompi-config/tests/configScope.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { loadDoomConfigLayers } from '../src/adapters/config.ts';
 import { setDoomConfigValue, unsetDoomConfigValue } from '../src/adapters/configWriter.ts';
-import { configLeafKeys, configScopeOf, mergeDoomConfigs } from '../src/services/configPolicy.ts';
+import { configLeafKeys, configScopeOf, mergeDoomConfigs, parseDoomConfig } from '../src/services/configPolicy.ts';
 
 /**
  * Scope, made answerable.
@@ -66,11 +66,29 @@ describe('which file a key may be written to', () => {
     expect(configScopeOf(['voice', 'autoCapture', 'tts', 'rate'])).toBe('global');
   });
 
+  it('keeps the computer-use opt-in global only', () => {
+    expect(
+      mergeDoomConfigs({ projectTrust: 'ask', computerUse: { enabled: true } }, { projectTrust: 'ask' }).computerUse
+        ?.enabled,
+    ).toBe(true);
+    expect(configScopeOf(['computerUse', 'enabled'])).toBe('global');
+    expect(() =>
+      mergeDoomConfigs({ projectTrust: 'ask' }, { projectTrust: 'ask', computerUse: { enabled: true } }),
+    ).toThrow('global-only');
+  });
   it('lets a repository override the keys the merge merges', () => {
     expect(configScopeOf(['modes', 'planning', 'main', 'model'])).toBe('both');
     expect(configScopeOf(['modes', 'planning', 'subagents', 'model'])).toBe('both');
     expect(configScopeOf(['selection', 'profile'])).toBe('both');
     expect(configScopeOf(['voice', 'language'])).toBe('both');
+  });
+
+  it('parses computer use as an explicit opt-in', () => {
+    expect(parseDoomConfig('', '/config.yaml').computerUse?.enabled).toBeUndefined();
+    expect(parseDoomConfig('computerUse:\n  enabled: true\n', '/config.yaml').computerUse?.enabled).toBe(true);
+    expect(() => parseDoomConfig('computerUse:\n  typo: true\n', '/config.yaml')).toThrow(
+      'unsupported computerUse field(s): typo',
+    );
   });
 
   it('answers for a key it has never heard of, leaving rejection to the parser', () => {

--- a/packages/core/doompi-web-contracts/src/types/webPlugin.ts
+++ b/packages/core/doompi-web-contracts/src/types/webPlugin.ts
@@ -446,6 +446,8 @@ export interface MinorModeContribution {
   statusKey?: string;
   /** Widget key whose presence reports the mode as installed but off. */
   widgetKey?: string;
+  /** Omit the row when the active session does not register this opt-in mode. */
+  hideWhenMissing?: boolean;
   /** Sort position in the selection bar list; lower first, name breaks ties. */
   order?: number;
 }

--- a/packages/minor/doompi-computer-use/package.json
+++ b/packages/minor/doompi-computer-use/package.json
@@ -69,6 +69,7 @@
     "fixcode": "oxlint . --fix && oxfmt ."
   },
   "dependencies": {
+    "@agimon-ai/doompi-config": "workspace:*",
     "@agimon-ai/doompi-extension-contracts": "workspace:*",
     "@agimon-ai/doompi-web-components": "workspace:*",
     "@agimon-ai/doompi-web-contracts": "workspace:*",

--- a/packages/minor/doompi-computer-use/src/adapters/pi/extension.ts
+++ b/packages/minor/doompi-computer-use/src/adapters/pi/extension.ts
@@ -80,13 +80,14 @@ export function installComputerUseRuntime(
   const client = dependencies.client;
   let state: ComputerUseSessionView | undefined;
   let enabled = false;
+  let globallyEnabled = false;
   let mode: MinorModeOwnerHandle | undefined;
+  let syncModeOwner = (): void => undefined;
   let timer: ReturnType<typeof setInterval> | undefined;
   let activeContext: ExtensionContext | undefined;
   let publishedMode = '';
   let publishedModeStatus: string | undefined;
   let publishedActivityStatus: string | undefined;
-
   const publish = (): void => {
     const phase = state?.phase ?? 'inactive';
     const projection = `${enabled}:${phase}:${state?.revision ?? 'none'}`;
@@ -106,7 +107,29 @@ export function installComputerUseRuntime(
     }
   };
   const refresh = async (): Promise<void> => {
-    if (client === undefined) {
+    let nextGloballyEnabled = false;
+    try {
+      nextGloballyEnabled = (await dependencies.enabled?.()) === true;
+    } catch {
+      nextGloballyEnabled = false;
+    }
+    if (nextGloballyEnabled !== globallyEnabled) {
+      globallyEnabled = nextGloballyEnabled;
+      if (!globallyEnabled) {
+        if (client !== undefined && state !== undefined && state.phase !== 'inactive' && state.phase !== 'failed') {
+          try {
+            await client.stop();
+          } catch {
+            // The global opt-in is still authoritative even when remote cleanup fails.
+          }
+        }
+        enabled = false;
+        state = undefined;
+        reconcileTools(pi, false);
+      }
+      syncModeOwner();
+    }
+    if (!globallyEnabled || client === undefined) {
       state = undefined;
       reconcileTools(pi, false);
       publish();
@@ -130,7 +153,7 @@ export function installComputerUseRuntime(
     promptSnippet: 'Observe the authorized application before choosing a semantic action',
     parameters: { type: 'object', properties: {}, additionalProperties: false },
     async execute(_toolCallId, _params, signal) {
-      if (client === undefined || state?.phase !== 'active')
+      if (!globallyEnabled || client === undefined || state?.phase !== 'active')
         throw new Error('Computer use is not active for this session.');
       const observation = await client.observe(signal);
       return { content: [{ type: 'text', text: JSON.stringify(observation, null, 2) }], details: observation };
@@ -155,7 +178,7 @@ export function installComputerUseRuntime(
       additionalProperties: false,
     },
     async execute(_toolCallId, params, signal) {
-      if (client === undefined || state?.phase !== 'active')
+      if (!globallyEnabled || client === undefined || state?.phase !== 'active')
         throw new Error('Computer use is not active for this session.');
       const result = await client.act(params as unknown as ComputerUseAction, signal);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }], details: result };
@@ -163,77 +186,96 @@ export function installComputerUseRuntime(
   });
 
   cordis.inject([DOOM_MINOR_MODE_CATALOG_SERVICE], (context) => {
-    const owner = registerMinorModeOwner<ExtensionContext>(requireMinorModeCatalog(context), {
-      descriptor: {
-        source: PACKAGE_SOURCE,
-        id: COMPUTER_USE_MODE_ID,
-        label: 'Computer Use',
-        description: 'Session-scoped semantic control through DoomPi Desktop.',
-        order: 450,
-        actions: [
-          {
-            id: 'activate',
-            label: 'Activate',
-            description: 'Open the cockpit activation workflow and native confirmation.',
-            contexts: ['tui', 'headless'],
-            parameters: [],
-          },
-          {
-            id: 'deactivate',
-            label: 'Deactivate',
-            description: 'Stop this session computer-use run.',
-            contexts: ['tui', 'headless'],
-            parameters: [],
-          },
-          {
-            id: 'doctor',
-            label: 'Doctor',
-            description: 'Report Desktop availability and session state.',
-            contexts: ['tui', 'headless'],
-            parameters: [],
-          },
-        ],
-      },
-      initialState: modeState(state, enabled),
-      async handleAction(actionId, _argumentsValue, execution) {
-        activeContext = execution.context;
-        if (actionId === 'activate') {
-          if (client === undefined) throw new Error('DoomPi Desktop computer use is unavailable.');
-          enabled = true;
-          await refresh();
-          publish();
-          return { message: 'Computer use is ready to configure in Activity.' };
-        }
-        if (actionId === 'doctor') {
-          await refresh();
-          return {
-            message:
-              client === undefined
-                ? 'DoomPi Desktop session API is unavailable.'
-                : `Computer use is ${state?.phase.replaceAll('_', ' ') ?? 'unavailable'}.`,
-          };
-        }
-        if (actionId === 'deactivate') {
-          if (client === undefined) throw new Error('DoomPi Desktop computer use is unavailable.');
-          if (state !== undefined && state.phase !== 'inactive' && state.phase !== 'failed')
-            await client.stop(execution.signal);
-          enabled = false;
-          await refresh();
-          publish();
-          return { message: 'Computer use is off.' };
-        }
-        throw new Error(`Unknown computer-use action: ${actionId}`);
-      },
-    });
-    mode = owner;
+    const catalog = requireMinorModeCatalog(context);
+    const registerOwner = (): MinorModeOwnerHandle =>
+      registerMinorModeOwner<ExtensionContext>(catalog, {
+        descriptor: {
+          source: PACKAGE_SOURCE,
+          id: COMPUTER_USE_MODE_ID,
+          label: 'Computer Use',
+          description: 'Session-scoped semantic control through DoomPi Desktop.',
+          order: 450,
+          actions: [
+            {
+              id: 'activate',
+              label: 'Activate',
+              description: 'Open the cockpit activation workflow and native confirmation.',
+              contexts: ['tui', 'headless'],
+              parameters: [],
+            },
+            {
+              id: 'deactivate',
+              label: 'Deactivate',
+              description: 'Stop this session computer-use run.',
+              contexts: ['tui', 'headless'],
+              parameters: [],
+            },
+            {
+              id: 'doctor',
+              label: 'Doctor',
+              description: 'Report Desktop availability and session state.',
+              contexts: ['tui', 'headless'],
+              parameters: [],
+            },
+          ],
+        },
+        initialState: modeState(state, enabled),
+        async handleAction(actionId, _argumentsValue, execution) {
+          activeContext = execution.context;
+          if (actionId === 'activate') {
+            if ((await dependencies.enabled?.()) !== true) {
+              await refresh();
+              throw new Error('Enable computer use in global settings first.');
+            }
+            if (client === undefined) throw new Error('DoomPi Desktop computer use is unavailable.');
+            enabled = true;
+            await refresh();
+            publish();
+            return { message: 'Computer use is ready to configure in Activity.' };
+          }
+          if (actionId === 'doctor') {
+            await refresh();
+            return {
+              message:
+                client === undefined
+                  ? 'DoomPi Desktop session API is unavailable.'
+                  : `Computer use is ${state?.phase.replaceAll('_', ' ') ?? 'unavailable'}.`,
+            };
+          }
+          if (actionId === 'deactivate') {
+            if (client === undefined) throw new Error('DoomPi Desktop computer use is unavailable.');
+            if (state !== undefined && state.phase !== 'inactive' && state.phase !== 'failed')
+              await client.stop(execution.signal);
+            enabled = false;
+            await refresh();
+            publish();
+            return { message: 'Computer use is off.' };
+          }
+          throw new Error(`Unknown computer-use action: ${actionId}`);
+        },
+      });
+    syncModeOwner = (): void => {
+      if (globallyEnabled && mode === undefined) {
+        publishedMode = '';
+        mode = registerOwner();
+      } else if (!globallyEnabled && mode !== undefined) {
+        mode.dispose();
+        mode = undefined;
+        publishedMode = '';
+      }
+    };
+    syncModeOwner();
     return () => {
-      owner.dispose();
-      if (mode === owner) mode = undefined;
+      syncModeOwner = () => undefined;
+      mode?.dispose();
+      mode = undefined;
     };
   });
 
   pi.on('before_agent_start', (event) =>
-    state?.phase === 'active' ? { systemPrompt: `${event.systemPrompt}\n\n${COMPUTER_USE_GUIDANCE}` } : undefined,
+    globallyEnabled && state?.phase === 'active'
+      ? { systemPrompt: `${event.systemPrompt}\n\n${COMPUTER_USE_GUIDANCE}` }
+      : undefined,
   );
   pi.on('session_start', (_event, context) => {
     activeContext = context;

--- a/packages/minor/doompi-computer-use/src/container/index.ts
+++ b/packages/minor/doompi-computer-use/src/container/index.ts
@@ -1,3 +1,4 @@
+import { loadDoomConfig } from '@agimon-ai/doompi-config';
 import { createComputerUseSessionClient } from '../adapters/pi/sessionApiClient.ts';
 import { DefaultComputerUseExtensionService } from '../services/extensionService.ts';
 import type { ComputerUseExtensionDependencies } from '../types/extension.ts';
@@ -8,6 +9,9 @@ export function createComputerUseContainer(
   const client = overrides.client ?? createComputerUseSessionClient();
   return {
     service: overrides.service ?? new DefaultComputerUseExtensionService(client),
+    enabled:
+      overrides.enabled ??
+      (() => loadDoomConfig(process.env.PI_PROJECT_ROOT ?? process.cwd()).computerUse?.enabled === true),
     ...(client === undefined ? {} : { client }),
   };
 }

--- a/packages/minor/doompi-computer-use/src/types/extension.ts
+++ b/packages/minor/doompi-computer-use/src/types/extension.ts
@@ -14,4 +14,5 @@ export interface ComputerUseExtensionService {
 export interface ComputerUseExtensionDependencies {
   service: ComputerUseExtensionService;
   client?: ComputerUseSessionClient;
+  enabled?: () => boolean | Promise<boolean>;
 }

--- a/packages/minor/doompi-computer-use/src/web/computerUseSettings.ts
+++ b/packages/minor/doompi-computer-use/src/web/computerUseSettings.ts
@@ -1,0 +1,17 @@
+import type { SettingsSectionContribution } from '@agimon-ai/doompi-web-contracts';
+
+export const computerUseSettingsSection: SettingsSectionContribution = {
+  id: 'computer-use',
+  label: 'computer use',
+  detail: 'control whether DoomPi Desktop may expose session-scoped computer control',
+  order: 45,
+  fields: [
+    {
+      id: 'enabled',
+      label: 'enable computer use',
+      kind: 'toggle',
+      keyPath: ['computerUse', 'enabled'],
+      detail: 'Makes the computer-use minor mode available. Each control session still requires native confirmation.',
+    },
+  ],
+};

--- a/packages/minor/doompi-computer-use/src/web/index.ts
+++ b/packages/minor/doompi-computer-use/src/web/index.ts
@@ -10,6 +10,7 @@ import { ComputerStateToolCard } from './ComputerStateToolCard.tsx';
 import { computerStateToolName } from './computerStateToolRender.ts';
 import { ComputerUsePanel } from './ComputerUsePanel.tsx';
 import { computerUseChannel } from './computerUseStore.ts';
+import { computerUseSettingsSection } from './computerUseSettings.ts';
 
 export const webPlugin = defineWebPlugin({
   id: 'computer-use',
@@ -19,6 +20,7 @@ export const webPlugin = defineWebPlugin({
       modeId: COMPUTER_USE_MODE_ID,
       keys: 'c e',
       statusKey: COMPUTER_USE_MODE_STATUS_KEY,
+      hideWhenMissing: true,
       order: 70,
     },
   ],
@@ -32,6 +34,7 @@ export const webPlugin = defineWebPlugin({
       marksBackgroundWork: false,
     },
   ],
+  settingsSections: [computerUseSettingsSection],
   activitySections: [{ id: 'computer-use', component: ComputerUsePanel }],
   channels: [computerUseChannel],
   toolRenderers: [

--- a/packages/minor/doompi-computer-use/tests/integration/extensions/pi.test.ts
+++ b/packages/minor/doompi-computer-use/tests/integration/extensions/pi.test.ts
@@ -37,7 +37,7 @@ describe('doompi-computer-use Pi extension', () => {
     const service: ComputerUseExtensionService = {
       execute: vi.fn().mockResolvedValue({ message: 'ready', level: 'info' }),
     };
-    await activateComputerUseExtension(host.pi, { service });
+    await activateComputerUseExtension(host.pi, { service, enabled: () => true });
     await host.runCommand(COMMAND_NAME);
     expect(service.execute).toHaveBeenCalledOnce();
     expect(host.notifications).toEqual([{ sessionId: 'test-session', message: 'ready', level: 'info' }]);
@@ -48,6 +48,7 @@ describe('doompi-computer-use Pi extension', () => {
     const host = createPiTestHost();
     host.pi.setActiveTools(['read']);
     let phase: 'active' | 'inactive' | 'awaiting_confirmation' = 'inactive';
+    let globallyEnabled = true;
     const client: ComputerUseSessionClient = {
       state: vi.fn(async (): Promise<ComputerUseSessionView> => ({
         sessionId: 'test-session',
@@ -66,6 +67,7 @@ describe('doompi-computer-use Pi extension', () => {
     };
     const dependencies: ComputerUseExtensionDependencies = {
       client,
+      enabled: () => globallyEnabled,
       service: { execute: vi.fn(async () => ({ message: 'active', level: 'info' as const })) },
     };
     await activateComputerUseExtension(host.pi, dependencies);
@@ -117,6 +119,16 @@ describe('doompi-computer-use Pi extension', () => {
     ).resolves.toMatchObject({ details: { applied: true } });
     const prompts = await host.emit('before_agent_start', { systemPrompt: 'base' });
     expect(prompts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ systemPrompt: expect.stringContaining('COMPUTER USE ACTIVE') }),
+      ]),
+    );
+
+    globallyEnabled = false;
+    await host.emit('session_start', {});
+    await vi.waitFor(() => expect(client.stop).toHaveBeenCalledOnce());
+    expect(host.activeTools()).toEqual(['read']);
+    expect(await host.emit('before_agent_start', { systemPrompt: 'base' })).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ systemPrompt: expect.stringContaining('COMPUTER USE ACTIVE') }),
       ]),

--- a/packages/minor/doompi-computer-use/tests/web/computerUsePanel.test.ts
+++ b/packages/minor/doompi-computer-use/tests/web/computerUsePanel.test.ts
@@ -44,7 +44,18 @@ describe('computer-use panel', () => {
   it('registers as a default-off minor mode and Activity section without a permanent tab', () => {
     expect(webPlugin.tabs).toBeUndefined();
     expect(webPlugin.minorModes).toEqual([
-      expect.objectContaining({ name: 'computer use', modeId: 'computer-use', statusKey: 'doom-computer-use-mode' }),
+      expect.objectContaining({
+        name: 'computer use',
+        modeId: 'computer-use',
+        statusKey: 'doom-computer-use-mode',
+        hideWhenMissing: true,
+      }),
+    ]);
+    expect(webPlugin.settingsSections).toEqual([
+      expect.objectContaining({
+        id: 'computer-use',
+        fields: [expect.objectContaining({ kind: 'toggle', keyPath: ['computerUse', 'enabled'] })],
+      }),
     ]);
     expect(webPlugin.activityGroups).toEqual([
       expect.objectContaining({ name: 'computer-use', statusKey: 'doom-computer-use', hideWhenEmpty: true }),

--- a/packages/minor/doompi-plan/package.json
+++ b/packages/minor/doompi-plan/package.json
@@ -106,6 +106,7 @@
     "@agimon-ai/doompi-telemetry": "workspace:*",
     "@agimon-ai/doompi-web-components": "workspace:*",
     "@agimon-ai/doompi-web-contracts": "workspace:*",
+    "@agimon-ai/doompi-web-security": "workspace:*",
     "@deepseek-ai/cordis": "4.0.1",
     "hono": "4.13.5"
   },

--- a/packages/minor/doompi-plan/src/web/planApi.ts
+++ b/packages/minor/doompi-plan/src/web/planApi.ts
@@ -1,3 +1,4 @@
+import { sealedTransport } from '@agimon-ai/doompi-web-security/browser';
 import { contentUrl, currentUrl, type PlanDetailView, type PlanSaveView } from '../types/planApi.ts';
 
 /**
@@ -34,7 +35,7 @@ export type FetchPlanResult = { ok: true; detail: PlanDetailView } | { ok: false
 export async function fetchPlan(sessionId: string): Promise<FetchPlanResult> {
   let response: Response;
   try {
-    response = await fetch(currentUrl(sessionId));
+    response = await sealedTransport.fetch(currentUrl(sessionId));
   } catch {
     return { ok: false, error: UNREACHABLE };
   }
@@ -54,7 +55,7 @@ export type SavePlanResult =
 export async function savePlan(sessionId: string, expectedHash: string, content: string): Promise<SavePlanResult> {
   let response: Response;
   try {
-    response = await fetch(contentUrl(sessionId), {
+    response = await sealedTransport.fetch(contentUrl(sessionId), {
       method: 'PUT',
       headers: JSON_HEADERS,
       body: JSON.stringify({ expectedHash, content }),

--- a/packages/minor/doompi-plan/tests/webPlanApi.test.ts
+++ b/packages/minor/doompi-plan/tests/webPlanApi.test.ts
@@ -1,6 +1,9 @@
+import { sealedTransport } from '@agimon-ai/doompi-web-security/browser';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { contentUrl, currentUrl } from '../src/types/planApi.ts';
 import { fetchPlan, savePlan } from '../src/web/planApi.ts';
+
+vi.mock('@agimon-ai/doompi-web-security/browser', () => ({ sealedTransport: { fetch: vi.fn() } }));
 
 /**
  * The page's half of the session API.
@@ -12,20 +15,18 @@ import { fetchPlan, savePlan } from '../src/web/planApi.ts';
  * reported as an ordinary failure and the reader retries into a clobber.
  */
 
-const realFetch = globalThis.fetch;
+const transport = vi.mocked(sealedTransport.fetch);
 
 function answering(status: number, body?: unknown): void {
-  globalThis.fetch = vi.fn(async () =>
-    Promise.resolve(new Response(body === undefined ? '' : JSON.stringify(body), { status })),
-  ) as typeof globalThis.fetch;
+  transport.mockResolvedValue(new Response(body === undefined ? '' : JSON.stringify(body), { status }));
 }
 
 function refusing(): void {
-  globalThis.fetch = vi.fn(async () => Promise.reject(new Error('offline'))) as typeof globalThis.fetch;
+  transport.mockRejectedValue(new Error('offline'));
 }
 
 afterEach(() => {
-  globalThis.fetch = realFetch;
+  transport.mockReset();
 });
 
 describe('reading the plan from the page', () => {
@@ -34,7 +35,7 @@ describe('reading the plan from the page', () => {
 
     await fetchPlan('s1');
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(currentUrl('s1'));
+    expect(transport).toHaveBeenCalledWith(currentUrl('s1'));
   });
 
   it('answers the plan the session sent', async () => {
@@ -73,7 +74,7 @@ describe('saving the plan from the page', () => {
 
     const result = await savePlan('s1', 'held', '# edited');
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(
+    expect(transport).toHaveBeenCalledWith(
       contentUrl('s1'),
       expect.objectContaining({ method: 'PUT', body: JSON.stringify({ expectedHash: 'held', content: '# edited' }) }),
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,9 @@ importers:
       '@agimon-ai/doompi':
         specifier: workspace:*
         version: link:../../core/doompi
+      '@agimon-ai/doompi-config':
+        specifier: workspace:*
+        version: link:../../core/doompi-config
       '@agimon-ai/doompi-server':
         specifier: workspace:*
         version: link:../doompi-server
@@ -1987,6 +1990,9 @@ importers:
 
   packages/minor/doompi-computer-use:
     dependencies:
+      '@agimon-ai/doompi-config':
+        specifier: workspace:*
+        version: link:../../core/doompi-config
       '@agimon-ai/doompi-extension-contracts':
         specifier: workspace:*
         version: link:../../core/doompi-extension-contracts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2195,6 +2195,9 @@ importers:
       '@agimon-ai/doompi-web-contracts':
         specifier: workspace:*
         version: link:../../core/doompi-web-contracts
+      '@agimon-ai/doompi-web-security':
+        specifier: workspace:*
+        version: link:../../core/doompi-web-security
       '@deepseek-ai/cordis':
         specifier: 4.0.1
         version: 4.0.1


### PR DESCRIPTION
## Summary
- add a global-only `computerUse.enabled` setting that defaults off
- hide and block the computer-use minor mode until enabled
- stop active control and remove tools when the setting is disabled
- enforce the preference in the desktop host, including confirmation races
- add contributed settings UI and focused regression coverage

## Verification
- `pnpm lint:vibe --preflight-only`
- affected Nx lint, typecheck, and build targets
- `@agimon-ai/doompi-web-contracts:test`
- `@agimon-ai/doompi-computer-use:test`
- `@agimon-ai/doompi-web:test`
- `@agimon-ai/doompi-desktop:test`
- focused `doompi-config` config-scope tests, 18 passing

## Known repository test issue
The full `@agimon-ai/doompi-config:test` target still reports six lifecycle failures because the composed Doom Cordis host is unavailable. The focused changed config tests pass.
