### PR TITLE
fix(doompi-web): refresh transient tabs after plugin handoff

### DIFF
--- a/packages/clients/doompi-web/src/web/routes/CockpitPage.tsx
+++ b/packages/clients/doompi-web/src/web/routes/CockpitPage.tsx
@@ -14,7 +14,7 @@ import { SessionRail } from '../features/sessions/SessionRail.tsx';
 import { WelcomePanel } from '../features/sessions/WelcomePanel.tsx';
 import { Timeline } from '../features/session/Timeline.tsx';
 import { TopBar } from '../features/status/TopBar.tsx';
-import { HOST_SLOTS, webTabs } from '../lib/pluginRegistry.ts';
+import { HOST_SLOTS, pluginActivityGroups, webTabs } from '../lib/pluginRegistry.ts';
 import { useActiveSession } from '../stores/sessionStore.ts';
 import { sessionsStore, setActiveSession, useNoSessions } from '../stores/sessionsStore.ts';
 import { useWebPluginRegistry } from '../stores/useWebPluginRegistry.ts';
@@ -38,7 +38,16 @@ export function CockpitPage() {
   const noSessions = useNoSessions();
   const dialogId = useActiveSession((state) => state.dialog?.id ?? null);
   // A declared tab first, then one a plugin opened at runtime for this session.
-  const transientTab = useStore(transientTabsStore, (state) => findTransientTab(state, sessionId, tabId));
+  // Session plugin compositions replace the builtin plugin module after verification.
+  // Refresh activity-owned tabs from the active registry so a tab opened during that
+  // handoff does not keep rendering the retired module's disconnected stores.
+  const storedTransientTab = useStore(transientTabsStore, (state) => findTransientTab(state, sessionId, tabId));
+  const transientTab =
+    storedTransientTab === undefined
+      ? undefined
+      : (pluginActivityGroups()
+          .map((group) => group.transientTab?.())
+          .find((candidate) => candidate?.id === storedTransientTab.id) ?? storedTransientTab);
   const tab = (tabId === undefined ? undefined : webTabs().find((entry) => entry.id === tabId)) ?? transientTab;
 
   // Both side panels are temporary drawers on mobile. Route changes can also


### PR DESCRIPTION
## Summary

- refresh activity-owned transient tabs from the active plugin registry
- prevent tabs opened during plugin verification from retaining retired module stores
- fix workflow panels that stayed empty while the activity dock showed live runs

## Verification

- `pnpm lint:vibe --preflight-only`
- `pnpm nx run @agimon-ai/doompi-web:lint`
- `pnpm nx run @agimon-ai/doompi-web:typecheck`
- `pnpm nx run @agimon-ai/doompi-web:build`
- workflow E2E stress run in CI mode: 58 passed, 2 passed on retry

The full unit suite also ran. One unrelated integration assertion failed because the generated server registry contained plugin channels while the test expected a bare registry.

Fixes the Browser E2E failure observed in release PR #85.
