### PR TITLE
fix(doompi-author): avoid pinning release version in test

### DIFF
--- a/packages/minor/doompi-author/tests/contract/packageShape.test.ts
+++ b/packages/minor/doompi-author/tests/contract/packageShape.test.ts
@@ -7,7 +7,6 @@ const packageDirectory = fileURLToPath(new URL('../..', import.meta.url));
 
 interface PackageManifest {
   name: string;
-  version: string;
   private?: boolean;
   type?: string;
   files?: string[];
@@ -27,7 +26,6 @@ describe('doompi-author package contract', () => {
   it('is a public ESM package with closed entries', async () => {
     const value = await manifest();
     expect(value.name).toBe('@agimon-ai/doompi-author');
-    expect(value.version).toBe('0.0.1-alpha.0');
     expect(value.private).toBeUndefined();
     expect(value.type).toBe('module');
     expect(value.publishConfig).toEqual({ access: 'public' });


### PR DESCRIPTION
## Summary
- remove the exact package version assertion from the author package contract
- allow Nx release automation to bump prerelease versions without breaking CI

## Verification
- `pnpm --dir packages/minor/doompi-author exec vitest --run tests/contract/packageShape.test.ts`
- `pnpm lint:vibe --preflight-only`