### PR TITLE
fix(web): close dialogs from nested select backdrops

### DIFF
--- a/packages/clients/doompi-web/tests/e2e/activity.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/activity.spec.ts
@@ -33,6 +33,26 @@ test('keeps the workflow launcher available before any package reports work', as
   await expect(page.getByTestId('activity-empty')).toBeHidden();
 });
 
+test('keeps the prompts dialog interactive after outside dismissal and reopening', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForAttach();
+
+  const dialog = page.getByTestId('prompts-dialog');
+  await page.getByTestId('activity-prompts-open').click();
+  await expect(dialog).toBeVisible();
+  await page.getByTestId('prompts-filter').fill('dismiss before reopening');
+  await page.locator('[data-slot="dialog-overlay"]').click({ position: { x: 8, y: 8 } });
+  await expect(dialog).toBeHidden();
+
+  await page.getByTestId('activity-prompts-open').click();
+  await expect(dialog).toBeVisible();
+  await page.getByTestId('prompts-filter').fill('interactive after reopening');
+  await expect(page.getByTestId('prompts-filter')).toHaveValue('interactive after reopening');
+  await page.getByTestId('prompts-new').click();
+  await expect(page.getByTestId('prompts-name')).toBeVisible();
+  await expect(page.getByTestId('prompts-text')).toBeVisible();
+});
+
 test('lists the groups whose packages report in, each rendered by its own plugin', async ({ page, cockpit }) => {
   await page.goto(cockpit.url);
   await cockpit.session.waitForAttach();

--- a/packages/clients/doompi-web/tests/e2e/dialogs.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/dialogs.spec.ts
@@ -114,6 +114,48 @@ test('cancelling tells the agent instead of stranding it', async ({ page, cockpi
   await expect(page.getByTestId('dialog')).toBeHidden();
 });
 
+test('answers a reopened dialog after outside dismissal', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForAttach();
+
+  cockpit.session.emit({
+    type: 'extension_ui_request',
+    id: 'outside-first',
+    method: 'select',
+    title: 'dismiss this request',
+    options: ['a', 'b'],
+  });
+  await expect(page.getByTestId('dialog')).toBeVisible();
+  await page.locator('[data-slot="dialog-overlay"]').click({ position: { x: 8, y: 8 } });
+  await expect(page.getByTestId('dialog')).toBeHidden();
+  await expect
+    .poll(() =>
+      cockpit.session.received.some(
+        (frame) => frame.type === 'extension_ui_response' && frame.id === 'outside-first' && frame.cancelled === true,
+      ),
+    )
+    .toBe(true);
+
+  cockpit.session.emit({
+    type: 'extension_ui_request',
+    id: 'outside-second',
+    method: 'select',
+    title: 'answer after reopening',
+    options: ['reopened', 'cancel'],
+  });
+  await expect(page.getByTestId('dialog-title')).toHaveText('answer after reopening');
+  await page.getByTestId('dialog-option-0').click();
+
+  await expect
+    .poll(() =>
+      cockpit.session.received.some(
+        (frame) =>
+          frame.type === 'extension_ui_response' && frame.id === 'outside-second' && frame.value === 'reopened',
+      ),
+    )
+    .toBe(true);
+});
+
 test('a long option list is reachable from the keyboard past the ninth', async ({ page, cockpit }) => {
   await page.goto(cockpit.url);
   await cockpit.session.waitForAttach();

--- a/packages/clients/doompi-web/tests/e2e/model.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/model.spec.ts
@@ -44,6 +44,20 @@ test('picks a model from the chip popup and asks the session to switch', async (
   await expect(popup.getByTestId('model-openai-gpt-5.6-sol')).toHaveAttribute('data-current', 'true');
   await expect(popup.getByTestId('thinking-max')).toHaveAttribute('data-current', 'true');
 
+  await page.getByTestId('model-filter').fill('dismiss before reopening');
+  await page.getByTestId('top-bar').click({ position: { x: 8, y: 8 } });
+  await expect(popup).toBeHidden();
+
+  const modelRequests = () => cockpit.session.received.filter((frame) => frame.type === 'get_available_models').length;
+  const levelRequests = () =>
+    cockpit.session.received.filter((frame) => frame.type === 'get_available_thinking_levels').length;
+  await page.getByTestId('axis-model').click();
+  await expect.poll(modelRequests).toBe(2);
+  await expect.poll(levelRequests).toBe(2);
+  cockpit.session.emit(MODELS);
+  cockpit.session.emit(LEVELS);
+  await expect(popup).toBeVisible();
+
   await page.getByTestId('model-filter').fill('opus');
   await expect(popup.getByTestId('model-anthropic-claude-haiku-4-5')).toBeHidden();
   await popup.getByTestId('model-anthropic-claude-opus-5').click();

--- a/packages/clients/doompi-web/tests/e2e/subagents.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/subagents.spec.ts
@@ -80,6 +80,12 @@ test('shows the session fleet in the subagents tab', async ({ page, cockpit }) =
   await expect(page.getByTestId('sheet-agent')).toHaveText('reviewer');
   await expect(page.getByTestId('sheet-task')).toContainText('Review the diff before the cut.');
   await expect(page.getByTestId('run-sheet').getByTestId('thread-timeline')).toHaveCount(0);
+  await page.locator('[data-slot="sheet-overlay"]').click({ position: { x: 8, y: 8 } });
+  await expect(page.getByTestId('run-sheet')).toBeHidden();
+
+  await page.getByTestId('run-menu-run-a').click();
+  await page.getByTestId('run-detail-run-a').click();
+  await expect(page.getByTestId('run-sheet')).toBeVisible();
   await page.getByTestId('run-sheet').getByLabel('close the run detail').click();
   await expect(page.getByTestId('run-sheet')).toBeHidden();
 
@@ -288,6 +294,33 @@ test('the activity dock lists the runs and opens one in a temporary agent tab', 
   await page.getByTestId('tab-subagents-run-run-dock-close').click();
   await expect(page).toHaveURL(/\/session\/s1$/);
   await expect(chip).toHaveCount(0);
+});
+
+test('a dialog with an open select dismisses and reopens with working controls', async ({ page, cockpit }) => {
+  writeAgentDefinition(cockpit.agentDir, 'nested-overlay-e2e', 'Exercises a nested overlay lifecycle.');
+
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForAttach();
+  await page.getByTestId('activity-open-agents').click();
+  await page.getByTestId('subagents-launch').click();
+  await page.getByTestId('catalog-filter').fill('nested-overlay-e2e');
+  await page.getByTestId('catalog-agent-nested-overlay-e2e').click();
+  await page.getByTestId('catalog-launch-nested-overlay-e2e').click();
+
+  const launchDialog = page.getByTestId('launch-dialog');
+  await expect(launchDialog).toBeVisible();
+  await page.getByTestId('launch-model').click();
+  await expect(page.locator('[data-slot="select-content"]')).toBeVisible();
+
+  await page.locator('[data-slot="dialog-overlay"]').click({ position: { x: 8, y: 8 } });
+  await expect(page.locator('[data-slot="select-content"]')).toHaveCount(0);
+  await expect(launchDialog).toBeHidden();
+
+  await page.getByTestId('catalog-launch-nested-overlay-e2e').click();
+  await expect(launchDialog).toBeVisible();
+  await page.getByTestId('launch-task').fill('Still interactive.');
+  await page.getByTestId('launch-fork').click();
+  await expect(page.getByTestId('launch-command')).toHaveText('/run nested-overlay-e2e Still interactive. --fork');
 });
 
 test('the catalog lists the agents the session can launch and launches one through /run', async ({ page, cockpit }) => {

--- a/packages/core/doompi-web-components/src/components/Dialog.tsx
+++ b/packages/core/doompi-web-components/src/components/Dialog.tsx
@@ -1,16 +1,22 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Dialog as DialogPrimitive } from 'radix-ui';
-import type { ComponentProps } from 'react';
+import { createContext, type ComponentProps, useContext } from 'react';
 import { CloseIcon } from '../icons/icons.ts';
 import { cn } from '../lib/cn.ts';
 import { Button } from './Button.tsx';
 
+const DialogOpenChangeContext = createContext<((open: boolean) => void) | undefined>(undefined);
 /**
  * shadcn's Dialog on Radix: focus trap, Escape, outside click, scroll lock,
  * and focus restored to the trigger on close. The frame is the Doom panel.
  */
 export function Dialog(props: ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+  const onOpenChange = props.onOpenChange === undefined ? undefined : (open: boolean) => props.onOpenChange?.(open);
+  return (
+    <DialogOpenChangeContext.Provider value={onOpenChange}>
+      <DialogPrimitive.Root data-slot="dialog" {...props} onOpenChange={onOpenChange} />
+    </DialogOpenChangeContext.Provider>
+  );
 }
 
 export function DialogTrigger(props: ComponentProps<typeof DialogPrimitive.Trigger>) {
@@ -25,11 +31,28 @@ export function DialogClose(props: ComponentProps<typeof DialogPrimitive.Close>)
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
-export function DialogOverlay({ className, ...props }: ComponentProps<typeof DialogPrimitive.Overlay>) {
+export function DialogOverlay({
+  className,
+  onPointerDownCapture,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Overlay>) {
+  const onOpenChange = useContext(DialogOpenChangeContext);
   return (
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn('fixed inset-0 z-40 bg-doom-deep/70 data-[state=open]:animate-doom-fade', className)}
+      onPointerDownCapture={(event) => {
+        onPointerDownCapture?.(event);
+        if (event.defaultPrevented || onOpenChange === undefined) return;
+        const dialogContent = event.currentTarget.nextElementSibling;
+        const openSelectTrigger = dialogContent?.querySelector('[data-slot="select-trigger"][data-state="open"]');
+        if (openSelectTrigger === null || openSelectTrigger === undefined) return;
+
+        // Radix's parent outside listener can lag one render behind a nested
+        // modal Select. Own this backdrop press so the complete stack closes.
+        event.stopPropagation();
+        onOpenChange(false);
+      }}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

- close a parent dialog when its backdrop is pressed while a nested select is open
- cover activity, model, subagent, and dialog flows with regression tests

## Verification

- `pnpm lint:vibe --preflight-only`
- affected lint and typecheck targets
- `@agimon-ai/doompi-web-components` build and tests
- `@agimon-ai/doompi-web` build

## Local test note

`@agimon-ai/doompi-web:test` had one integration failure in `tests/integration/bridge.test.ts` because the bare server returned registered plugin channels instead of an empty channel list. The changed dialog and E2E files are not involved in that assertion.