### PR TITLE
feat(doompi-author): enable npm publishing

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -57,6 +57,7 @@
           "@agimon-ai/doompi-autocompact",
           "@agimon-ai/doompi-autostop",
           "@agimon-ai/doompi-cache",
+          "@agimon-ai/doompi-author",
           "@agimon-ai/doompi-computer-use",
           "@agimon-ai/doompi-config",
           "@agimon-ai/doompi-domain",

--- a/packages/core/doompi/tests/fixtures/packageCompatibility.json
+++ b/packages/core/doompi/tests/fixtures/packageCompatibility.json
@@ -1,4 +1,57 @@
 {
+  "@agimon-ai/doompi-author": {
+    "exports": {
+      ".": "tir",
+      "./extensions/pi": "tir",
+      "./session-api": "tir",
+      "./web-hub": "tir",
+      "./package.json": "esm"
+    },
+    "exportTargets": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs"
+      },
+      "./extensions/pi": {
+        "types": "./dist/extensions/pi.d.mts",
+        "import": "./dist/extensions/pi.mjs",
+        "require": "./dist/extensions/pi.cjs"
+      },
+      "./session-api": {
+        "types": "./dist/sessionApi.d.mts",
+        "import": "./dist/sessionApi.mjs",
+        "require": "./dist/sessionApi.cjs"
+      },
+      "./web-hub": {
+        "types": "./dist/webHub.d.mts",
+        "import": "./dist/webHub.mjs",
+        "require": "./dist/webHub.cjs"
+      },
+      "./package.json": "./package.json"
+    },
+    "main": "./dist/index.cjs",
+    "types": "./dist/index.d.mts",
+    "jsnextMain": "./dist/index.mjs",
+    "bin": {},
+    "pi": { "extensions": ["./dist/extensions/pi.mjs"] },
+    "assets": ["./llms.txt", "./README.md", "./src/prompts/doompi-use-author/SKILL.md"],
+    "files": [
+      "dist",
+      "src/web",
+      "src/types/author.ts",
+      "src/types/webAuthor.ts",
+      "src/types/structuredDocuments.ts",
+      "src/exports/webClient.ts",
+      "src/prompts",
+      "llms.txt",
+      "README.md",
+      "LICENSE",
+      "package.json"
+    ],
+    "os": [],
+    "cpu": []
+  },
   "@agimon-ai/doompi-computer-use": {
     "exports": {
       ".": "tir",

--- a/packages/core/doompi/tests/system/packInstall.system.test.ts
+++ b/packages/core/doompi/tests/system/packInstall.system.test.ts
@@ -1660,8 +1660,9 @@ describe('consumer ownership boundaries', () => {
 
   it('keeps the matrix explicit instead of silently dropping standard entries', () => {
     const names = PACKAGE_MATRIX.map((entry) => entry.name);
-    expect(PACKAGE_MATRIX).toHaveLength(44);
-    expect(standardPackageSet.size).toBe(29);
+    expect(PACKAGE_MATRIX).toHaveLength(45);
+    expect(standardPackageSet.size).toBe(30);
+    expect(standardPackageSet).toContain('@agimon-ai/doompi-author');
     expect(standardPackageSet).toContain('@agimon-ai/doompi-computer-use');
     expect(standardPackageSet).toContain('@agimon-ai/doompi-help');
     expect(names).toContain('@agimon-ai/doompi');

--- a/packages/core/doompi/tests/system/packageMatrix.ts
+++ b/packages/core/doompi/tests/system/packageMatrix.ts
@@ -27,6 +27,7 @@ const OWNED_PACKAGE_DIRECTORIES: Readonly<Record<string, string>> = {
   '@agimon-ai/doompi': 'packages/core/doompi',
   '@agimon-ai/doompi-autocompact': 'packages/default/doompi-autocompact',
   '@agimon-ai/doompi-autostop': 'packages/core/doompi-autostop',
+  '@agimon-ai/doompi-author': 'packages/minor/doompi-author',
   '@agimon-ai/doompi-cache': 'packages/core/doompi-cache',
   '@agimon-ai/doompi-computer-use': 'packages/minor/doompi-computer-use',
   '@agimon-ai/doompi-config': 'packages/core/doompi-config',
@@ -73,6 +74,7 @@ const OWNED_PACKAGE_DIRECTORIES: Readonly<Record<string, string>> = {
 const STANDARD_PI_NAMES = [
   '@agimon-ai/doompi-autocompact',
   '@agimon-ai/doompi-autostop',
+  '@agimon-ai/doompi-author',
   '@agimon-ai/doompi-cache',
   '@agimon-ai/doompi-computer-use',
   '@agimon-ai/doompi-config',
@@ -109,6 +111,7 @@ const PACKAGE_RESOURCES: Readonly<Record<string, readonly string[]>> = {
     './src/prompts/doompi-author-extension/SKILL.md',
     './src/prompts/doompi-author-extension/references/extension-contract.md',
   ],
+  '@agimon-ai/doompi-author': ['./llms.txt', './README.md', './src/prompts/doompi-use-author/SKILL.md'],
   '@agimon-ai/doompi-cache': ['./llms.txt', './README.md', './src/prompts/doompi-use-cache/SKILL.md'],
   '@agimon-ai/doompi-computer-use': ['./llms.txt', './README.md', './src/prompts/doompi-use-computer-use/SKILL.md'],
   '@agimon-ai/doompi-config': [

--- a/packages/minor/doompi-author/package.json
+++ b/packages/minor/doompi-author/package.json
@@ -1,8 +1,19 @@
 {
   "name": "@agimon-ai/doompi-author",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1-alpha.0",
   "description": "Visual steering workspace for focused document review and bounded authoring",
+  "keywords": [
+    "ai",
+    "authoring",
+    "coding-agent",
+    "developer-tools",
+    "doompi",
+    "pi-coding-agent",
+    "pi-extension",
+    "pi-package",
+    "typescript"
+  ],
+  "homepage": "https://agimon.ai",
   "bugs": {
     "url": "https://github.com/AgiFlow/doompi/issues"
   },
@@ -52,6 +63,9 @@
       "require": "./dist/webHub.cjs"
     },
     "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",

--- a/packages/minor/doompi-author/tests/contract/packageShape.test.ts
+++ b/packages/minor/doompi-author/tests/contract/packageShape.test.ts
@@ -9,8 +9,11 @@ interface PackageManifest {
   name: string;
   version: string;
   private?: boolean;
+  type?: string;
   files?: string[];
+  keywords?: string[];
   exports?: Record<string, unknown>;
+  publishConfig?: { access?: string };
   doompiApi?: { basePath?: string; session?: { entry?: string } };
   doompiWeb?: { pluginId?: string; channels?: string[]; client?: string; hub?: { entry?: string } };
   pi?: { extensions?: string[] };
@@ -21,9 +24,24 @@ async function manifest(): Promise<PackageManifest> {
 }
 
 describe('doompi-author package contract', () => {
-  it('is a private foundation package with closed entries', async () => {
+  it('is a public ESM package with closed entries', async () => {
     const value = await manifest();
-    expect(value).toMatchObject({ name: '@agimon-ai/doompi-author', version: '0.0.0', private: true });
+    expect(value.name).toBe('@agimon-ai/doompi-author');
+    expect(value.version).toBe('0.0.1-alpha.0');
+    expect(value.private).toBeUndefined();
+    expect(value.type).toBe('module');
+    expect(value.publishConfig).toEqual({ access: 'public' });
+    expect(value.keywords).toEqual(
+      expect.arrayContaining([
+        'authoring',
+        'coding-agent',
+        'doompi',
+        'pi-coding-agent',
+        'pi-extension',
+        'pi-package',
+        'typescript',
+      ]),
+    );
     expect(Object.keys(value.exports ?? {})).toEqual([
       '.',
       './extensions/pi',

--- a/scripts/audit-workspace.mjs
+++ b/scripts/audit-workspace.mjs
@@ -35,7 +35,7 @@ const additionalToolingPackageNames = ['@agimon-ai/vibe-lint-plugin-doom-web'];
 // never be a runtime dependency of a released package: the release publishes
 // the resolved `workspace:*` version, so a released package that points at an
 // unreleased one ships a dependency npm cannot install.
-const unreleasedOwnedPackageNames = new Set(['@agimon-ai/doompi-author', '@agimon-ai/doompi-desktop']);
+const unreleasedOwnedPackageNames = new Set(['@agimon-ai/doompi-desktop']);
 const vibeLintVersion = '0.0.1-alpha.29';
 
 function readJson(file) {


### PR DESCRIPTION
## Summary
- make `@agimon-ai/doompi-author` a public alpha npm package
- add it to the Nx alpha release group and standard package matrix
- add package compatibility and packed-install coverage

## Verification
- `pnpm lint:vibe --preflight-only`
- author lint, typecheck, build, and package contract tests
- packed-install system tests: 296 passed, 1 skipped
- `npm pack --dry-run`