### PR TITLE
fix(doompi-prompt): improve web prompt library UX

### DIFF
--- a/packages/clients/doompi-web/src/web/features/session/Timeline.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/Timeline.tsx
@@ -1,3 +1,4 @@
+import type { UserMessageActionRunContext } from '@agimon-ai/doompi-web-contracts';
 import {
   Avatar,
   AvatarFallback,
@@ -18,8 +19,9 @@ import { useStore } from '@tanstack/react-store';
 import type { Store } from '@tanstack/store';
 import { useActivityGroups } from '../../lib/composition.ts';
 import { parseFileMentions } from '../../lib/fileMentions.ts';
-import { pluginToolRenderer } from '../../lib/pluginRegistry.ts';
+import { pluginToolRenderer, pluginUserMessageActions } from '../../lib/pluginRegistry.ts';
 import { focusPrompt } from '../../lib/promptFocus.ts';
+import { useWebPluginRegistry } from '../../stores/useWebPluginRegistry.ts';
 import {
   isSupportedImageMimeType,
   type SessionState,
@@ -117,16 +119,35 @@ function MessageActions({
   disabled,
   onQuote,
   onRewind,
+  userMessage,
 }: {
   disabled: boolean;
   onQuote: () => void;
   onRewind: () => void;
+  userMessage?: UserMessageActionRunContext;
 }) {
   return (
     <div
       data-testid="entry-actions"
-      className="pointer-events-none absolute right-1 bottom-0 z-10 flex translate-y-1/2 gap-1 rounded-md border border-doom-border-soft bg-doom-panel p-0.5 opacity-0 shadow-sm transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 group-focus-within/message:pointer-events-auto group-focus-within/message:opacity-100 [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100"
+      className="pointer-events-none absolute right-1 bottom-0 z-10 flex max-w-[calc(100%-0.5rem)] translate-y-1/2 flex-wrap justify-end gap-1 rounded-md border border-doom-border-soft bg-doom-panel p-0.5 opacity-0 shadow-sm transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 group-focus-within/message:pointer-events-auto group-focus-within/message:opacity-100 [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100"
     >
+      {userMessage
+        ? pluginUserMessageActions().map((action) => (
+            <Button
+              key={`${action.pluginId}.${action.id}`}
+              variant="subtle"
+              size="sm"
+              data-testid="entry-plugin-action"
+              aria-label={action.label}
+              title={action.label}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => action.run(userMessage)}
+              className="h-6 border-0 px-2 text-[10px] shadow-none"
+            >
+              {action.label}
+            </Button>
+          ))
+        : null}
       <Button
         variant="subtle"
         size="icon"
@@ -216,6 +237,7 @@ function ToolGroupRow({
   );
 }
 const Entry = memo(function Entry({ entry, sessionId }: { entry: TimelineEntry; sessionId: string | null }) {
+  useWebPluginRegistry();
   const sessionStreaming = useActiveSession((state) => state.streaming);
   const quoteSource = useRef<HTMLDivElement>(null);
   const quoteMessage = (text: string): void => {
@@ -268,6 +290,11 @@ const Entry = memo(function Entry({ entry, sessionId }: { entry: TimelineEntry; 
             disabled={sessionStreaming}
             onQuote={() => quoteMessage(entry.text)}
             onRewind={() => rewindToMessage(entry.id, sessionId)}
+            userMessage={
+              sessionId !== null && entry.text.trim().length > 0
+                ? { sessionId, messageId: entry.id, text: entry.text }
+                : undefined
+            }
           />
         </div>
         <SpeakerAvatar speaker="user" />

--- a/packages/clients/doompi-web/src/web/lib/pluginRegistry.ts
+++ b/packages/clients/doompi-web/src/web/lib/pluginRegistry.ts
@@ -16,6 +16,7 @@ import type {
   SurfaceContribution,
   TabContribution,
   ToolRendererContribution,
+  UserMessageActionContribution,
   WebPluginDefinition,
   WebPluginRuntime,
   WebPluginSlotProps,
@@ -78,6 +79,9 @@ export interface InstalledContextAction extends ContextActionContribution {
   pluginId: string;
 }
 
+export interface InstalledUserMessageAction extends UserMessageActionContribution {
+  pluginId: string;
+}
 /** The slots the host itself declares; a plugin's own slots are namespaced by its id instead. */
 export const HOST_SLOTS = {
   overlay: 'overlay',
@@ -104,6 +108,7 @@ interface RegistryState {
   channels: Map<string, SessionChannelContribution>;
   commands: PaletteCommandContribution[];
   contextActions: InstalledContextAction[];
+  userMessageActions: InstalledUserMessageAction[];
   leaderBindings: LeaderBindingContribution[];
   selectionAxes: SelectionAxisContribution[];
   minorModes: MinorModeContribution[];
@@ -126,6 +131,7 @@ function emptyState(): RegistryState {
     channels: new Map(),
     commands: [],
     contextActions: [],
+    userMessageActions: [],
     leaderBindings: [],
     selectionAxes: [],
     minorModes: [],
@@ -274,6 +280,15 @@ function checkContextAction(pluginId: string, seen: Set<string>, action: Context
   seen.add(action.id);
 }
 
+function checkUserMessageAction(pluginId: string, seen: Set<string>, action: UserMessageActionContribution): void {
+  if (action.id.trim() === '') throw new Error(`Web plugin '${pluginId}' has a user message action with an empty id.`);
+  if (seen.has(action.id))
+    throw new Error(`Web plugin '${pluginId}' declares user message action '${action.id}' twice.`);
+  if (action.label.trim() === '')
+    throw new Error(`Web plugin '${pluginId}' user message action '${action.id}' has an empty label.`);
+  seen.add(action.id);
+}
+
 const byFillOrder = (left: ResolvedFill, right: ResolvedFill): number =>
   left.order - right.order || left.pluginId.localeCompare(right.pluginId) || left.id.localeCompare(right.id);
 
@@ -415,6 +430,11 @@ function buildWebPluginState(plugins: readonly WebPluginDefinition[]): RegistryS
         checkContextAction(plugin.id, contextActions, action);
         installingState.contextActions.push({ pluginId: plugin.id, ...action });
       }
+      const userMessageActions = new Set<string>();
+      for (const action of plugin.userMessageActions ?? []) {
+        checkUserMessageAction(plugin.id, userMessageActions, action);
+        installingState.userMessageActions.push({ pluginId: plugin.id, ...action });
+      }
       for (const binding of plugin.leaderBindings ?? []) {
         checkLeaderBinding(plugin.id, binding);
         pendingBindings.push({ pluginId: plugin.id, binding });
@@ -484,6 +504,12 @@ function buildWebPluginState(plugins: readonly WebPluginDefinition[]): RegistryS
     resolveLeaderConflicts(pendingBindings);
     installingState.leaderBindings.push(...pendingBindings.map((entry) => entry.binding));
     installingState.contextActions.sort(
+      (left, right) =>
+        (left.order ?? DEFAULT_FILL_ORDER) - (right.order ?? DEFAULT_FILL_ORDER) ||
+        left.pluginId.localeCompare(right.pluginId) ||
+        left.id.localeCompare(right.id),
+    );
+    installingState.userMessageActions.sort(
       (left, right) =>
         (left.order ?? DEFAULT_FILL_ORDER) - (right.order ?? DEFAULT_FILL_ORDER) ||
         left.pluginId.localeCompare(right.pluginId) ||
@@ -623,6 +649,11 @@ export function paletteCommands(): readonly PaletteCommandContribution[] {
 /** Context actions from every installed plugin, in stable display order. */
 export function pluginContextActions(): readonly InstalledContextAction[] {
   return activeState().contextActions;
+}
+
+/** User-message actions from every installed plugin, in stable display order. */
+export function pluginUserMessageActions(): readonly InstalledUserMessageAction[] {
+  return activeState().userMessageActions;
 }
 
 /** Leader Space bindings from every installed plugin, in install order: a later binding on a bound leaf wins. */

--- a/packages/clients/doompi-web/tests/unit/Timeline.test.ts
+++ b/packages/clients/doompi-web/tests/unit/Timeline.test.ts
@@ -1,0 +1,51 @@
+import { defineWebPlugin } from '@agimon-ai/doompi-web-contracts';
+import { Store } from '@tanstack/store';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Transcript } from '../../src/web/features/session/Timeline.tsx';
+import { initialSessionState } from '../../src/web/lib/sessionModel.ts';
+import { installWebPlugins, resetWebPlugins } from '../../src/web/lib/pluginRegistry.ts';
+
+vi.mock('../../src/web/features/session/MessageMarkdown.tsx', () => ({
+  MessageMarkdown: ({ text }: { text: string }) => createElement('span', null, text),
+}));
+
+vi.mock('../../src/web/features/session/MentionPreviews.tsx', () => ({
+  MentionPreviews: () => null,
+}));
+
+afterEach(() => resetWebPlugins());
+
+describe('Timeline user-message actions', () => {
+  it('renders contributed actions only for user entries with nonempty text and keeps message controls', () => {
+    installWebPlugins([
+      defineWebPlugin({
+        id: 'capture',
+        userMessageActions: [{ id: 'save', label: 'Save prompt', run: () => undefined }],
+      }),
+    ]);
+    const store = new Store({
+      ...initialSessionState,
+      entries: [
+        { kind: 'user' as const, id: 'user-text', text: 'capture me' },
+        { kind: 'user' as const, id: 'user-image', text: '', images: [{ mimeType: 'image/png', data: 'cG5n' }] },
+        { kind: 'user' as const, id: 'user-whitespace', text: '   ' },
+        { kind: 'assistant' as const, id: 'assistant', text: 'capture me', thinking: '', streaming: false },
+      ],
+    });
+
+    const markup = renderToStaticMarkup(
+      createElement(Transcript, {
+        store,
+        sessionId: 'session-1',
+        empty: createElement('div'),
+      }),
+    );
+
+    expect(markup.match(/data-testid="entry-plugin-action"/g)).toHaveLength(1);
+    expect(markup).toContain('Save prompt');
+    expect(markup.match(/data-testid="entry-rewind"/g)).toHaveLength(4);
+    expect(markup.match(/data-testid="entry-quote"/g)).toHaveLength(4);
+  });
+});

--- a/packages/clients/doompi-web/tests/unit/pluginRegistry.test.ts
+++ b/packages/clients/doompi-web/tests/unit/pluginRegistry.test.ts
@@ -14,6 +14,7 @@ import {
   pluginContextActions,
   pluginDockFaces,
   pluginLeaderBindings,
+  pluginUserMessageActions,
   pluginMinorModes,
   pluginRepositorySettingsPanels,
   pluginSelectionAxes,
@@ -157,6 +158,55 @@ describe('the web plugin registry', () => {
     expect(webPluginDiagnostics()).toEqual([]);
 
     expect(() => installWebPlugins([])).toThrow(/already installed/);
+  });
+
+  it('collects user-message actions in stable display order and keeps plugin ids', () => {
+    installWebPlugins([
+      defineWebPlugin({
+        id: 'zeta',
+        userMessageActions: [
+          { id: 'later', label: 'Later', order: 20, run: () => undefined },
+          { id: 'same-order', label: 'Same order', run: () => undefined },
+        ],
+      }),
+      defineWebPlugin({
+        id: 'alpha',
+        userMessageActions: [{ id: 'first', label: 'First', order: 10, run: () => undefined }],
+      }),
+    ]);
+
+    expect(pluginUserMessageActions().map(({ pluginId, id }) => [pluginId, id])).toEqual([
+      ['alpha', 'first'],
+      ['zeta', 'later'],
+      ['zeta', 'same-order'],
+    ]);
+  });
+
+  it('separates user-message action ids by plugin and rejects duplicates inside one plugin', () => {
+    installWebPlugins([
+      defineWebPlugin({
+        id: 'one',
+        userMessageActions: [{ id: 'capture', label: 'Capture', run: () => undefined }],
+      }),
+      defineWebPlugin({
+        id: 'two',
+        userMessageActions: [{ id: 'capture', label: 'Capture again', run: () => undefined }],
+      }),
+    ]);
+    expect(pluginUserMessageActions()).toHaveLength(2);
+
+    resetWebPlugins();
+    expect(() =>
+      installWebPlugins([
+        defineWebPlugin({
+          id: 'one',
+          userMessageActions: [
+            { id: 'capture', label: 'Capture', run: () => undefined },
+            { id: 'capture', label: 'Again', run: () => undefined },
+          ],
+        }),
+      ]),
+    ).toThrow(/user message action 'capture' twice/);
   });
 
   it('orders repository management panels without sharing repository ownership with plugins', () => {

--- a/packages/core/doompi-web-contracts/src/exports/index.ts
+++ b/packages/core/doompi-web-contracts/src/exports/index.ts
@@ -68,6 +68,8 @@ export type {
   ToolRendererContribution,
   ToolResultView,
   TransientTab,
+  UserMessageActionContribution,
+  UserMessageActionRunContext,
   WebPluginContextInventoryItem,
   WebPluginContextItem,
   WebPluginDefinition,

--- a/packages/core/doompi-web-contracts/src/types/webPlugin.ts
+++ b/packages/core/doompi-web-contracts/src/types/webPlugin.ts
@@ -143,6 +143,25 @@ export interface ContextAction {
   run(): void;
 }
 
+/** The text-bearing user timeline message handed to a plugin action. */
+export interface UserMessageActionRunContext {
+  sessionId: string;
+  /** Stable identity of the user message inside the session timeline. */
+  messageId: string;
+  /** The complete plain text carried by the user message. */
+  text: string;
+}
+
+/** An action a plugin contributes for every text-bearing user timeline message. */
+export interface UserMessageActionContribution {
+  /** Unique inside this plugin. */
+  id: string;
+  label: string;
+  /** Lower values appear first, then plugin id and action id. */
+  order?: number;
+  run(context: UserMessageActionRunContext): void;
+}
+
 /** Compact live inventory row exposed to Context slot components. */
 export interface WebPluginContextInventoryItem {
   name: string;
@@ -696,6 +715,8 @@ export interface WebPluginDefinition {
   paletteCommands?: PaletteCommandContribution[];
   /** Actions this plugin offers when another plugin presents compatible structured context. */
   contextActions?: ContextActionContribution[];
+  /** Actions this plugin offers on text-bearing user timeline messages. */
+  userMessageActions?: UserMessageActionContribution[];
   leaderBindings?: LeaderBindingContribution[];
   railSections?: SurfaceContribution[];
   /** Sections placed before the host's built-in Context composition groups. */

--- a/packages/core/doompi-web-contracts/tests/define.test.ts
+++ b/packages/core/doompi-web-contracts/tests/define.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { defineSessionChannel, defineWebPlugin } from '../src/services/define.ts';
-import type { SessionChannelContribution, WebPluginRuntime } from '../src/types/webPlugin.ts';
+import { defineSessionChannel, defineWebPlugin } from '../src/exports/index.ts';
+import type {
+  SessionChannelContribution,
+  UserMessageActionContribution,
+  UserMessageActionRunContext,
+  WebPluginRuntime,
+} from '../src/exports/index.ts';
 
 interface DemoPayload {
   items: string[];
@@ -34,6 +39,21 @@ describe('contract identity helpers', () => {
     const plugin = defineWebPlugin({ id: 'demo', channels: [channel] });
     expect(plugin.id).toBe('demo');
     expect(plugin.channels).toHaveLength(1);
+  });
+
+  it('exposes the user-message action context through an optional plugin contribution', () => {
+    const received: UserMessageActionRunContext[] = [];
+    const action: UserMessageActionContribution = {
+      id: 'capture',
+      label: 'Capture',
+      run: (context) => received.push(context),
+    };
+    const plugin = defineWebPlugin({ id: 'demo', userMessageActions: [action] });
+    const context = { sessionId: 's1', messageId: 'm1', text: 'hello' };
+
+    plugin.userMessageActions?.[0]?.run(context);
+
+    expect(received).toEqual([context]);
   });
 
   it('requires a page hub connection subscription on plugin runtimes', () => {

--- a/packages/default/doompi-prompt/README.md
+++ b/packages/default/doompi-prompt/README.md
@@ -61,8 +61,10 @@ cursor position, bind `tui.editor.historyPrevious` and `tui.editor.historyNext` 
 
 The package contributes a `prompts` group to the cockpit's activity dock, next to agents, runners
 and workflows, backed by a hub-scoped API at `/api/plugin/prompts`. The group reports how many
-prompts are saved and offers `send a prompt`, which opens a dialog over the conversation. Picking
-one sends it to the focused session; the same dialog creates, edits, renames and deletes entries.
+prompts are saved and offers `send a prompt`, which opens a list-first dialog over the conversation.
+Picking one sends it immediately to the focused session. The same dialog creates and edits entries,
+confirms replacements and removals, and refreshes the list after writes. Every text-bearing user
+message also offers `save as prompt`, opening the editor with that message text ready to name or edit.
 
 | Route                   | Purpose                                                             |
 | ----------------------- | ------------------------------------------------------------------- |

--- a/packages/default/doompi-prompt/src/web/components/PromptEditor.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptEditor.tsx
@@ -23,33 +23,42 @@ export interface PromptEditorProps {
 }
 
 export function PromptEditor({ draft, busy, onChange, onSave, onCancel }: PromptEditorProps) {
+  const editing = draft.original !== '';
   return (
-    <div data-testid="prompts-editor" className="flex flex-col gap-2 rounded-[5px] border border-doom-border p-2">
-      <Input
-        data-testid="prompts-name"
-        value={draft.name}
-        placeholder="name, lowercase letters, digits and dashes"
-        onChange={(event) => onChange({ ...draft, name: event.target.value })}
-      />
-      <Textarea
-        data-testid="prompts-text"
-        rows={8}
-        value={draft.text}
-        placeholder="the prompt text"
-        onChange={(event) => onChange({ ...draft, text: event.target.value })}
-      />
-      <div className="flex items-center gap-2">
-        <Button
-          size="xs"
-          className="text-[9px]"
-          data-testid="prompts-save"
-          disabled={busy || !canSaveDraft(draft)}
-          onClick={onSave}
-        >
-          save
-        </Button>
-        <Button variant="ghost" size="xs" className="text-[9px]" data-testid="prompts-cancel" onClick={onCancel}>
+    <div data-testid="prompts-editor" className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="prompts-name" className="text-[10px] font-bold text-doom-dim">
+          prompt name
+        </label>
+        <Input
+          id="prompts-name"
+          data-testid="prompts-name"
+          value={draft.name}
+          placeholder="lowercase letters, digits and dashes"
+          autoComplete="off"
+          autoFocus
+          onChange={(event) => onChange({ ...draft, name: event.target.value })}
+        />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="prompts-text" className="text-[10px] font-bold text-doom-dim">
+          prompt text
+        </label>
+        <Textarea
+          id="prompts-text"
+          data-testid="prompts-text"
+          rows={10}
+          value={draft.text}
+          placeholder="the prompt text"
+          onChange={(event) => onChange({ ...draft, text: event.target.value })}
+        />
+      </div>
+      <div className="flex items-center justify-end gap-2">
+        <Button variant="outline" size="md" data-testid="prompts-cancel" disabled={busy} onClick={onCancel}>
           cancel
+        </Button>
+        <Button size="md" data-testid="prompts-save" disabled={busy || !canSaveDraft(draft)} onClick={onSave}>
+          {busy ? 'saving…' : editing ? 'save changes' : 'save prompt'}
         </Button>
       </div>
     </div>

--- a/packages/default/doompi-prompt/src/web/components/PromptPickerList.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptPickerList.tsx
@@ -1,34 +1,30 @@
 import { Button, Input } from '@agimon-ai/doompi-web-components';
 import type { SavedPromptView } from '../../types/webPrompts.ts';
-import { PromptEditor } from './PromptEditor.tsx';
-import type { DraftState } from '../lib/promptsActions.ts';
 import { filterPrompts } from '../lib/promptsActions.ts';
 
 /**
- * The body of the prompt dialog: filter, rows, and the editor when one is open.
+ * The list-first body of the prompt dialog.
  *
  * DESIGN PATTERNS:
- * - Presentational and outside the dialog chrome, so it renders without a DOM
- *   portal and the tests can see it.
- * - Sending is the row's primary action; managing sits to its right.
+ * - Sending is the row's large primary target; management actions stay visible.
+ * - Loading, failure and empty states occupy the list instead of looking like a
+ *   successfully loaded empty library.
  *
  * AVOID:
- * - Fetching here. The dialog owns the calls, this owns the markup.
+ * - Fetching or mutating here. The dialog owns behavior, this owns markup.
  */
 
 export interface PromptPickerListProps {
   prompts: readonly SavedPromptView[];
   filter: string;
-  draft: DraftState | undefined;
+  loading: boolean;
   busy: boolean;
   error: string;
   onFilterChange: (filter: string) => void;
   onSend: (prompt: SavedPromptView) => void;
   onEdit: (prompt: SavedPromptView) => void;
-  onDelete: (name: string) => void;
-  onDraftChange: (draft: DraftState) => void;
-  onSave: () => void;
-  onCancelDraft: () => void;
+  onDelete: (prompt: SavedPromptView) => void;
+  onRetry: () => void;
 }
 
 export function PromptPickerList(props: PromptPickerListProps) {
@@ -43,66 +39,65 @@ export function PromptPickerList(props: PromptPickerListProps) {
         onChange={(event) => props.onFilterChange(event.target.value)}
       />
 
-      {props.error === '' ? null : (
-        <span className="text-[10px] text-doom-red" data-testid="prompts-error">
-          {props.error}
-        </span>
-      )}
-
-      {visible.length === 0 ? (
-        <p data-testid="prompts-empty" className="text-[11px] text-doom-faint">
-          {props.prompts.length === 0 ? 'no saved prompts yet' : 'nothing matches that filter'}
+      {props.loading ? (
+        <p data-testid="prompts-loading" className="py-4 text-center text-[11px] text-doom-faint">
+          loading prompts…
+        </p>
+      ) : props.error !== '' ? (
+        <div className="flex items-center justify-between gap-3 rounded-[5px] border border-doom-red/40 p-3">
+          <span className="text-[11px] text-doom-red" data-testid="prompts-error">
+            {props.error}
+          </span>
+          <Button variant="outline" size="sm" data-testid="prompts-retry" onClick={props.onRetry}>
+            retry
+          </Button>
+        </div>
+      ) : visible.length === 0 ? (
+        <p data-testid="prompts-empty" className="py-4 text-center text-[11px] text-doom-faint">
+          {props.prompts.length === 0 ? 'no saved prompts yet. create one below.' : 'nothing matches that filter'}
         </p>
       ) : null}
 
-      {visible.map((prompt) => (
-        <div
-          key={prompt.name}
-          data-testid={`prompts-item-${prompt.name}`}
-          className="flex items-center gap-2 rounded-[5px] px-2 py-1 text-[11px] text-doom-text hover:bg-doom-panel"
-        >
-          <Button
-            variant="ghost"
-            size="xs"
-            className="min-w-0 flex-1 justify-start text-left text-[11px]"
-            data-testid={`prompts-send-${prompt.name}`}
-            title="send this prompt to the focused session"
-            onClick={() => props.onSend(prompt)}
-          >
-            <span className="min-w-0 flex-1 truncate font-bold">/{prompt.name}</span>
-            <span className="min-w-0 flex-1 truncate text-[9px] text-doom-faint">{prompt.description}</span>
-          </Button>
-          <Button
-            variant="ghost"
-            size="xs"
-            className="text-[9px]"
-            data-testid={`prompts-edit-${prompt.name}`}
-            onClick={() => props.onEdit(prompt)}
-          >
-            edit
-          </Button>
-          <Button
-            variant="ghost"
-            size="xs"
-            className="text-[9px]"
-            data-testid={`prompts-delete-${prompt.name}`}
-            disabled={props.busy}
-            onClick={() => props.onDelete(prompt.name)}
-          >
-            delete
-          </Button>
-        </div>
-      ))}
-
-      {props.draft === undefined ? null : (
-        <PromptEditor
-          draft={props.draft}
-          busy={props.busy}
-          onChange={props.onDraftChange}
-          onSave={props.onSave}
-          onCancel={props.onCancelDraft}
-        />
-      )}
+      {props.loading || props.error !== ''
+        ? null
+        : visible.map((prompt) => (
+            <div
+              key={prompt.name}
+              data-testid={`prompts-item-${prompt.name}`}
+              className="flex min-h-11 items-center gap-1 rounded-[5px] border border-doom-border-soft px-2 py-1.5 text-doom-text hover:bg-doom-deep"
+            >
+              <Button
+                variant="ghost"
+                size="md"
+                className="min-w-0 flex-1 flex-col items-start justify-center gap-0 px-2 text-left"
+                data-testid={`prompts-send-${prompt.name}`}
+                title="send this prompt to the focused session"
+                onClick={() => props.onSend(prompt)}
+              >
+                <span className="w-full truncate text-[11px] font-bold">/{prompt.name}</span>
+                <span className="w-full truncate text-[10px] font-normal text-doom-faint">{prompt.description}</span>
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                data-testid={`prompts-edit-${prompt.name}`}
+                aria-label={`edit /${prompt.name}`}
+                onClick={() => props.onEdit(prompt)}
+              >
+                edit
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                data-testid={`prompts-delete-${prompt.name}`}
+                aria-label={`remove /${prompt.name}`}
+                disabled={props.busy}
+                onClick={() => props.onDelete(prompt)}
+              >
+                remove
+              </Button>
+            </div>
+          ))}
     </div>
   );
 }

--- a/packages/default/doompi-prompt/src/web/components/PromptsActivitySection.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptsActivitySection.tsx
@@ -1,9 +1,11 @@
 import { Button } from '@agimon-ai/doompi-web-components';
 import type { WebPluginSlotProps } from '@agimon-ai/doompi-web-contracts';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { SavedPromptView } from '../../types/webPrompts.ts';
 import { PromptsDialog } from './PromptsDialog.tsx';
 import { fetchSavedPrompts } from '../api/promptsApi.ts';
+import { subscribeMessagePromptDraft } from '../lib/messagePromptDraft.ts';
+import type { DraftState } from '../lib/promptsActions.ts';
 
 /**
  * The prompts group's body in the activity dock.
@@ -12,8 +14,8 @@ import { fetchSavedPrompts } from '../api/promptsApi.ts';
  * - One line and one action, like the agents and workflows groups: the dock is
  *   a status surface, so the library itself opens in a dialog over the
  *   conversation rather than pushing the reader into another page.
- * - The count is read once on mount and again whenever the dialog closes,
- *   because a write inside it is the only thing that changes the number.
+ * - The library loads on mount, again on open, and after every mutation so the
+ *   visible list is never an aborted or stale snapshot.
  *
  * AVOID:
  * - Rendering the library here. A dock group is a summary.
@@ -22,23 +24,47 @@ import { fetchSavedPrompts } from '../api/promptsApi.ts';
 export function PromptsActivitySection({ sessionId, sendSessionFrame }: WebPluginSlotProps) {
   const [prompts, setPrompts] = useState<readonly SavedPromptView[]>([]);
   const [open, setOpen] = useState(false);
+  const [initialDraft, setInitialDraft] = useState<DraftState | undefined>(undefined);
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    if (open) return undefined;
-    const controller = new AbortController();
-    void fetchSavedPrompts(controller.signal, sessionId).then((result) => {
-      if (controller.signal.aborted) return;
+  const loadPrompts = useCallback(
+    async (signal?: AbortSignal): Promise<void> => {
+      setLoading(true);
+      const result = await fetchSavedPrompts(signal, sessionId);
+      if (signal?.aborted) return;
       if ('error' in result) setError(result.error);
       else {
         setError('');
         setPrompts(result.prompts);
       }
-    });
-    return () => controller.abort();
-  }, [open, sessionId]);
+      setLoading(false);
+    },
+    [sessionId],
+  );
 
-  const summary = error !== '' ? error : prompts.length === 0 ? 'idle' : `${String(prompts.length)} saved`;
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadPrompts(controller.signal);
+    return () => controller.abort();
+  }, [loadPrompts, open]);
+
+  useEffect(
+    () =>
+      subscribeMessagePromptDraft((draft) => {
+        setInitialDraft(draft);
+        setOpen(true);
+      }),
+    [],
+  );
+
+  const changeOpen = (next: boolean): void => {
+    if (!next) setInitialDraft(undefined);
+    setOpen(next);
+  };
+
+  const summary =
+    error !== '' ? error : loading ? 'loading' : prompts.length === 0 ? 'idle' : `${String(prompts.length)} saved`;
 
   return (
     <div data-testid="activity-section-prompts" className="flex flex-col gap-0.5">
@@ -51,7 +77,10 @@ export function PromptsActivitySection({ sessionId, sendSessionFrame }: WebPlugi
           size="xs"
           data-testid="activity-prompts-open"
           className="px-0"
-          onClick={() => setOpen(true)}
+          onClick={() => {
+            setInitialDraft(undefined);
+            setOpen(true);
+          }}
         >
           send a prompt
         </Button>
@@ -60,8 +89,12 @@ export function PromptsActivitySection({ sessionId, sendSessionFrame }: WebPlugi
       <PromptsDialog
         open={open}
         prompts={prompts}
+        loading={loading}
+        loadError={error}
+        initialDraft={initialDraft}
         sessionId={sessionId}
-        onOpenChange={setOpen}
+        onOpenChange={changeOpen}
+        onReload={loadPrompts}
         onSend={sendSessionFrame}
       />
     </div>

--- a/packages/default/doompi-prompt/src/web/components/PromptsDialog.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptsDialog.tsx
@@ -58,7 +58,7 @@ export function PromptsDialog({
   onSend,
 }: PromptsDialogProps) {
   const [filter, setFilter] = useState('');
-  const [draft, setDraft] = useState<DraftState | undefined>(undefined);
+  const [draft, setDraft] = useState<DraftState | undefined>(initialDraft);
   const [confirmation, setConfirmation] = useState<Confirmation | undefined>(undefined);
   const [error, setError] = useState('');
 

--- a/packages/default/doompi-prompt/src/web/components/PromptsDialog.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptsDialog.tsx
@@ -9,8 +9,9 @@ import {
   DialogTitle,
 } from '@agimon-ai/doompi-web-components';
 import type { SessionFrameSender } from '@agimon-ai/doompi-web-contracts';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { SavedPromptView } from '../../types/webPrompts.ts';
+import { PromptEditor } from './PromptEditor.tsx';
 import { PromptPickerList } from './PromptPickerList.tsx';
 import { commitDraft, type DraftState, draftOf, EMPTY_DRAFT, promptFrame } from '../lib/promptsActions.ts';
 import { deleteSavedPrompt, saveSavedPrompt } from '../api/promptsApi.ts';
@@ -34,16 +35,49 @@ const NO_SESSION = 'Focus a session first: a prompt has to be sent somewhere.';
 export interface PromptsDialogProps {
   open: boolean;
   prompts: readonly SavedPromptView[];
+  loading: boolean;
+  loadError: string;
+  initialDraft?: DraftState;
   sessionId: string | null;
   onOpenChange: (open: boolean) => void;
+  onReload: () => Promise<void>;
   onSend: SessionFrameSender;
 }
 
-export function PromptsDialog({ open, prompts, sessionId, onOpenChange, onSend }: PromptsDialogProps) {
+type Confirmation = { kind: 'remove'; prompt: SavedPromptView } | { kind: 'replace'; name: string };
+
+export function PromptsDialog({
+  open,
+  prompts,
+  loading,
+  loadError,
+  initialDraft,
+  sessionId,
+  onOpenChange,
+  onReload,
+  onSend,
+}: PromptsDialogProps) {
   const [filter, setFilter] = useState('');
   const [draft, setDraft] = useState<DraftState | undefined>(undefined);
+  const [confirmation, setConfirmation] = useState<Confirmation | undefined>(undefined);
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (open && initialDraft) setDraft(initialDraft);
+  }, [initialDraft, open]);
   const [busy, setBusy] = useState(false);
+
+  const resetView = (): void => {
+    setFilter('');
+    setDraft(undefined);
+    setConfirmation(undefined);
+    setError('');
+  };
+
+  const changeOpen = (next: boolean): void => {
+    if (!next) resetView();
+    onOpenChange(next);
+  };
 
   const send = (prompt: SavedPromptView): void => {
     if (sessionId === null) {
@@ -51,68 +85,164 @@ export function PromptsDialog({ open, prompts, sessionId, onOpenChange, onSend }
       return;
     }
     onSend(sessionId, promptFrame(prompt.text));
-    onOpenChange(false);
+    changeOpen(false);
   };
 
-  const runMutation = async (mutation: Promise<{ error: string } | undefined>): Promise<void> => {
+  const runMutation = async (mutation: () => Promise<{ error: string } | undefined>): Promise<void> => {
     setBusy(true);
-    const failure = await mutation;
-    setBusy(false);
+    setError('');
+    const failure = await mutation();
     if (failure) {
+      setBusy(false);
       setError(failure.error);
       return;
     }
+    await onReload();
+    setBusy(false);
     setDraft(undefined);
-    // The activity section reloads the library whenever this dialog closes.
-    onOpenChange(false);
+    setConfirmation(undefined);
   };
 
+  const saveDraft = (): void => {
+    if (!draft) return;
+    const name = draft.name.trim();
+    const replacesAnother = prompts.some((prompt) => prompt.name === name && prompt.name !== draft.original);
+    if (replacesAnother) {
+      setConfirmation({ kind: 'replace', name });
+      return;
+    }
+    void runMutation(() =>
+      commitDraft(draft, {
+        save: (nextName, text) => saveSavedPrompt(nextName, text, sessionId),
+        remove: (previousName) => deleteSavedPrompt(previousName, sessionId),
+      }),
+    );
+  };
+
+  const title =
+    confirmation?.kind === 'remove'
+      ? 'remove prompt'
+      : confirmation?.kind === 'replace'
+        ? 'replace prompt'
+        : draft
+          ? draft.original === ''
+            ? 'new prompt'
+            : 'edit prompt'
+          : 'prompts';
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent data-testid="prompts-dialog">
-        <DialogHeader>
-          <DialogTitle>prompts</DialogTitle>
-          <DialogDescription>pick one to send it to this session</DialogDescription>
+    <Dialog open={open} onOpenChange={changeOpen}>
+      <DialogContent
+        data-testid="prompts-dialog"
+        onOpenAutoFocus={(event) => {
+          if (!initialDraft) event.preventDefault();
+        }}
+        aria-describedby="prompts-dialog-description"
+      >
+        <DialogHeader dismissible closeLabel="close prompts">
+          <div className="min-w-0">
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription id="prompts-dialog-description">
+              {draft || confirmation ? 'manage your saved prompt library' : 'select one to send it now'}
+            </DialogDescription>
+          </div>
         </DialogHeader>
 
         <DialogBody>
-          <PromptPickerList
-            prompts={prompts}
-            filter={filter}
-            draft={draft}
-            busy={busy}
-            error={error}
-            onFilterChange={setFilter}
-            onSend={send}
-            onEdit={(prompt) => setDraft(draftOf(prompt))}
-            onDelete={(name) => void runMutation(deleteSavedPrompt(name, sessionId))}
-            onDraftChange={setDraft}
-            onSave={() =>
-              void runMutation(
-                draft
-                  ? commitDraft(draft, {
-                      save: (name, text) => saveSavedPrompt(name, text, sessionId),
-                      remove: (name) => deleteSavedPrompt(name, sessionId),
-                    })
-                  : Promise.resolve(undefined),
-              )
-            }
-            onCancelDraft={() => setDraft(undefined)}
-          />
+          {error === '' ? null : draft || confirmation ? (
+            <span className="text-[11px] text-doom-red" data-testid="prompts-error">
+              {error}
+            </span>
+          ) : null}
+
+          {confirmation?.kind === 'remove' ? (
+            <div className="flex flex-col gap-4" data-testid="prompts-remove-confirmation">
+              <p className="text-[11px] leading-relaxed text-doom-dim">
+                Remove <strong className="text-doom-hi">/{confirmation.prompt.name}</strong>? This cannot be undone.
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" size="md" disabled={busy} onClick={() => setConfirmation(undefined)}>
+                  cancel
+                </Button>
+                <Button
+                  variant="danger"
+                  size="md"
+                  data-testid="prompts-remove-confirm"
+                  disabled={busy}
+                  onClick={() => void runMutation(() => deleteSavedPrompt(confirmation.prompt.name, sessionId))}
+                >
+                  {busy ? 'removing…' : 'remove prompt'}
+                </Button>
+              </div>
+            </div>
+          ) : confirmation?.kind === 'replace' && draft ? (
+            <div className="flex flex-col gap-4" data-testid="prompts-replace-confirmation">
+              <p className="text-[11px] leading-relaxed text-doom-dim">
+                <strong className="text-doom-hi">/{confirmation.name}</strong> already exists. Replace its text with
+                this draft?
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" size="md" disabled={busy} onClick={() => setConfirmation(undefined)}>
+                  go back
+                </Button>
+                <Button
+                  variant="danger"
+                  size="md"
+                  data-testid="prompts-replace-confirm"
+                  disabled={busy}
+                  onClick={() =>
+                    void runMutation(() =>
+                      commitDraft(draft, {
+                        save: (name, text) => saveSavedPrompt(name, text, sessionId),
+                        remove: (name) => deleteSavedPrompt(name, sessionId),
+                      }),
+                    )
+                  }
+                >
+                  {busy ? 'replacing…' : 'replace prompt'}
+                </Button>
+              </div>
+            </div>
+          ) : draft ? (
+            <PromptEditor
+              draft={draft}
+              busy={busy}
+              onChange={setDraft}
+              onSave={saveDraft}
+              onCancel={() => setDraft(undefined)}
+            />
+          ) : (
+            <PromptPickerList
+              prompts={prompts}
+              filter={filter}
+              loading={loading}
+              busy={busy}
+              error={error || loadError}
+              onFilterChange={setFilter}
+              onSend={send}
+              onEdit={(prompt) => setDraft(draftOf(prompt))}
+              onDelete={(prompt) => setConfirmation({ kind: 'remove', prompt })}
+              onRetry={() => void onReload()}
+            />
+          )}
         </DialogBody>
 
-        <DialogFooter>
-          <Button
-            variant="ghost"
-            size="xs"
-            className="text-[9px]"
-            data-testid="prompts-new"
-            disabled={busy}
-            onClick={() => setDraft(EMPTY_DRAFT)}
-          >
-            new
-          </Button>
-        </DialogFooter>
+        {draft || confirmation ? null : (
+          <DialogFooter variant="bar">
+            <span className="text-[10px] text-doom-faint">
+              {prompts.length === 0 ? 'build your reusable library' : `${String(prompts.length)} saved`}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="prompts-new"
+              disabled={busy}
+              onClick={() => setDraft(EMPTY_DRAFT)}
+            >
+              new prompt
+            </Button>
+          </DialogFooter>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/packages/default/doompi-prompt/src/web/index.ts
+++ b/packages/default/doompi-prompt/src/web/index.ts
@@ -1,5 +1,6 @@
 import { defineWebPlugin } from '@agimon-ai/doompi-web-contracts';
 import { PromptsActivitySection } from './components/PromptsActivitySection.tsx';
+import { requestMessagePromptDraft } from './lib/messagePromptDraft.ts';
 
 /**
  * This package's cockpit presence: one activity group.
@@ -29,4 +30,5 @@ export const webPlugin = defineWebPlugin({
     },
   ],
   activitySections: [{ id: 'prompts', component: PromptsActivitySection }],
+  userMessageActions: [{ id: 'save', label: 'save as prompt', order: 40, run: requestMessagePromptDraft }],
 });

--- a/packages/default/doompi-prompt/src/web/lib/messagePromptDraft.ts
+++ b/packages/default/doompi-prompt/src/web/lib/messagePromptDraft.ts
@@ -1,0 +1,37 @@
+import { defineGlobalStore, type UserMessageActionRunContext } from '@agimon-ai/doompi-web-contracts';
+import type { DraftState } from './promptsActions.ts';
+
+/**
+ * Package-local handoff from a timeline action to the mounted prompt dialog.
+ *
+ * DESIGN PATTERNS:
+ * - The web plugin action has no React owner, so it publishes one short-lived
+ *   request to the activity section that already owns prompt dialog state.
+ * - Message text is copied into a new editable draft; the user must choose a
+ *   stable name before anything is written.
+ *
+ * AVOID:
+ * - Persisting drafts or message content in browser storage.
+ * - Making the host understand prompt-specific dialog state.
+ */
+
+type MessagePromptListener = (draft: DraftState) => void;
+
+const messagePromptDraft = defineGlobalStore<DraftState | undefined>(undefined);
+
+export function requestMessagePromptDraft(context: UserMessageActionRunContext): void {
+  const draft: DraftState = { name: '', text: context.text, original: '' };
+  messagePromptDraft.update(() => draft);
+}
+
+export function subscribeMessagePromptDraft(listener: MessagePromptListener): () => void {
+  const deliver = (): void => {
+    const draft = messagePromptDraft.store.state;
+    if (!draft) return;
+    messagePromptDraft.reset();
+    listener(draft);
+  };
+  const subscription = messagePromptDraft.store.subscribe(deliver);
+  deliver();
+  return () => subscription.unsubscribe();
+}

--- a/packages/default/doompi-prompt/tests/web/messagePromptDraft.test.ts
+++ b/packages/default/doompi-prompt/tests/web/messagePromptDraft.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { requestMessagePromptDraft, subscribeMessagePromptDraft } from '../../src/web/lib/messagePromptDraft.ts';
+
+describe('message prompt draft handoff', () => {
+  it('copies user message text into an editable unnamed draft', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeMessagePromptDraft(listener);
+
+    requestMessagePromptDraft({ sessionId: 'session-1', messageId: 'message-1', text: 'Review this change' });
+
+    expect(listener).toHaveBeenCalledWith({ name: '', text: 'Review this change', original: '' });
+    unsubscribe();
+  });
+
+  it('retains a request until the dialog owner subscribes', () => {
+    requestMessagePromptDraft({ sessionId: 'session-1', messageId: 'message-2', text: 'Write the tests' });
+    const listener = vi.fn();
+
+    const unsubscribe = subscribeMessagePromptDraft(listener);
+
+    expect(listener).toHaveBeenCalledWith({ name: '', text: 'Write the tests', original: '' });
+    unsubscribe();
+  });
+});

--- a/packages/default/doompi-prompt/tests/web/promptComponents.test.ts
+++ b/packages/default/doompi-prompt/tests/web/promptComponents.test.ts
@@ -10,14 +10,14 @@ vi.mock('@agimon-ai/doompi-web-security/browser', () => ({ sealedTransport: { fe
 const PROMPT: SavedPromptView = { name: 'review', description: 'Review the diff', text: 'Review the diff\nnow' };
 
 describe('the prompts activity group', () => {
-  it('reports idle with the action that fills the library', () => {
+  it('reports loading with the action that opens the library', () => {
     const { props } = slotPropsFixture();
 
     const rendered = renderPlugin(PromptsActivitySection, props);
 
     expect(rendered.error).toBeUndefined();
     expect(rendered.html).toContain('activity-summary-prompts');
-    expect(rendered.includes('idle')).toBe(true);
+    expect(rendered.includes('loading')).toBe(true);
     expect(rendered.includes('send a prompt')).toBe(true);
   });
 
@@ -40,16 +40,14 @@ describe('the prompt picker list', () => {
   const listProps = (overrides: Partial<Parameters<typeof PromptPickerList>[0]> = {}) => ({
     prompts: [PROMPT],
     filter: '',
-    draft: undefined,
+    loading: false,
     busy: false,
     error: '',
     onFilterChange: vi.fn(),
     onSend: vi.fn(),
     onEdit: vi.fn(),
     onDelete: vi.fn(),
-    onDraftChange: vi.fn(),
-    onSave: vi.fn(),
-    onCancelDraft: vi.fn(),
+    onRetry: vi.fn(),
     ...overrides,
   });
 
@@ -61,12 +59,13 @@ describe('the prompt picker list', () => {
     expect(rendered.includes('Review the diff')).toBe(true);
   });
 
-  it('offers sending, editing and deleting each entry', () => {
+  it('offers sending, editing and removing each entry', () => {
     const rendered = renderPlugin(PromptPickerList, listProps());
 
     expect(rendered.html).toContain('prompts-send-review');
     expect(rendered.html).toContain('prompts-edit-review');
     expect(rendered.html).toContain('prompts-delete-review');
+    expect(rendered.includes('remove')).toBe(true);
   });
 
   it('says so when the library is empty', () => {
@@ -93,11 +92,11 @@ describe('the prompt picker list', () => {
     expect(rendered.includes('now')).toBe(false);
   });
 
-  it('opens the editor only when a draft is open', () => {
-    expect(renderPlugin(PromptPickerList, listProps()).html).not.toContain('prompts-editor');
-    expect(renderPlugin(PromptPickerList, listProps({ draft: { name: 'n', text: 't', original: '' } })).html).toContain(
-      'prompts-editor',
-    );
+  it('shows loading separately from an empty library', () => {
+    const rendered = renderPlugin(PromptPickerList, listProps({ prompts: [], loading: true }));
+
+    expect(rendered.html).toContain('prompts-loading');
+    expect(rendered.html).not.toContain('prompts-empty');
   });
 });
 

--- a/packages/default/doompi-prompt/tests/web/promptDialogBehavior.test.ts
+++ b/packages/default/doompi-prompt/tests/web/promptDialogBehavior.test.ts
@@ -1,0 +1,175 @@
+import { renderPlugin } from '@agimon-ai/doompi-web-contracts/testing';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SavedPromptView } from '../../src/types/webPrompts.ts';
+import { PromptsDialog } from '../../src/web/components/PromptsDialog.tsx';
+
+const captured = vi.hoisted(() => ({
+  buttons: [] as Array<Record<string, unknown>>,
+  contents: [] as Array<Record<string, unknown>>,
+  inputs: [] as Array<Record<string, unknown>>,
+  textareas: [] as Array<Record<string, unknown>>,
+}));
+
+const api = vi.hoisted(() => ({
+  remove: vi.fn(async () => undefined),
+  save: vi.fn(async () => undefined),
+}));
+
+vi.mock('@agimon-ai/doompi-web-security/browser', () => ({ sealedTransport: { fetch: vi.fn() } }));
+vi.mock('../../src/web/api/promptsApi.ts', () => ({
+  deleteSavedPrompt: api.remove,
+  saveSavedPrompt: api.save,
+}));
+
+vi.mock('@agimon-ai/doompi-web-components', () => {
+  const shell = (tag: string) =>
+    function Shell({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) {
+      return createElement(tag, { 'data-testid': props['data-testid'] }, children);
+    };
+
+  return {
+    Button(props: Record<string, unknown>) {
+      captured.buttons.push(props);
+      return createElement(
+        'button',
+        { 'data-testid': props['data-testid'], disabled: props.disabled },
+        props.children as ReactNode,
+      );
+    },
+    Input(props: Record<string, unknown>) {
+      captured.inputs.push(props);
+      return createElement('input', { 'data-testid': props['data-testid'], value: props.value, readOnly: true });
+    },
+    Textarea(props: Record<string, unknown>) {
+      captured.textareas.push(props);
+      return createElement('textarea', { 'data-testid': props['data-testid'], value: props.value, readOnly: true });
+    },
+    Dialog({ open, children }: { open?: boolean; children?: ReactNode }) {
+      return open ? createElement('div', null, children) : null;
+    },
+    DialogBody: shell('div'),
+    DialogContent(props: Record<string, unknown>) {
+      captured.contents.push(props);
+      return createElement('section', { 'data-testid': props['data-testid'] }, props.children as ReactNode);
+    },
+    DialogDescription: shell('p'),
+    DialogFooter: shell('footer'),
+    DialogHeader: shell('header'),
+    DialogTitle: shell('h2'),
+  };
+});
+
+const PROMPT: SavedPromptView = { name: 'review', description: 'Review the change', text: 'Review the change' };
+
+function props(overrides: Partial<Parameters<typeof PromptsDialog>[0]> = {}): Parameters<typeof PromptsDialog>[0] {
+  return {
+    open: true,
+    prompts: [PROMPT],
+    loading: false,
+    loadError: '',
+    sessionId: 'session-1',
+    onOpenChange: vi.fn(),
+    onReload: vi.fn(async () => undefined),
+    onSend: vi.fn(),
+    ...overrides,
+  };
+}
+
+function button(testId: string): Record<string, unknown> {
+  const found = captured.buttons.find((candidate) => candidate['data-testid'] === testId);
+  if (!found) throw new Error(`Missing button ${testId}`);
+  return found;
+}
+
+function control(controls: Array<Record<string, unknown>>, index: number, label: string): Record<string, unknown> {
+  const found = controls[index];
+  if (!found) throw new Error(`Missing ${label}`);
+  return found;
+}
+
+beforeEach(() => {
+  captured.buttons.length = 0;
+  captured.contents.length = 0;
+  captured.inputs.length = 0;
+  captured.textareas.length = 0;
+  api.remove.mockClear();
+  api.save.mockClear();
+});
+
+describe('prompt dialog behavior', () => {
+  it('sends a selected prompt to the focused session and closes', () => {
+    const dialogProps = props();
+    const rendered = renderPlugin(PromptsDialog, dialogProps);
+
+    expect(rendered.error).toBeUndefined();
+    const preventDefault = vi.fn();
+    (
+      control(captured.contents, 0, 'dialog content').onOpenAutoFocus as (event: { preventDefault: () => void }) => void
+    )({ preventDefault });
+    (control(captured.inputs, 0, 'filter input').onChange as (event: { target: { value: string } }) => void)({
+      target: { value: 'rev' },
+    });
+    (button('prompts-edit-review').onClick as () => void)();
+    (button('prompts-delete-review').onClick as () => void)();
+    (button('prompts-new').onClick as () => void)();
+    (button('prompts-send-review').onClick as () => void)();
+
+    expect(dialogProps.onSend).toHaveBeenCalledWith('session-1', { type: 'prompt', message: PROMPT.text });
+    expect(dialogProps.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('keeps the dialog open when no session is focused', () => {
+    const dialogProps = props({ sessionId: null });
+    renderPlugin(PromptsDialog, dialogProps);
+
+    (button('prompts-send-review').onClick as () => void)();
+
+    expect(dialogProps.onSend).not.toHaveBeenCalled();
+    expect(dialogProps.onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('prefills and saves a user-message draft without losing its text', async () => {
+    const onReload = vi.fn(async () => undefined);
+    const dialogProps = props({
+      prompts: [],
+      initialDraft: { name: 'saved-message', text: 'Keep this exact text', original: '' },
+      onReload,
+    });
+    const rendered = renderPlugin(PromptsDialog, dialogProps);
+
+    expect(rendered.includes('Keep this exact text')).toBe(true);
+    expect(captured.inputs[0]?.value).toBe('saved-message');
+    const preventDefault = vi.fn();
+    (
+      control(captured.contents, 0, 'dialog content').onOpenAutoFocus as (event: { preventDefault: () => void }) => void
+    )({ preventDefault });
+    expect(preventDefault).not.toHaveBeenCalled();
+    (button('prompts-save').onClick as () => void)();
+
+    await vi.waitFor(() => expect(onReload).toHaveBeenCalledOnce());
+    expect(api.save).toHaveBeenCalledWith('saved-message', 'Keep this exact text', 'session-1');
+  });
+
+  it('exposes editable name and text controls for a message draft', () => {
+    renderPlugin(
+      PromptsDialog,
+      props({ prompts: [], initialDraft: { name: '', text: 'Original text', original: '' } }),
+    );
+    const onNameChange = captured.inputs[0]?.onChange as (event: { target: { value: string } }) => void;
+    const onTextChange = captured.textareas[0]?.onChange as (event: { target: { value: string } }) => void;
+
+    onNameChange({ target: { value: 'new-name' } });
+    onTextChange({ target: { value: 'Changed text' } });
+    (button('prompts-cancel').onClick as () => void)();
+  });
+
+  it('renders retry while loading the library failed', () => {
+    const onReload = vi.fn(async () => undefined);
+    const rendered = renderPlugin(PromptsDialog, props({ prompts: [], loadError: 'unavailable', onReload }));
+
+    expect(rendered.includes('unavailable')).toBe(true);
+    (button('prompts-retry').onClick as () => void)();
+    expect(onReload).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- make the saved prompt dialog list-first with loading, retry, empty, and mobile-friendly states
- send a selected prompt immediately and provide dedicated edit, replacement, and removal flows
- add a user-message action contract so text-bearing user messages can be saved as editable prompts
- keep timeline plugin actions reactive and reachable on narrow screens

## Verification

- `pnpm lint:vibe --preflight-only`
- affected lint, typecheck, and build targets for web contracts, web client, and prompt package
- web contract tests
- focused web client tests: 27 passed
- focused prompt web tests: 45 passed
- `git diff --check`

## Known repository test issues

- the full prompt package suite has 9 existing Cordis host setup failures
- the full web client suite has 1 existing bridge channel expectation failure

## Browser validation

The local Vite app loaded without console errors. The prompt UI could not be exercised end to end without a connected hub and session.
