### PR TITLE
feat: update cockpit state and wire the web style system

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -81,6 +81,10 @@ jobs:
           fi
           echo "RELEASE_PROJECTS=${RELEASE_PROJECTS}" >> "${GITHUB_ENV}"
 
+      - name: Raise the selected versions to the registry floor
+        if: env.RELEASE_PROJECTS != ''
+        run: node scripts/sync-registry-versions.mjs "${RELEASE_PROJECTS}"
+
       - name: Validate the release candidate
         if: env.RELEASE_PROJECTS != ''
         run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,9 +14,15 @@ concurrency:
 
 jobs:
   publish:
+    # A merge commit does not always carry the release pull request title in its
+    # body, and one that does not used to skip the publish silently, leaving main
+    # on a version the registry never received. The release branch name is in the
+    # merge subject either way, so it is matched as well.
     if: >-
       github.ref == 'refs/heads/main' &&
-      (github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, 'chore(release): publish'))
+      (github.event_name == 'workflow_dispatch' ||
+      contains(github.event.head_commit.message, 'chore(release): publish') ||
+      contains(github.event.head_commit.message, format('from {0}/release/alpha-', github.repository_owner)))
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment:
@@ -98,8 +104,12 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$NODE_AUTH_TOKEN"
-          readonly RECONCILE_ATTEMPTS=5
-          readonly RECONCILE_DELAY_SECONDS=30
+          # npm serves a version it has just accepted from a read path that lags
+          # behind the write path, so the budget has to outlast that lag: a short
+          # one fails the job over a registry that is merely catching up, and
+          # takes the tagging and the latest promotion down with it.
+          readonly RECONCILE_ATTEMPTS=8
+          readonly RECONCILE_DELAY_SECONDS=60
           readonly PENDING_FILE="${RUNNER_TEMP}/doompi-release-pending.tsv"
           readonly ROUND_FILE="${RUNNER_TEMP}/doompi-release-pending-round.tsv"
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ packages/default/doompi-runner-rmux-*/vendor/
 packages/default/doompi-runner-rtk-*/vendor/
 # The cockpit dev loop's generated plugin registry (packages/clients/doompi-web/vite.config.ts).
 packages/clients/doompi-web/.dev/
+# Scratch Vite builds written into a project by the style-system screenshot
+# renderer (`style-system get-ui-component`). It does not clean them up.
+.tmp/
 # The desktop app's staged cockpit payload and packaged artifacts, produced by
 # `pnpm deploy` and electron-builder rather than stored here.
 packages/clients/doompi-desktop/build/

--- a/layers/ask-user/doompi-user-feedback/package.json
+++ b/layers/ask-user/doompi-user-feedback/package.json
@@ -33,7 +33,8 @@
     "src/types/questionnaire.ts",
     "README.md",
     "LICENSE",
-    "package.json"
+    "package.json",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -79,6 +80,7 @@
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "5.0.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsdown": "0.23.0",
     "typescript": "7.0.2",
     "vitest": "5.0.0"

--- a/layers/ask-user/doompi-user-feedback/src/web/components/AskUserQuestionToolMessage.stories.tsx
+++ b/layers/ask-user/doompi-user-feedback/src/web/components/AskUserQuestionToolMessage.stories.tsx
@@ -1,0 +1,89 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the tool contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { AskUserQuestionToolMessage } from './AskUserQuestionToolMessage.tsx';
+
+const ARGS = {
+  questions: [
+    { header: 'Scope', question: 'Which packages should the story batch cover?' },
+    { header: 'Titles', question: 'Which title prefix belongs to a layer package?' },
+  ],
+};
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'ask_user_question', args: ARGS, ...overrides }).props;
+
+const meta = {
+  title: 'UserFeedback/AskUserQuestionToolMessage',
+  component: AskUserQuestionToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running · questionnaire is open below</span>
+        <AskUserQuestionToolMessage {...props({ running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">answered · single and multi select</span>
+        <AskUserQuestionToolMessage
+          {...props({
+            result: {
+              content: [],
+              details: {
+                answers: [
+                  { question: 'Which packages should the story batch cover?', kind: 'single', answer: 'All five' },
+                  {
+                    question: 'Which title prefix belongs to a layer package?',
+                    kind: 'multi',
+                    selected: ['Git', 'Task', 'UserFeedback'],
+                  },
+                ],
+              },
+            },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">handed to voice</span>
+        <AskUserQuestionToolMessage
+          {...props({
+            result: {
+              content: [],
+              details: {
+                answers: [],
+                delivery: 'voice',
+                voicePrompt: 'Which packages should the story batch cover, and which title prefix do layers use?',
+              },
+            },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">cancelled</span>
+        <AskUserQuestionToolMessage
+          {...props({ result: { content: [], details: { answers: [], cancelled: true } } })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed · no details attached</span>
+        <AskUserQuestionToolMessage
+          {...props({ output: 'no interactive session is attached to answer the questionnaire', isError: true })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/layers/ask-user/doompi-user-feedback/src/web/components/QuestionnairePrompt.stories.tsx
+++ b/layers/ask-user/doompi-user-feedback/src/web/components/QuestionnairePrompt.stories.tsx
@@ -1,0 +1,81 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The timeline half of the props comes from the contracts
+ * package's own testing fixture; the prompt half (the open request and the two
+ * ways to settle it) is spelled out here because the fixture covers messages.
+ *
+ * Each block opens on its first question: the prompt shows one question at a
+ * time and the arrow keys walk the rest, which a screenshot cannot press.
+ */
+import type { ToolPromptDialog } from '@agimon-ai/doompi-web-contracts';
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { QuestionnairePrompt } from './QuestionnairePrompt.tsx';
+
+const TOOL_NAME = 'ask_user_question';
+const dialog = (id: string): ToolPromptDialog => ({
+  id,
+  method: 'select',
+  title: TOOL_NAME,
+  message: 'answer to continue',
+  options: [],
+  placeholder: '',
+  prefill: '',
+});
+
+const props = (id: string, questions: unknown[]) => ({
+  ...toolMessagePropsFixture({ toolName: TOOL_NAME, args: { questions }, running: true }).props,
+  dialog: dialog(id),
+  answer: () => undefined,
+  cancel: () => undefined,
+});
+
+const SINGLE = [
+  {
+    header: 'Scope',
+    question: 'Which packages should the story batch cover?',
+    options: [
+      { label: 'All five', description: 'ui, web, git, task and user-feedback' },
+      { label: 'Layers only', description: 'skip the two packages with work in flight' },
+      { label: 'One package', description: 'land a pattern first, then repeat it' },
+    ],
+  },
+  { header: 'Titles', question: 'Which title prefix belongs to a layer package?', options: [] },
+];
+
+const MULTI = [
+  {
+    header: 'Verification',
+    question: 'Which checks must a story pass before it lands?',
+    multiSelect: true,
+    options: [
+      { label: 'Renders', description: 'the style-system renderer returns a PNG' },
+      { label: 'Formatted', description: 'oxfmt leaves the file alone' },
+      { label: 'Typechecked', description: 'tsc --noEmit is clean', preview: 'pnpm exec tsc --noEmit' },
+    ],
+  },
+];
+
+const meta = {
+  title: 'UserFeedback/QuestionnairePrompt',
+  component: QuestionnairePrompt,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex max-w-3xl flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">single select · question 1 of 2</span>
+        <QuestionnairePrompt {...props('q-single', SINGLE)} />
+      </div>
+
+      <div className="flex max-w-3xl flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">multi select · one question</span>
+        <QuestionnairePrompt {...props('q-multi', MULTI)} />
+      </div>
+    </div>
+  ),
+};

--- a/layers/ask-user/doompi-user-feedback/src/web/components/QuestionnairePrompt.tsx
+++ b/layers/ask-user/doompi-user-feedback/src/web/components/QuestionnairePrompt.tsx
@@ -53,7 +53,7 @@ function StepBar({
             data-testid={`questionnaire-step-${String(index)}`}
             data-step-state={active ? 'current' : answered ? 'answered' : 'pending'}
             onClick={() => onPick(index)}
-            className={`gap-1.5 rounded-full px-2.5 py-0.5 text-[10px] ${
+            className={`gap-1.5 rounded-full px-2.5 py-0.5 text-xs ${
               active
                 ? 'bg-doom-selected text-doom-on-selected'
                 : answered
@@ -112,7 +112,7 @@ function QuestionBody({
   const preview = question.options[cursor]?.preview;
   return (
     <div className="flex min-w-0 flex-col gap-2">
-      <p data-testid="questionnaire-question" className="break-words text-[13px] leading-relaxed text-doom-hi">
+      <p data-testid="questionnaire-question" className="break-words text-base leading-relaxed text-doom-hi">
         {question.question}
       </p>
 
@@ -134,15 +134,15 @@ function QuestionBody({
               }
               className="min-w-0 items-start gap-2.5 rounded-md px-2.5 py-1.5 whitespace-normal"
             >
-              <span className={`mt-[2px] shrink-0 text-[11px] ${chosen ? 'text-doom-green' : 'text-doom-faint'}`}>
+              <span className={`mt-[2px] shrink-0 text-sm ${chosen ? 'text-doom-green' : 'text-doom-faint'}`}>
                 {question.multiSelect ? (chosen ? '[x]' : '[ ]') : chosen ? '●' : '○'}
               </span>
               <OptionLabel className="min-w-0 flex flex-col gap-0.5 text-left">
-                <span className={`break-words text-[12px] ${chosen ? 'text-doom-hi' : 'text-doom-text'}`}>
+                <span className={`break-words text-sm ${chosen ? 'text-doom-hi' : 'text-doom-text'}`}>
                   {option.label}
                 </span>
                 {option.description ? (
-                  <span className="break-words text-[11px] leading-relaxed whitespace-normal text-doom-dim">
+                  <span className="break-words text-sm leading-relaxed whitespace-normal text-doom-dim">
                     {option.description}
                   </span>
                 ) : null}
@@ -157,8 +157,8 @@ function QuestionBody({
           onClick={() => onDraft(setCustom(draft, index, entry.custom ?? ''), false)}
           className="min-w-0 items-center gap-2.5 rounded-md px-2.5 py-1.5 whitespace-normal"
         >
-          <span className="shrink-0 text-[11px] text-doom-faint">✎</span>
-          <OptionLabel className="min-w-0 text-[12px] whitespace-normal text-doom-text">{CUSTOM_LABEL}</OptionLabel>
+          <span className="shrink-0 text-sm text-doom-faint">✎</span>
+          <OptionLabel className="min-w-0 text-sm whitespace-normal text-doom-text">{CUSTOM_LABEL}</OptionLabel>
         </OptionRow>
       </div>
 
@@ -173,7 +173,7 @@ function QuestionBody({
             placeholder="type your answer…"
             onChange={(event) => onDraft(setCustom(draft, index, event.target.value), false)}
             onKeyDown={fieldKeys(() => onCommit(true))}
-            className="text-[12px]"
+            className="text-sm"
           />
         </div>
       ) : null}
@@ -181,7 +181,7 @@ function QuestionBody({
       {preview ? (
         <div data-testid="questionnaire-preview" className="flex flex-col gap-1">
           <SectionLabel>preview</SectionLabel>
-          <div className="max-h-40 overflow-y-auto border-l-2 border-doom-edge-magenta pl-3 text-[11px] text-doom-dim">
+          <div className="max-h-40 overflow-y-auto border-l-2 border-doom-edge-magenta pl-3 text-sm text-doom-dim">
             <Markdown text={preview} />
           </div>
         </div>
@@ -196,7 +196,7 @@ function QuestionBody({
           placeholder="anything the options do not cover"
           onChange={(event) => onDraft(setNotes(draft, index, event.target.value), false)}
           onKeyDown={fieldKeys(() => onCommit(false))}
-          className="text-[11px]"
+          className="text-sm"
         />
       </div>
     </div>
@@ -262,7 +262,7 @@ export function QuestionnairePrompt({ args, dialog, answer, cancel }: ToolPrompt
   if (question === undefined) {
     return (
       <div className="flex items-center justify-between gap-3 px-3.5 py-3">
-        <span data-testid="questionnaire-empty" className="text-[12px] text-doom-dim">
+        <span data-testid="questionnaire-empty" className="text-sm text-doom-dim">
           the agent asked something this cockpit could not read
         </span>
         <Button variant="outline" size="sm" data-testid="questionnaire-cancel" onClick={cancel}>
@@ -320,7 +320,7 @@ export function QuestionnairePrompt({ args, dialog, answer, cancel }: ToolPrompt
       <div className="flex min-w-0 flex-wrap items-center gap-2 px-3 pt-2.5 pb-2 sm:gap-3 sm:px-3.5">
         <StepBar questions={questions} draft={draft} current={current} onPick={show} />
         <span className="min-w-0 flex-1" />
-        <Badge size="xs" className="shrink-0 border-transparent bg-doom-panel py-0.5 text-[9px] text-doom-dim">
+        <Badge size="xs" className="shrink-0 border-transparent bg-doom-panel py-0.5 text-2xs text-doom-dim">
           question {current + 1} / {questions.length}
         </Badge>
       </div>
@@ -345,7 +345,7 @@ export function QuestionnairePrompt({ args, dialog, answer, cancel }: ToolPrompt
       <Separator />
 
       <div className="flex min-w-0 items-center gap-2 px-3 py-2 sm:px-3.5">
-        <span data-testid="questionnaire-hint" className="min-w-0 truncate text-[10px] text-doom-faint max-sm:hidden">
+        <span data-testid="questionnaire-hint" className="min-w-0 truncate text-xs text-doom-faint max-sm:hidden">
           <Kbd>←→</Kbd> questions · <Kbd>↑↓</Kbd> options · <Kbd>enter</Kbd>{' '}
           {question.multiSelect ? 'toggles' : 'selects'} · <Kbd>esc</Kbd> cancels
         </span>

--- a/layers/ask-user/doompi-user-feedback/style-system.config.yaml
+++ b/layers/ask-user/doompi-user-feedback/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/layers/ask-user/doompi-user-feedback/styles/preview.css
+++ b/layers/ask-user/doompi-user-feedback/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/layers/ask-user/doompi-user-feedback/vibe-lint.config.yaml
+++ b/layers/ask-user/doompi-user-feedback/vibe-lint.config.yaml
@@ -17,3 +17,14 @@ rules:
   no-raw-theme-color: error
   boundary-import-allowlist: error
   file-naming-convention: error
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/layers/source-control/doompi-git/package.json
+++ b/layers/source-control/doompi-git/package.json
@@ -32,7 +32,8 @@
     "src/prompts",
     "src/types/webWorktrees.ts",
     "src/types/worktreeRegistry.ts",
-    "src/web"
+    "src/web",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -83,6 +84,7 @@
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "5.0.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsdown": "0.22.14",
     "typescript": "7.0.2",
     "vitest": "5.0.0"

--- a/layers/source-control/doompi-git/src/web/components/RunWorktreeToolMessage.stories.tsx
+++ b/layers/source-control/doompi-git/src/web/components/RunWorktreeToolMessage.stories.tsx
@@ -1,0 +1,66 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the tool contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { RunWorktreeToolMessage } from './RunWorktreeToolMessage.tsx';
+
+const LISTING = [
+  'wt/fix-auth  ~/.pi/.doom/git/worktrees/fix-auth  session s7',
+  'wt/split-hub  ~/.pi/.doom/git/worktrees/split-hub  orphaned',
+].join('\n');
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'run_worktree', ...overrides }).props;
+
+const meta = {
+  title: 'Git/RunWorktreeToolMessage',
+  component: RunWorktreeToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running · branch in the heading</span>
+        <RunWorktreeToolMessage
+          {...props({ args: { action: 'spawn_worktree', branch: 'wt/fix-auth' }, running: true })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · listing</span>
+        <RunWorktreeToolMessage {...props({ args: { action: 'list' }, output: LISTING })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · id in the heading</span>
+        <RunWorktreeToolMessage
+          {...props({ args: { action: 'close_worktree', id: 'a1b2c3d4' }, output: 'closed wt/fix-auth' })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <RunWorktreeToolMessage
+          {...props({
+            args: { action: 'close_worktree', id: 'a1b2c3d4' },
+            output: 'refusing to close a dirty worktree; pass force to override',
+            isError: true,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">unknown action</span>
+        <RunWorktreeToolMessage {...props({ args: { action: 'rebase' }, output: 'unsupported action' })} />
+      </div>
+    </div>
+  ),
+};

--- a/layers/source-control/doompi-git/src/web/components/RunWorktreeToolMessage.tsx
+++ b/layers/source-control/doompi-git/src/web/components/RunWorktreeToolMessage.tsx
@@ -24,13 +24,13 @@ export function RunWorktreeToolMessage({ args, output, running, isError }: ToolM
 
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-[11px] font-bold text-doom-hi">
+      <span className="text-sm font-bold text-doom-hi">
         {ACTION_LABEL[action] ?? 'Worktree'}
         {subject === '' ? '' : ` ${subject}`}
         {running ? ' …' : ''}
       </span>
       {output !== '' && (
-        <pre className={`whitespace-pre-wrap text-[10px] ${isError ? 'text-doom-red' : 'text-doom-dim'}`}>{output}</pre>
+        <pre className={`whitespace-pre-wrap text-xs ${isError ? 'text-doom-red' : 'text-doom-dim'}`}>{output}</pre>
       )}
     </div>
   );

--- a/layers/source-control/doompi-git/src/web/components/WorktreesActivitySection.stories.tsx
+++ b/layers/source-control/doompi-git/src/web/components/WorktreesActivitySection.stories.tsx
@@ -1,0 +1,81 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The slot props come from the contracts package's own testing
+ * fixture, and the rows come from the plugin's own session store seeded per
+ * session id, which is exactly where the hub channel puts them.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { WorktreeView } from '../../types/webWorktrees.ts';
+import { worktreeActivity } from '../stores/worktreesActivityStore.ts';
+import { WorktreesActivitySection } from './WorktreesActivitySection.tsx';
+
+const WORKTREES: WorktreeView[] = [
+  {
+    id: 'a1b2c3d4',
+    branch: 'wt/fix-auth',
+    path: '~/.doom/git/worktrees/fix-auth',
+    sessionId: 's7',
+    orphaned: false,
+    unowned: false,
+  },
+  {
+    id: 'e5f6a7b8',
+    branch: 'wt/split-hub',
+    path: '~/.doom/git/worktrees/split-hub',
+    sessionId: null,
+    orphaned: true,
+    unowned: false,
+  },
+  {
+    id: 'c9d0e1f2',
+    branch: 'wt/retry-queue',
+    path: '~/.doom/git/worktrees/retry-queue',
+    sessionId: null,
+    orphaned: false,
+    unowned: true,
+  },
+];
+
+worktreeActivity.update('s-live', () => ({ worktrees: WORKTREES, pending: undefined, error: undefined }));
+worktreeActivity.update('s-busy', () => ({
+  worktrees: WORKTREES.slice(0, 1),
+  pending: 'creating wt/fix-auth: installing dependencies',
+  error: undefined,
+}));
+
+const slot = (sessionId: string | null) => slotPropsFixture({ sessionId }).props;
+
+const meta = {
+  title: 'Git/WorktreesActivitySection',
+  component: WorktreesActivitySection,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex w-80 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">idle · launcher stays</span>
+        <WorktreesActivitySection {...slot('s-idle')} />
+      </div>
+
+      <div className="flex w-80 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">idle · no focused session</span>
+        <WorktreesActivitySection {...slot(null)} />
+      </div>
+
+      <div className="flex w-80 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">three worktrees</span>
+        <WorktreesActivitySection {...slot('s-live')} />
+      </div>
+
+      <div className="flex w-80 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">work in flight</span>
+        <WorktreesActivitySection {...slot('s-busy')} />
+      </div>
+    </div>
+  ),
+};

--- a/layers/source-control/doompi-git/src/web/components/WorktreesActivitySection.tsx
+++ b/layers/source-control/doompi-git/src/web/components/WorktreesActivitySection.tsx
@@ -25,7 +25,7 @@ export function WorktreesActivitySection({ sessionId, openTransientTab }: WebPlu
   if (session.worktrees.length === 0 && session.pending === undefined) {
     return (
       <div className="flex items-center gap-2 px-1">
-        <p data-testid="activity-summary-git" className="px-1 text-[10px] text-doom-faint">
+        <p data-testid="activity-summary-git" className="px-1 text-xs text-doom-faint">
           idle
         </p>
         {sessionId === null ? null : (
@@ -45,18 +45,18 @@ export function WorktreesActivitySection({ sessionId, openTransientTab }: WebPlu
 
   return (
     <div data-testid="activity-git-worktrees" className="flex flex-col gap-0.5">
-      {session.pending === undefined ? null : <p className="px-1 text-[10px] text-doom-dim">{session.pending}</p>}
+      {session.pending === undefined ? null : <p className="px-1 text-xs text-doom-dim">{session.pending}</p>}
       {session.worktrees.map((worktree: WorktreeView) => (
         <button
           key={worktree.id}
           type="button"
           data-testid={`activity-git-worktree-${worktree.id}`}
-          className="flex items-center gap-2 px-1 text-left text-[11px] text-doom-dim hover:text-doom-bright"
+          className="flex items-center gap-2 px-1 text-left text-sm text-doom-dim hover:text-doom-bright"
           onClick={() => openTransientTab(worktreesTab())}
         >
           <span className="truncate">{worktree.branch}</span>
-          {worktree.orphaned ? <span className="text-[10px] text-doom-faint">orphaned</span> : null}
-          {worktree.unowned ? <span className="text-[10px] text-doom-faint">unowned</span> : null}
+          {worktree.orphaned ? <span className="text-xs text-doom-faint">orphaned</span> : null}
+          {worktree.unowned ? <span className="text-xs text-doom-faint">unowned</span> : null}
         </button>
       ))}
     </div>

--- a/layers/source-control/doompi-git/src/web/components/WorktreesPanel.stories.tsx
+++ b/layers/source-control/doompi-git/src/web/components/WorktreesPanel.stories.tsx
@@ -1,0 +1,76 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The slot props come from the contracts package's own testing
+ * fixture, and the rows come from the plugin's own session store seeded per
+ * session id, which is exactly where the hub channel puts them.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { WorktreeView } from '../../types/webWorktrees.ts';
+import { worktreeActivity } from '../stores/worktreesActivityStore.ts';
+import { WorktreesPanel } from './WorktreesPanel.tsx';
+
+const WORKTREES: WorktreeView[] = [
+  {
+    id: 'a1b2c3d4',
+    branch: 'wt/fix-auth',
+    path: '~/.doom/git/worktrees/fix-auth',
+    sessionId: 's7',
+    orphaned: false,
+    unowned: false,
+  },
+  {
+    id: 'e5f6a7b8',
+    branch: 'wt/split-hub',
+    path: '~/.doom/git/worktrees/split-hub',
+    sessionId: null,
+    orphaned: true,
+    unowned: false,
+  },
+  {
+    id: 'c9d0e1f2',
+    branch: 'wt/retry-queue',
+    path: '~/.doom/git/worktrees/retry-queue',
+    sessionId: null,
+    orphaned: false,
+    unowned: true,
+  },
+];
+
+worktreeActivity.update('panel-live', () => ({ worktrees: WORKTREES, pending: undefined, error: undefined }));
+worktreeActivity.update('panel-busy', () => ({
+  worktrees: WORKTREES.slice(0, 1),
+  pending: 'creating wt/fix-auth: installing dependencies',
+  error: 'close refused: wt/split-hub has uncommitted changes',
+}));
+
+const slot = (sessionId: string | null) => slotPropsFixture({ sessionId }).props;
+
+const meta = {
+  title: 'Git/WorktreesPanel',
+  component: WorktreesPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">empty</span>
+        <WorktreesPanel {...slot('panel-empty')} />
+      </div>
+
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">three worktrees</span>
+        <WorktreesPanel {...slot('panel-live')} />
+      </div>
+
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">work in flight · last failure</span>
+        <WorktreesPanel {...slot('panel-busy')} />
+      </div>
+    </div>
+  ),
+};

--- a/layers/source-control/doompi-git/src/web/components/WorktreesPanel.tsx
+++ b/layers/source-control/doompi-git/src/web/components/WorktreesPanel.tsx
@@ -71,24 +71,24 @@ export function WorktreesPanel({ sessionId }: WebPluginSlotProps) {
             Create
           </Button>
         </div>
-        <p className="text-[10px] text-doom-faint">
+        <p className="text-xs text-doom-faint">
           Creates the worktree outside the repository, installs its dependencies, then starts a session nested under
           this one. The install is what makes the wait; a warm store is under a minute.
         </p>
         {session.pending === undefined ? null : (
-          <p data-testid="git-worktree-pending" className="text-[10px] text-doom-dim">
+          <p data-testid="git-worktree-pending" className="text-xs text-doom-dim">
             {session.pending}
           </p>
         )}
         {session.error === undefined ? null : (
-          <p data-testid="git-worktree-error" className="text-[10px] text-doom-error">
+          <p data-testid="git-worktree-error" className="text-xs text-doom-error">
             {session.error}
           </p>
         )}
       </div>
 
       {session.worktrees.length === 0 ? (
-        <p className="text-[11px] text-doom-faint">No worktrees yet.</p>
+        <p className="text-sm text-doom-faint">No worktrees yet.</p>
       ) : (
         <ul className="flex flex-col gap-1">
           {session.worktrees.map((worktree: WorktreeView) => (
@@ -98,12 +98,12 @@ export function WorktreesPanel({ sessionId }: WebPluginSlotProps) {
               className="flex items-center justify-between gap-2 border border-doom-line px-2 py-1"
             >
               <div className="flex min-w-0 flex-col">
-                <span className="truncate text-[11px] text-doom-bright">{worktree.branch}</span>
-                <span className="truncate text-[10px] text-doom-faint">{worktree.path}</span>
+                <span className="truncate text-sm text-doom-bright">{worktree.branch}</span>
+                <span className="truncate text-xs text-doom-faint">{worktree.path}</span>
               </div>
               <div className="flex items-center gap-2">
-                {worktree.orphaned ? <span className="text-[10px] text-doom-faint">orphaned</span> : null}
-                {worktree.unowned ? <span className="text-[10px] text-doom-faint">unowned</span> : null}
+                {worktree.orphaned ? <span className="text-xs text-doom-faint">orphaned</span> : null}
+                {worktree.unowned ? <span className="text-xs text-doom-faint">unowned</span> : null}
                 {sessionId === null ? null : (
                   <Button
                     variant="link"

--- a/layers/source-control/doompi-git/style-system.config.yaml
+++ b/layers/source-control/doompi-git/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/layers/source-control/doompi-git/styles/preview.css
+++ b/layers/source-control/doompi-git/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/layers/source-control/doompi-git/vibe-lint.config.yaml
+++ b/layers/source-control/doompi-git/vibe-lint.config.yaml
@@ -14,3 +14,14 @@ rules:
   public-export-boundary: error
   no-internal-public-import: error
   doom-layer-boundary: error
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/layers/task/doompi-task/package.json
+++ b/layers/task/doompi-task/package.json
@@ -30,7 +30,8 @@
     "src/web",
     "src/exports/webClient.ts",
     "src/types/webTasks.ts",
-    "package.json"
+    "package.json",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -188,6 +189,7 @@
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "5.0.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsdown": "0.23.0",
     "typescript": "7.0.2",
     "vitest": "5.0.0"

--- a/layers/task/doompi-task/src/web/components/TaskDetailDialog.stories.tsx
+++ b/layers/task/doompi-task/src/web/components/TaskDetailDialog.stories.tsx
@@ -1,0 +1,48 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition.
+ *
+ * One dialog only. The component owns its DialogContent, which is portalled to
+ * document.body and centred, so a second mode rendered beside it would land on
+ * exactly the same pixels; edit and message are reached from the buttons here.
+ * The sender comes from the contracts package's own testing fixture, so an edit
+ * is recorded rather than sent.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { WebTask } from '../../types/webTasks.ts';
+import { TaskDetailDialog } from './TaskDetailDialog.tsx';
+
+const TASK: WebTask = {
+  id: 12,
+  subject: 'Render every plugin story and read the PNG',
+  description:
+    'One story file beside each component, verified through the style-system renderer. A component that cannot mount is reported rather than left broken.',
+  activeForm: 'rendering stories',
+  status: 'in_progress',
+  blockedBy: [9, 11],
+  owner: 'doompi-developer',
+  updatedAt: '2025-03-04T09:41:00Z',
+  delegation: { agent: 'doompi-developer', state: 'running' },
+};
+
+const slot = slotPropsFixture({ sessionId: 's1' }).props;
+
+const meta = {
+  title: 'Task/TaskDetailDialog',
+  component: TaskDetailDialog,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex min-h-96 flex-col gap-6 bg-doom-bg p-6">
+      <span className="text-2xs text-doom-dim uppercase tracking-widest">
+        view mode · a delegated task with every fact set
+      </span>
+      <TaskDetailDialog task={TASK} sessionId="s1" mode="view" send={slot.sendSessionFrame} onClose={() => undefined} />
+    </div>
+  ),
+};

--- a/layers/task/doompi-task/src/web/components/TaskDetailDialog.tsx
+++ b/layers/task/doompi-task/src/web/components/TaskDetailDialog.tsx
@@ -27,7 +27,7 @@ const DESCRIPTION_ROWS = 5;
 const MESSAGE_ROWS = 4;
 
 function FieldLabel({ children }: { children: string }) {
-  return <span className="text-[9px] font-bold tracking-[0.18em] text-doom-faint">{children}</span>;
+  return <span className="text-2xs font-bold tracking-widest text-doom-faint">{children}</span>;
 }
 
 function Field({ label, children }: { label: string; children: ReactNode }) {
@@ -41,7 +41,7 @@ function Field({ label, children }: { label: string; children: ReactNode }) {
 
 function ReadOnlyValue({ value, testId }: { value: string; testId: string }) {
   return (
-    <span data-testid={testId} className="whitespace-pre-wrap break-words text-[11px] leading-relaxed text-doom-dim">
+    <span data-testid={testId} className="whitespace-pre-wrap break-words text-sm leading-relaxed text-doom-dim">
       {value}
     </span>
   );
@@ -128,7 +128,7 @@ export function TaskDetailDialog({
       <DialogContent width="lg" data-testid="task-detail-dialog" data-mode={mode} aria-describedby={undefined}>
         <DialogHeader>
           <div className="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-2.5">
-            <span className="text-[9px] text-doom-faint">task #{task.id}</span>
+            <span className="text-2xs text-doom-faint">task #{task.id}</span>
             <DialogTitle data-testid="task-detail-title" className="max-w-full break-words">
               {task.subject}
             </DialogTitle>
@@ -189,7 +189,7 @@ export function TaskDetailDialog({
                 >
                   <SelectTrigger
                     data-testid="task-detail-status-input"
-                    className="h-7 w-full min-w-0 text-[10px] sm:min-w-[200px]"
+                    className="h-7 w-full min-w-0 text-xs sm:min-w-[200px]"
                   >
                     <SelectValue />
                   </SelectTrigger>
@@ -203,7 +203,7 @@ export function TaskDetailDialog({
                 </Select>
               </Field>
               <DialogFooter className="flex-wrap sm:flex-nowrap">
-                <span className="w-full text-[9px] text-doom-faint sm:w-auto">
+                <span className="w-full text-2xs text-doom-faint sm:w-auto">
                   saved as one prompt naming only the fields you changed
                 </span>
                 <span className="min-w-0 flex-1" />
@@ -230,7 +230,7 @@ export function TaskDetailDialog({
                 />
               </Field>
               <DialogFooter className="flex-wrap sm:flex-nowrap">
-                <span className="w-full text-[9px] text-doom-faint sm:w-auto">
+                <span className="w-full text-2xs text-doom-faint sm:w-auto">
                   steers the run, it does not edit the task
                 </span>
                 <span className="min-w-0 flex-1" />

--- a/layers/task/doompi-task/src/web/components/TaskToolMessage.stories.tsx
+++ b/layers/task/doompi-task/src/web/components/TaskToolMessage.stories.tsx
@@ -1,0 +1,111 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the tool contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { TaskToolMessage } from './TaskToolMessage.tsx';
+
+const TASKS = [
+  { id: 1, subject: 'Seed the plugin story files', status: 'completed', blockedBy: [] },
+  {
+    id: 2,
+    subject: 'Render every story and read the PNG',
+    status: 'in_progress',
+    activeForm: 'rendering stories',
+    blockedBy: [1],
+    delegation: { agent: 'doompi-developer', state: 'running' },
+  },
+  {
+    id: 3,
+    subject: 'Report the tokens the panel names but the theme does not define',
+    status: 'pending',
+    blockedBy: [2],
+  },
+  { id: 4, subject: 'Re-run the lint gate', status: 'failed', blockedBy: [] },
+];
+
+const details = (extra: Record<string, unknown>) => ({ params: {}, tasks: TASKS, ...extra });
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'task', ...overrides }).props;
+
+const meta = {
+  title: 'Task/TaskToolMessage',
+  component: TaskToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <TaskToolMessage
+          {...props({
+            args: { action: 'assign', assignments: [{ id: 2, agent: 'doompi-developer' }] },
+            output: 'starting doompi-developer',
+            running: true,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">list · every status</span>
+        <TaskToolMessage
+          {...props({
+            args: { action: 'list' },
+            result: { content: [], details: details({ action: 'list' }) },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">upsert · one task</span>
+        <TaskToolMessage
+          {...props({
+            args: { action: 'upsert', tasks: [{ id: 2, status: 'in_progress' }] },
+            result: {
+              content: [],
+              details: details({ action: 'upsert', upsert: { applied: [2], failed: 0 } }),
+            },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">assign · batch with a failure</span>
+        <TaskToolMessage
+          {...props({
+            args: {
+              action: 'assign',
+              assignments: [
+                { id: 2, agent: 'doompi-developer' },
+                { id: 3, agent: 'doompi-reviewer' },
+              ],
+            },
+            result: {
+              content: [],
+              details: details({ action: 'assign', assignment: { assigned: [2, 3], failed: 1 } }),
+            },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <TaskToolMessage
+          {...props({
+            args: { action: 'get', id: 9 },
+            output: 'task #9 does not exist',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/layers/task/doompi-task/src/web/components/TasksActivitySection.stories.tsx
+++ b/layers/task/doompi-task/src/web/components/TasksActivitySection.stories.tsx
@@ -1,0 +1,70 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The slot props come from the contracts package's own testing
+ * fixture, and the rows come from the plugin's own session store seeded per
+ * session id, which is exactly where the hub channel puts them.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { WebTask } from '../../types/webTasks.ts';
+import { tasks } from '../stores/tasksStore.ts';
+import { TasksActivitySection } from './TasksActivitySection.tsx';
+
+const ACTIVE: WebTask[] = [
+  {
+    id: 1,
+    subject: 'Render every plugin story and read the PNG',
+    status: 'in_progress',
+    activeForm: 'rendering stories',
+    blockedBy: [],
+    delegation: { agent: 'doompi-developer', state: 'running' },
+  },
+  {
+    id: 2,
+    subject: 'Report the tokens the worktrees panel names but the theme does not define',
+    description: 'text-doom-error and border-doom-line resolve to nothing',
+    status: 'pending',
+    blockedBy: [1],
+  },
+];
+
+const CLOSED: WebTask[] = [
+  { id: 3, subject: 'Seed the plugin story files', status: 'completed', blockedBy: [], owner: 'main' },
+  { id: 4, subject: 'Re-run the lint gate', status: 'failed', blockedBy: [] },
+];
+
+tasks.update('s-active', () => ({ tasks: ACTIVE, rev: 1 }));
+tasks.update('s-mixed', () => ({ tasks: [...ACTIVE, ...CLOSED], rev: 2 }));
+
+const slot = (sessionId: string) => slotPropsFixture({ sessionId }).props;
+
+const meta = {
+  title: 'Task/TasksActivitySection',
+  component: TasksActivitySection,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex w-80 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">active only</span>
+        <TasksActivitySection {...slot('s-active')} />
+      </div>
+
+      <div className="flex w-80 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">active · session history collapsed</span>
+        <TasksActivitySection {...slot('s-mixed')} />
+      </div>
+
+      <div className="flex w-80 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          no tasks · the section has no cockpit presence
+        </span>
+        <TasksActivitySection {...slot('s-empty')} />
+      </div>
+    </div>
+  ),
+};

--- a/layers/task/doompi-task/src/web/components/TasksActivitySection.tsx
+++ b/layers/task/doompi-task/src/web/components/TasksActivitySection.tsx
@@ -50,7 +50,7 @@ function TaskRow({
     <div
       data-testid={`activity-task-${task.id}`}
       data-task-status={task.status}
-      className="flex flex-col gap-1 rounded-[5px] px-1 py-1"
+      className="flex flex-col gap-1 rounded-md px-1 py-1"
     >
       <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-x-1.5">
         <Dot tone={STATUS_TONE[task.status]} pulse={task.status === 'in_progress'} />
@@ -59,11 +59,11 @@ function TaskRow({
           data-testid={`activity-task-title-${task.id}`}
           title={task.subject}
           onClick={() => openDialog('view')}
-          className={`min-w-0 truncate text-left text-[10px] font-bold hover:underline ${task.status === 'failed' ? 'text-doom-red' : task.status === 'completed' ? 'text-doom-dim' : 'text-doom-hi'}`}
+          className={`min-w-0 truncate text-left text-xs font-bold hover:underline ${task.status === 'failed' ? 'text-doom-red' : task.status === 'completed' ? 'text-doom-dim' : 'text-doom-hi'}`}
         >
           <span className="text-doom-faint">#{task.id}</span> {task.subject}
         </button>
-        <span className="shrink-0 text-[8px] text-doom-faint">{task.status.replace('_', ' ')}</span>
+        <span className="shrink-0 text-2xs text-doom-faint">{task.status.replace('_', ' ')}</span>
         {task.status !== 'completed' && task.status !== 'deleted' ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -105,7 +105,7 @@ function TaskRow({
         ) : null}
       </div>
       {detail || agent || task.blockedBy.length > 0 ? (
-        <span className="truncate pl-3 text-[9px] text-doom-faint">
+        <span className="truncate pl-3 text-2xs text-doom-faint">
           {agent ? `[${agent}] ` : ''}
           {detail ?? ''}
           {task.blockedBy.length > 0 ? ` · blocked by ${task.blockedBy.map((id) => `#${id}`).join(', ')}` : ''}
@@ -131,15 +131,13 @@ export function TasksActivitySection({ sessionId, sendSessionFrame }: WebPluginS
         <span
           aria-hidden
           className={
-            active.length > 0
-              ? 'animate-pulse text-[11px] font-bold text-doom-yellow'
-              : 'text-[11px] font-bold text-doom-faint'
+            active.length > 0 ? 'animate-pulse text-sm font-bold text-doom-yellow' : 'text-sm font-bold text-doom-faint'
           }
         >
           #
         </span>
-        <span className="flex-1 text-[11px] font-bold text-doom-text">tasks</span>
-        <span className="text-[9px] text-doom-faint">{active.length} active</span>
+        <span className="flex-1 text-sm font-bold text-doom-text">tasks</span>
+        <span className="text-2xs text-doom-faint">{active.length} active</span>
       </div>
       {active.length > 0 ? (
         <div className="flex flex-col gap-0.5">
@@ -161,15 +159,15 @@ export function TasksActivitySection({ sessionId, sendSessionFrame }: WebPluginS
             size="xs"
             aria-expanded={historyOpen}
             onClick={() => setHistoryOpen((open) => !open)}
-            className="justify-start gap-1.5 rounded-[5px] px-1 py-0.5 hover:bg-doom-panel"
+            className="justify-start gap-1.5 rounded-md px-1 py-0.5 hover:bg-doom-panel"
           >
             {historyOpen ? (
               <ChevronDownIcon className="h-2.5 w-2.5 text-doom-faint" />
             ) : (
               <ChevronRightIcon className="h-2.5 w-2.5 text-doom-faint" />
             )}
-            <span className="text-[10px] font-bold text-doom-dim">session</span>
-            <span className="text-[9px] text-doom-faint">{history.length}</span>
+            <span className="text-xs font-bold text-doom-dim">session</span>
+            <span className="text-2xs text-doom-faint">{history.length}</span>
           </Button>
           {historyOpen ? (
             <div className="flex flex-col gap-0.5 pl-2">

--- a/layers/task/doompi-task/style-system.config.yaml
+++ b/layers/task/doompi-task/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/layers/task/doompi-task/styles/preview.css
+++ b/layers/task/doompi-task/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/layers/task/doompi-task/vibe-lint.config.yaml
+++ b/layers/task/doompi-task/vibe-lint.config.yaml
@@ -19,6 +19,15 @@ rules:
   file-naming-convention: error
 
 overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off
   # These two commands render their own output rather than returning a value the
   # Pi adapter renders, which is how doompi-mcp keeps commands free of the TUI.
   # Inverting that is a behaviour change, so it is tracked separately and these

--- a/layers/team/doompi-team/package.json
+++ b/layers/team/doompi-team/package.json
@@ -29,7 +29,8 @@
     "dist",
     "src/web",
     "src/exports/webClient.ts",
-    "src/types/webSubagents.ts"
+    "src/types/webSubagents.ts",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "types": "./dist/index.d.mts",
@@ -83,6 +84,7 @@
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "5.0.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "typescript": "7.0.2",
     "vitest": "5.0.0"
   },

--- a/layers/team/doompi-team/src/adapters/asyncJobTracker.ts
+++ b/layers/team/doompi-team/src/adapters/asyncJobTracker.ts
@@ -112,6 +112,7 @@ export interface TrackedAsyncJob {
   /** Which runtime is executing this run. Absent means the default `pi` path. */
   runtime?: string;
   tokens?: number;
+  cost?: number;
   currentTool?: string;
   toolCount?: number;
 }
@@ -187,6 +188,7 @@ interface ReadStatusResult {
   attentionReason?: string;
   runtime?: string;
   tokens?: number;
+  cost?: number;
   currentTool?: string;
   toolCount?: number;
 }
@@ -279,6 +281,7 @@ export class AsyncJobTracker implements AsyncJobTrackerContract {
       attentionReason: status.attentionReason,
       runtime: status.runtime,
       tokens: status.tokens,
+      cost: status.cost,
       currentTool: status.currentTool,
       toolCount: status.toolCount,
     };
@@ -321,6 +324,7 @@ export class AsyncJobTracker implements AsyncJobTrackerContract {
       existing.status !== job.status ||
       existing.updatedAt !== job.updatedAt ||
       existing.tokens !== job.tokens ||
+      existing.cost !== job.cost ||
       existing.currentTool !== job.currentTool ||
       existing.toolCount !== job.toolCount
     );

--- a/layers/team/doompi-team/src/adapters/pi/extensions/subagentPromptRuntime.ts
+++ b/layers/team/doompi-team/src/adapters/pi/extensions/subagentPromptRuntime.ts
@@ -99,6 +99,7 @@ import {
   type ChildTranscriptMessage,
   formatToolActivity,
   getMessageActivity,
+  getMessageUsageCost,
   getMessageUsageTokens,
 } from '../../process/childTranscript';
 import { resolveWatchPath } from '../../filesystem/configDir';
@@ -422,6 +423,7 @@ export function registerRunnerLifecycle(
 
   let resolved: { teamContext: TeamMemberContext | undefined } | undefined;
   let cumulativeTokens: number | undefined;
+  let cumulativeCost = 0;
   let toolCount = 0;
   const countedMessages = new WeakSet<object>();
 
@@ -481,7 +483,8 @@ export function registerRunnerLifecycle(
     const messageTokens = getMessageUsageTokens(event.message);
     if (messageTokens === undefined) return;
     cumulativeTokens = (cumulativeTokens ?? 0) + messageTokens;
-    execution.setProgress({ tokens: cumulativeTokens });
+    cumulativeCost += getMessageUsageCost(event.message) ?? 0;
+    execution.setProgress({ tokens: cumulativeTokens, cost: cumulativeCost });
   });
   onEvent<{ toolName?: string; tool?: { name?: string }; args?: Record<string, unknown> }>(
     pi,

--- a/layers/team/doompi-team/src/adapters/pi/tui/fleetStatus.ts
+++ b/layers/team/doompi-team/src/adapters/pi/tui/fleetStatus.ts
@@ -5,6 +5,8 @@ import { type TrackedAsyncJobsContract, TERMINAL_ASYNC_JOB_STATES, type TrackedA
 import type { ActivityState } from '../../../types';
 
 export const FLEET_STATUS_KEY = 'doom-team-agents';
+/** Session cost total, published as a plain decimal string a consumer reads with `Number()`. */
+export const COST_STATUS_KEY = 'doom-team-cost';
 export const AGENT_PULSE_FRAMES = ['◐', '●', '◑'] as const;
 
 const FULL_PREFIX = 'Agents ';

--- a/layers/team/doompi-team/src/adapters/pi/tui/register.ts
+++ b/layers/team/doompi-team/src/adapters/pi/tui/register.ts
@@ -22,7 +22,7 @@ import type { PollSchedulerContract } from '../../pollScheduler';
 import { type AgentLaunchRequest, openAgentCatalog } from './agentCatalog';
 import { buildAgentCatalogEntries } from './agentResourceProjection';
 import { type FleetActionDispatcher, openSubagentFleet } from './fleet';
-import { AGENT_PULSE_FRAMES, agentFleetStatus, FLEET_STATUS_KEY } from './fleetStatus';
+import { AGENT_PULSE_FRAMES, agentFleetStatus, COST_STATUS_KEY, FLEET_STATUS_KEY } from './fleetStatus';
 
 export const SUBAGENT_FLEET_COMMAND = 'subagents-fleet';
 export const SUBAGENT_LIST_COMMAND = 'subagents-list';
@@ -37,6 +37,8 @@ const SUBAGENT_LEADER_SEGMENT = {
 const AGENT_FOOTER_ORDER = 20;
 const AGENT_STATUS_POLL_INTERVAL_MS = 250;
 const REQUESTED_STATUS = 'requested';
+/** Sub-cent precision: below any real run cost, short enough to read. */
+const COST_DECIMALS = 6;
 
 /** Publishes the nested SPC a menu for available agents and current-session runs. */
 export function registerSubagentLeaderContribution(hub: DoomUiHubService): () => void {
@@ -135,7 +137,21 @@ export function registerAgentStatus(
   hub: DoomUiHubService,
   deps: RegisterFleetCommandDeps,
 ): () => void {
-  let current: { ctx: ExtensionContext; jobs: TrackedAsyncJobsContract; fingerprint: string | undefined } | undefined;
+  let current:
+    | {
+        ctx: ExtensionContext;
+        jobs: TrackedAsyncJobsContract;
+        fingerprint: string | undefined;
+        /**
+         * Last-seen cost per run. The tracker evicts a finished run once its
+         * retention window expires, so summing `list()` alone would make the
+         * session total drop; remembering the run's final figure here keeps it
+         * monotonic for as long as the session lives.
+         */
+        costs: Map<string, number>;
+        costText: string | undefined;
+      }
+    | undefined;
   let disposed = false;
   let frame = 0;
   const footerContribution = hub.registerFooter({
@@ -144,11 +160,31 @@ export function registerAgentStatus(
     order: AGENT_FOOTER_ORDER,
   });
 
+  const publishCost = (): boolean => {
+    if (!current) return false;
+    for (const job of current.jobs.list()) {
+      if (job.cost !== undefined) current.costs.set(job.runId, job.cost);
+    }
+    let total = 0;
+    for (const cost of current.costs.values()) total += cost;
+    // Repeated float addition leaves artifacts ('0.30000000000000004'); the
+    // consumer reads this with Number(), so round to sub-cent precision first.
+    // A zero total is published as nothing at all, so a session that never ran
+    // an agent contributes no chip.
+    const text = total > 0 ? String(Number(total.toFixed(COST_DECIMALS))) : undefined;
+    if (text === current.costText) return false;
+    current.costText = text;
+    if (current.ctx.hasUI) current.ctx.ui.setStatus(COST_STATUS_KEY, text);
+    return true;
+  };
+
   const publish = (force = false): boolean => {
     if (!current) return false;
+    const costChanged = publishCost();
     const status = agentFleetStatus(current.jobs, frame);
     const fingerprint = status?.fingerprint;
-    if (!force && fingerprint === current.fingerprint) return false;
+    // The fleet fingerprint ignores cost, so cost is published above the guard.
+    if (!force && fingerprint === current.fingerprint) return costChanged;
     footerContribution.update(status?.footer);
     if (current.ctx.hasUI) current.ctx.ui.setStatus(FLEET_STATUS_KEY, status?.text);
     current.fingerprint = fingerprint;
@@ -170,6 +206,8 @@ export function registerAgentStatus(
       ctx,
       jobs: deps.tracker.forSession(ctx.sessionManager.getSessionId()),
       fingerprint: undefined,
+      costs: new Map(),
+      costText: undefined,
     };
     publish(true);
   });
@@ -179,7 +217,10 @@ export function registerAgentStatus(
     disposed = true;
     unregisterPoll();
     footerContribution.dispose();
-    if (current?.ctx.hasUI) current.ctx.ui.setStatus(FLEET_STATUS_KEY, undefined);
+    if (current?.ctx.hasUI) {
+      current.ctx.ui.setStatus(FLEET_STATUS_KEY, undefined);
+      current.ctx.ui.setStatus(COST_STATUS_KEY, undefined);
+    }
     current = undefined;
   };
 }

--- a/layers/team/doompi-team/src/adapters/process/childTranscript.ts
+++ b/layers/team/doompi-team/src/adapters/process/childTranscript.ts
@@ -218,6 +218,17 @@ export function getMessageUsageTokens(message: ChildTranscriptMessage): number |
 }
 
 /**
+ * Return the cost observed on one finalized child message.
+ *
+ * Same observation contract as `getMessageUsageTokens`: absent usage is no
+ * observation and returns undefined, while a usage object whose cost is
+ * missing or unreadable is a real zero (see `normalizeUsage`).
+ */
+export function getMessageUsageCost(message: ChildTranscriptMessage): number | undefined {
+  if (message.role !== 'assistant' || !message.usage || typeof message.usage !== 'object') return undefined;
+  return normalizeUsage(message.usage)?.cost;
+}
+/**
  * A bounded tail of the assistant's current streamed text/thinking.
  *
  * The tail changes as the model streams, so a parent can show what the child is

--- a/layers/team/doompi-team/src/adapters/runs/background/asyncExecution.ts
+++ b/layers/team/doompi-team/src/adapters/runs/background/asyncExecution.ts
@@ -260,6 +260,8 @@ export interface AsyncRunStatus extends StatusWithRecentEntries {
   noTools?: boolean;
   /** Cumulative tokens observed from finalized child messages. */
   tokens?: number;
+  /** Cumulative cost observed from finalized child messages. */
+  cost?: number;
   /** Most recently started child tool. */
   currentTool?: string;
   /** Number of child tool executions observed so far. */

--- a/layers/team/doompi-team/src/adapters/runs/background/runnerExecution.ts
+++ b/layers/team/doompi-team/src/adapters/runs/background/runnerExecution.ts
@@ -54,6 +54,7 @@ export interface RunnerExecutionHandlers {
 
 export interface RunnerProgress {
   tokens?: number;
+  cost?: number;
   currentTool?: string;
   toolCount?: number;
 }
@@ -104,11 +105,17 @@ export class RunnerExecution implements RunnerExecutionContract {
   }
 
   setProgress(progress: RunnerProgress): void {
-    if (progress.tokens === undefined && progress.currentTool === undefined && progress.toolCount === undefined) {
+    if (
+      progress.tokens === undefined &&
+      progress.cost === undefined &&
+      progress.currentTool === undefined &&
+      progress.toolCount === undefined
+    ) {
       return;
     }
     this.statusWriter.update((status) => {
       if (progress.tokens !== undefined) status.tokens = progress.tokens;
+      if (progress.cost !== undefined) status.cost = progress.cost;
       if (progress.currentTool !== undefined) status.currentTool = progress.currentTool;
       if (progress.toolCount !== undefined) status.toolCount = progress.toolCount;
       status.lastUpdate = Date.now();

--- a/layers/team/doompi-team/src/services/webSubagentRuns.ts
+++ b/layers/team/doompi-team/src/services/webSubagentRuns.ts
@@ -118,6 +118,7 @@ export function parseSubagentRun(raw: string): SubagentRun | undefined {
       : { currentTool: asOptionalString(parsed.currentTool) }),
     ...(asOptionalNumber(parsed.toolCount) === undefined ? {} : { toolCount: asOptionalNumber(parsed.toolCount) }),
     ...(asOptionalNumber(parsed.tokens) === undefined ? {} : { tokens: asOptionalNumber(parsed.tokens) }),
+    ...(asOptionalNumber(parsed.cost) === undefined ? {} : { cost: asOptionalNumber(parsed.cost) }),
     ...(summary === undefined ? {} : { summary }),
     ...(error === undefined ? {} : { error }),
     tail,

--- a/layers/team/doompi-team/src/types/webSubagents.ts
+++ b/layers/team/doompi-team/src/types/webSubagents.ts
@@ -30,6 +30,7 @@ export interface SubagentRun {
   currentTool?: string;
   toolCount?: number;
   tokens?: number;
+  cost?: number;
   /** Final report, present once the run finished. */
   summary?: string;
   /** Failure reason, present when the run failed. */

--- a/layers/team/doompi-team/src/web/components/AgentCatalogDrawer.stories.tsx
+++ b/layers/team/doompi-team/src/web/components/AgentCatalogDrawer.stories.tsx
@@ -1,0 +1,89 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`. The rows come from the real catalog
+ * session store, seeded at module scope, which is the drawer's only input.
+ */
+import type { SubagentCatalogAgent } from '../../types/webSubagents.ts';
+import { catalog } from '../stores/catalogStore.ts';
+import { AgentCatalogDrawer } from './AgentCatalogDrawer.tsx';
+
+const agent = (
+  overrides: Partial<SubagentCatalogAgent> & Pick<SubagentCatalogAgent, 'name' | 'source' | 'description'>,
+): SubagentCatalogAgent => ({
+  fallbackModels: [],
+  tools: [],
+  skills: [],
+  extensions: [],
+  defaultContext: 'fresh',
+  filePath: `.doom/agents/${overrides.name}.md`,
+  ...overrides,
+});
+
+catalog.update('catalog-full', (current) => ({
+  ...current,
+  cwd: '/Users/dev/workspace/doompi',
+  models: ['anthropic/claude-sonnet-4-5', 'openai/gpt-5'],
+  open: true,
+  selected: 'reviewer',
+  inspected: 'reviewer',
+  agents: [
+    agent({
+      name: 'reviewer',
+      source: 'project',
+      description: 'reviews a diff for defects, regressions, and contract violations',
+      model: 'anthropic/claude-sonnet-4-5',
+      tools: ['read', 'grep', 'bash', 'edit'],
+      skills: ['doompi-review'],
+      extensions: ['doompi-file-edit'],
+    }),
+    agent({
+      name: 'tester',
+      source: 'project',
+      description: 'writes and runs the focused suites for a change',
+      tools: ['read', 'bash'],
+      skills: ['doompi-testing'],
+      defaultContext: 'fork',
+    }),
+    agent({
+      name: 'scout',
+      source: 'user',
+      description: 'reads a codebase and reports back without editing',
+      filePath: '~/.doompi/agent/agents/scout.md',
+    }),
+    agent({
+      name: 'ponytail',
+      source: 'plugin',
+      packageName: '@agimon-ai/doompi-development',
+      description: 'the lazy senior developer; smallest coherent change, no scaffolding',
+      tools: ['read', 'edit', 'bash', 'grep', 'write'],
+      filePath: 'plugins/development/agents/ponytail.md',
+    }),
+  ],
+}));
+
+catalog.update('catalog-empty', (current) => ({
+  ...current,
+  cwd: '/tmp/scratch',
+  open: true,
+  warning: 'the agent directory could not be read: EACCES',
+}));
+
+const meta = {
+  title: 'Team/AgentCatalogDrawer',
+  component: AgentCatalogDrawer,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+const noop = () => {};
+
+export const Playground = {
+  render: () => (
+    <div className="flex h-screen gap-6 bg-doom-bg p-6">
+      <AgentCatalogDrawer sessionId="catalog-full" onClose={noop} onLaunch={noop} />
+      <AgentCatalogDrawer sessionId="catalog-empty" onClose={noop} onLaunch={noop} />
+    </div>
+  ),
+};

--- a/layers/team/doompi-team/src/web/components/AgentCatalogDrawer.tsx
+++ b/layers/team/doompi-team/src/web/components/AgentCatalogDrawer.tsx
@@ -21,7 +21,7 @@ function Resources({ agent }: { agent: SubagentCatalogAgent }) {
     ['file', agent.filePath],
   ];
   return (
-    <dl data-testid={`catalog-resources-${agent.name}`} className="flex flex-col gap-1 pt-1 text-[9px]">
+    <dl data-testid={`catalog-resources-${agent.name}`} className="flex flex-col gap-1 pt-1 text-2xs">
       {rows.map(([label, value]) => (
         <div key={label} className="flex gap-2">
           <dt className="w-16 shrink-0 text-doom-faint">{label}</dt>
@@ -62,17 +62,17 @@ function AgentRow({
       }`}
     >
       <div className="flex min-w-0 items-center gap-2">
-        <span className="truncate text-[12px] font-bold text-doom-hi">{agent.name}</span>
+        <span className="truncate text-sm font-bold text-doom-hi">{agent.name}</span>
         <Badge size="xs" className="shrink-0">
           {agent.packageName ?? agent.source}
         </Badge>
         <span className="min-w-0 flex-1" />
-        <span className={`shrink-0 text-[9px] ${agent.model ? 'text-doom-cyan' : 'text-doom-faint'}`}>
+        <span className={`shrink-0 text-2xs ${agent.model ? 'text-doom-cyan' : 'text-doom-faint'}`}>
           {agent.model ? shortModel(agent.model) : 'agent default'}
         </span>
       </div>
-      <span className="truncate text-[10px] text-doom-dim">{agent.description}</span>
-      <span className="truncate text-[9px] text-doom-faint">{agentMeta(agent)}</span>
+      <span className="truncate text-xs text-doom-dim">{agent.description}</span>
+      <span className="truncate text-2xs text-doom-faint">{agentMeta(agent)}</span>
       {selected ? (
         <div className="flex items-center gap-3 pt-0.5">
           <Button
@@ -175,7 +175,7 @@ export function AgentCatalogDrawer({
       className="flex w-[min(440px,calc(100vw-24px))] shrink-0 flex-col overflow-hidden border-l border-doom-border bg-doom-rail outline-none"
     >
       <div className="flex h-11 shrink-0 items-center gap-2.5 border-b border-doom-border px-4">
-        <span className="text-[13px] font-bold text-doom-hi">agent catalog</span>
+        <span className="text-base font-bold text-doom-hi">agent catalog</span>
         <Badge size="xs" data-testid="catalog-count">
           {state.agents.length} agent{state.agents.length === 1 ? '' : 's'}
         </Badge>
@@ -196,7 +196,7 @@ export function AgentCatalogDrawer({
       </div>
       <div role="listbox" className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-2">
         {shown.length === 0 ? (
-          <p data-testid="catalog-empty" className="px-4 py-3 text-[10px] text-doom-faint">
+          <p data-testid="catalog-empty" className="px-4 py-3 text-xs text-doom-faint">
             {state.warning ??
               (state.agents.length === 0
                 ? 'no agents found for this session; add one under .doom/agents or ~/.doompi/agent/agents'
@@ -205,9 +205,7 @@ export function AgentCatalogDrawer({
         ) : null}
         {sections.map((section) => (
           <div key={section.source} className="flex flex-col">
-            <span className="px-4 pt-2.5 pb-1 text-[9px] font-bold tracking-[0.18em] text-doom-faint">
-              {section.label}
-            </span>
+            <span className="px-4 pt-2.5 pb-1 text-2xs font-bold tracking-widest text-doom-faint">{section.label}</span>
             {section.agents.map((agent) => (
               <AgentRow
                 key={agent.name}
@@ -223,8 +221,8 @@ export function AgentCatalogDrawer({
         ))}
       </div>
       <div className="flex h-8 shrink-0 items-center justify-between border-t border-doom-border-soft bg-doom-deep px-4">
-        <span className="text-[9px] text-doom-faint">↑↓ choose · enter launch · f fork · i inspect · esc close</span>
-        <span className="text-[9px] text-doom-faint">
+        <span className="text-2xs text-doom-faint">↑↓ choose · enter launch · f fork · i inspect · esc close</span>
+        <span className="text-2xs text-doom-faint">
           {sections.length} source{sections.length === 1 ? '' : 's'}
         </span>
       </div>

--- a/layers/team/doompi-team/src/web/components/AgentThreadPanel.stories.tsx
+++ b/layers/team/doompi-team/src/web/components/AgentThreadPanel.stories.tsx
@@ -1,0 +1,97 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`. The slot props come from the contracts
+ * package's own testing fixture, whose `thread` option stands in for the host's
+ * transcript; the runs come from the real session store seeded at module scope.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { ReactNode } from 'react';
+import type { SubagentRun } from '../../types/webSubagents.ts';
+import { subagents } from '../stores/subagentsStore.ts';
+import { AgentThreadPanel } from './AgentThreadPanel.tsx';
+
+const NOW = Date.now();
+const MINUTE = 60_000;
+
+const run = (overrides: Partial<SubagentRun> & Pick<SubagentRun, 'runId' | 'agent' | 'state'>): SubagentRun => ({
+  rawState: overrides.state,
+  task: 'review the team stories\nand file anything that will not mount',
+  cwd: '/Users/dev/workspace/doompi',
+  startedAt: NOW - 7 * MINUTE,
+  lastUpdate: NOW,
+  tail: [],
+  ...overrides,
+});
+
+subagents.update('thread-live', (current) => ({
+  ...current,
+  runs: [run({ runId: 'run-8f21', agent: 'reviewer', state: 'running', model: 'anthropic/claude-sonnet-4-5' })],
+}));
+
+subagents.update('thread-stopping', (current) => ({
+  ...current,
+  runs: [run({ runId: 'run-8f22', agent: 'tester', state: 'running' })],
+  stopRequested: ['run-8f22'],
+}));
+
+subagents.update('thread-done', (current) => ({
+  ...current,
+  runs: [
+    run({
+      runId: 'run-8f14',
+      agent: 'reviewer',
+      state: 'done',
+      endedAt: NOW - MINUTE,
+      summary: 'two defects filed',
+    }),
+  ],
+}));
+
+/** Stands in for the host transcript the cockpit renders into this panel. */
+const thread = (threadId: string): ReactNode => (
+  <div className="min-h-0 flex-1 overflow-auto px-6 py-4 text-xs text-doom-dim">
+    <p className="text-doom-faint">transcript of {threadId}</p>
+    <p className="pt-2 text-doom-text">read packages/core/doompi-web-contracts/src/services/testing/slotProps.ts</p>
+    <p className="pt-1 text-doom-text">the fixture already builds every slot prop, so the story stays honest</p>
+  </div>
+);
+
+const Framed = ({ caption, children }: { caption: string; children: ReactNode }) => (
+  <div className="flex min-w-0 flex-col gap-2">
+    <span className="text-2xs text-doom-dim uppercase tracking-widest">{caption}</span>
+    <div className="flex h-72 flex-col overflow-hidden rounded-md border border-doom-border-soft bg-doom-bg">
+      {children}
+    </div>
+  </div>
+);
+
+const meta = {
+  title: 'Team/AgentThreadPanel',
+  component: AgentThreadPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <Framed caption="running · stop and steer">
+        <AgentThreadPanel {...slotPropsFixture({ sessionId: 'thread-live', thread }).props} runId="run-8f21" />
+      </Framed>
+
+      <Framed caption="stop requested">
+        <AgentThreadPanel {...slotPropsFixture({ sessionId: 'thread-stopping', thread }).props} runId="run-8f22" />
+      </Framed>
+
+      <Framed caption="finished · no composer">
+        <AgentThreadPanel {...slotPropsFixture({ sessionId: 'thread-done', thread }).props} runId="run-8f14" />
+      </Framed>
+
+      <Framed caption="run no longer listed">
+        <AgentThreadPanel {...slotPropsFixture({ sessionId: 'thread-gone', thread }).props} runId="run-8f09xyz" />
+      </Framed>
+    </div>
+  ),
+};

--- a/layers/team/doompi-team/src/web/components/AgentThreadPanel.tsx
+++ b/layers/team/doompi-team/src/web/components/AgentThreadPanel.tsx
@@ -60,17 +60,17 @@ export function AgentThreadPanel({
       >
         {run ? (
           <>
-            <span data-testid="agent-thread-agent" className="shrink-0 truncate text-[12px] font-bold text-doom-hi">
+            <span data-testid="agent-thread-agent" className="shrink-0 truncate text-sm font-bold text-doom-hi">
               {run.agent}
             </span>
             <StatusBadge tone={RUN_BADGE[run.state].tone} data-testid="agent-thread-state">
               {RUN_BADGE[run.state].label}
             </StatusBadge>
-            <span className="shrink-0 text-[10px] text-doom-faint">{elapsedRun(run, now)}</span>
+            <span className="shrink-0 text-xs text-doom-faint">{elapsedRun(run, now)}</span>
             {run.model ? (
-              <span className="shrink-0 text-[10px] text-doom-faint">{run.model.split('/').pop() ?? run.model}</span>
+              <span className="shrink-0 text-xs text-doom-faint">{run.model.split('/').pop() ?? run.model}</span>
             ) : null}
-            <span data-testid="agent-thread-task" className="min-w-0 flex-1 truncate text-[10px] text-doom-dim">
+            <span data-testid="agent-thread-task" className="min-w-0 flex-1 truncate text-xs text-doom-dim">
               {firstLine}
             </span>
             {sessionId !== null && !isTerminalRun(run) ? (
@@ -83,7 +83,7 @@ export function AgentThreadPanel({
             ) : null}
           </>
         ) : (
-          <span data-testid="agent-thread-gone" className="text-[10px] text-doom-faint">
+          <span data-testid="agent-thread-gone" className="text-xs text-doom-faint">
             run {runId.slice(0, 8)} is no longer listed; its transcript stays readable
           </span>
         )}
@@ -97,7 +97,7 @@ export function AgentThreadPanel({
         >
           <div className="rounded-lg border border-doom-border bg-doom-deep transition-colors focus-within:border-doom-blue/60">
             <div className="flex min-w-0 items-start gap-2.5 px-3.5 pt-3">
-              <span className="mt-[3px] shrink-0 select-none text-[13px] leading-none text-doom-green">&gt;</span>
+              <span className="mt-[3px] shrink-0 select-none text-base leading-none text-doom-green">&gt;</span>
               <Textarea
                 variant="bare"
                 data-testid="agent-steer-input"
@@ -105,12 +105,12 @@ export function AgentThreadPanel({
                 rows={2}
                 value={guidance}
                 placeholder="Guide this agent…"
-                className="min-w-0 flex-1 text-[13px] leading-relaxed"
+                className="min-w-0 flex-1 text-base leading-relaxed"
                 onChange={(event) => setGuidance(event.target.value)}
               />
             </div>
             <div className="flex items-center gap-2 px-3.5 pt-2 pb-2.5">
-              <span data-testid="agent-steer-hint" className="text-[10px] text-doom-faint">
+              <span data-testid="agent-steer-hint" className="text-xs text-doom-faint">
                 guidance reaches this run while it is still working
               </span>
               <span className="min-w-0 flex-1" />

--- a/layers/team/doompi-team/src/web/components/AgentsActivitySection.stories.tsx
+++ b/layers/team/doompi-team/src/web/components/AgentsActivitySection.stories.tsx
@@ -1,0 +1,77 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`. The slot props come from the contracts
+ * package's own testing fixture, and the rows come from the real session store
+ * seeded at module scope, which is the only input this component reads.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { SubagentRun } from '../../types/webSubagents.ts';
+import { subagents } from '../stores/subagentsStore.ts';
+import { AgentsActivitySection } from './AgentsActivitySection.tsx';
+
+const NOW = Date.now();
+const MINUTE = 60_000;
+
+const run = (overrides: Partial<SubagentRun> & Pick<SubagentRun, 'runId' | 'agent' | 'state'>): SubagentRun => ({
+  rawState: overrides.state,
+  task: 'review the team stories',
+  cwd: '/Users/dev/workspace/doompi',
+  startedAt: NOW - 4 * MINUTE,
+  lastUpdate: NOW,
+  tail: [],
+  ...overrides,
+});
+
+/** activityRuns() keeps only queued and running rows, so the done one below is filtered out. */
+subagents.update('agents-busy', (current) => ({
+  ...current,
+  runs: [
+    run({
+      runId: 'run-8f21',
+      agent: 'reviewer',
+      state: 'running',
+      startedAt: NOW - 7 * MINUTE,
+      currentTool: 'read · packages/core/doompi-web-contracts',
+      toolCount: 24,
+    }),
+    run({
+      runId: 'run-8f22',
+      agent: 'tester',
+      state: 'running',
+      startedAt: NOW - 2 * MINUTE,
+      toolCount: 6,
+      tail: ['pnpm exec vitest run src/web'],
+    }),
+    run({ runId: 'run-8f23', agent: 'scout', state: 'queued', startedAt: NOW, toolCount: 0 }),
+    run({ runId: 'run-8f14', agent: 'reviewer', state: 'done', summary: 'two defects filed' }),
+  ],
+}));
+
+const meta = {
+  title: 'Team/AgentsActivitySection',
+  component: AgentsActivitySection,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex max-w-lg flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex min-w-0 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no runs</span>
+        <div className="rounded-md border border-doom-border-soft bg-doom-panel p-2">
+          <AgentsActivitySection {...slotPropsFixture({ sessionId: 'agents-idle' }).props} />
+        </div>
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running, queued, and one filtered out</span>
+        <div className="rounded-md border border-doom-border-soft bg-doom-panel p-2">
+          <AgentsActivitySection {...slotPropsFixture({ sessionId: 'agents-busy' }).props} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/layers/team/doompi-team/src/web/components/AgentsActivitySection.tsx
+++ b/layers/team/doompi-team/src/web/components/AgentsActivitySection.tsx
@@ -48,7 +48,7 @@ export function AgentsActivitySection({ sessionId, openTransientTab }: WebPlugin
   if (runs.length === 0) {
     return (
       <div className="flex items-center gap-2 px-1">
-        <p data-testid="activity-summary-agents" className="text-[10px] text-doom-faint">
+        <p data-testid="activity-summary-agents" className="text-xs text-doom-faint">
           idle
         </p>
         <Button
@@ -82,21 +82,21 @@ export function AgentsActivitySection({ sessionId, openTransientTab }: WebPlugin
             if (sessionId === null) return;
             openTransientTab(agentThreadTab(run));
           }}
-          className="min-w-0 gap-0.5 rounded-[5px] px-1 py-1 hover:bg-doom-panel"
+          className="min-w-0 gap-0.5 rounded-md px-1 py-1 hover:bg-doom-panel"
         >
           <span className="flex min-w-0 items-center gap-1.5">
             <Dot tone={STATE_TONE[run.state]} pulse={run.state === 'running'} />
             <span
-              className={`min-w-0 flex-1 truncate text-[10px] font-bold ${isTerminalRun(run) ? 'text-doom-dim' : 'text-doom-hi'}`}
+              className={`min-w-0 flex-1 truncate text-xs font-bold ${isTerminalRun(run) ? 'text-doom-dim' : 'text-doom-hi'}`}
             >
               {run.agent}
             </span>
-            <span className="shrink-0 text-[9px] text-doom-faint">
+            <span className="shrink-0 text-2xs text-doom-faint">
               {elapsed(run, now)}
               {run.toolCount !== undefined ? ` · ${run.toolCount} tools` : ''}
             </span>
           </span>
-          <span className={`truncate pl-3 text-[9px] ${run.state === 'failed' ? 'text-doom-red' : 'text-doom-faint'}`}>
+          <span className={`truncate pl-3 text-2xs ${run.state === 'failed' ? 'text-doom-red' : 'text-doom-faint'}`}>
             {detail(run)}
           </span>
         </Button>

--- a/layers/team/doompi-team/src/web/components/IntercomToolMessage.stories.tsx
+++ b/layers/team/doompi-team/src/web/components/IntercomToolMessage.stories.tsx
@@ -1,0 +1,97 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`. The props come from the contracts
+ * package's own testing fixture rather than a hand-rolled stub, so a change to
+ * the slot contract breaks this story at the type level.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { IntercomToolMessage } from './IntercomToolMessage.tsx';
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'intercom', ...overrides }).props;
+
+const resultOf = (text: string, details: unknown) => ({ content: [{ type: 'text', text }], details });
+
+const DELIVERED = 'sent to reviewer';
+const ANSWER = ['reviewer answered:', '', 'the launch dialog reads well; the model picker needs a default'].join('\n');
+
+const meta = {
+  title: 'Team/IntercomToolMessage',
+  component: IntercomToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">send · delivered</span>
+        <IntercomToolMessage
+          {...props({
+            args: { action: 'send', to: 'reviewer', message: 'the diff is ready for a look' },
+            result: resultOf(DELIVERED, { delivered: true, to: 'reviewer' }),
+            output: DELIVERED,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">send · queued, delivery unconfirmed</span>
+        <IntercomToolMessage
+          {...props({
+            args: { action: 'send', to: 'reviewer', message: 'the diff is ready for a look' },
+            result: resultOf('queued for reviewer', { state: 'queued', to: 'reviewer' }),
+            output: 'queued for reviewer',
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">ask · answered</span>
+        <IntercomToolMessage
+          {...props({
+            args: { action: 'ask', to: 'reviewer', message: 'does the launch dialog need a model default?' },
+            result: resultOf(ANSWER, { reply: 'the model picker needs a default', from: 'reviewer' }),
+            output: ANSWER,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">reply · confirms its request</span>
+        <IntercomToolMessage
+          {...props({
+            args: { action: 'reply', requestId: 'req-42', message: 'yes, ship it' },
+            result: resultOf('replied to main', { requestId: 'req-42', to: 'main' }),
+            output: 'replied to main',
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">waiting</span>
+        <IntercomToolMessage
+          {...props({
+            args: { action: 'ask', to: 'reviewer', message: 'does the launch dialog need a model default?' },
+            running: true,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <IntercomToolMessage
+          {...props({
+            args: { action: 'send', to: 'ghost', message: 'anyone there?' },
+            result: resultOf('no member named ghost is active', null),
+            output: 'no member named ghost is active',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/layers/team/doompi-team/src/web/components/LaunchAgentDialog.stories.tsx
+++ b/layers/team/doompi-team/src/web/components/LaunchAgentDialog.stories.tsx
@@ -1,0 +1,49 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`. The dialog is always open and portals
+ * to the body, so one instance is shown; the frame sender comes from the
+ * contracts package's own testing fixture.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { SubagentCatalogAgent } from '../../types/webSubagents.ts';
+import { LaunchAgentDialog } from './LaunchAgentDialog.tsx';
+
+const REVIEWER: SubagentCatalogAgent = {
+  name: 'reviewer',
+  source: 'project',
+  description: 'reviews a diff for defects, regressions, missing tests, and contract violations',
+  model: 'anthropic/claude-sonnet-4-5',
+  fallbackModels: ['anthropic/claude-haiku-4-5'],
+  tools: ['read', 'grep', 'bash'],
+  skills: ['doompi-review'],
+  extensions: [],
+  defaultContext: 'fresh',
+  filePath: '.doom/agents/reviewer.md',
+};
+
+const meta = {
+  title: 'Team/LaunchAgentDialog',
+  component: LaunchAgentDialog,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="h-96 bg-doom-bg">
+      <LaunchAgentDialog
+        sessionId="launch"
+        agent={REVIEWER}
+        cwd="/Users/dev/workspace/doompi/layers/team/doompi-team"
+        models={['anthropic/claude-sonnet-4-5', 'openai/gpt-5', 'google/gemini-3-pro']}
+        fork={false}
+        initialTask="review the team stories batch and report anything that will not mount"
+        send={slotPropsFixture({ sessionId: 'launch' }).props.sendSessionFrame}
+        onClose={() => {}}
+        onLaunched={() => {}}
+      />
+    </div>
+  ),
+};

--- a/layers/team/doompi-team/src/web/components/LaunchAgentDialog.tsx
+++ b/layers/team/doompi-team/src/web/components/LaunchAgentDialog.tsx
@@ -26,7 +26,7 @@ const AGENT_DEFAULT = 'agent-default';
 const TASK_ROWS = 4;
 
 function FieldLabel({ children }: { children: string }) {
-  return <span className="text-[9px] font-bold tracking-[0.18em] text-doom-faint">{children}</span>;
+  return <span className="text-2xs font-bold tracking-widest text-doom-faint">{children}</span>;
 }
 
 /**
@@ -82,7 +82,7 @@ export function LaunchAgentDialog({
       <DialogContent width="lg" data-testid="launch-dialog" aria-describedby={undefined}>
         <DialogHeader>
           <div className="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-2.5">
-            <span className="text-[9px] text-doom-faint">launch subagent</span>
+            <span className="text-2xs text-doom-faint">launch subagent</span>
             <DialogTitle data-testid="launch-agent" className="max-w-full break-words">
               {agent.name}
             </DialogTitle>
@@ -92,7 +92,7 @@ export function LaunchAgentDialog({
           </div>
         </DialogHeader>
         <DialogBody>
-          <p className="text-[11px] leading-relaxed text-doom-dim">{agent.description}</p>
+          <p className="text-sm leading-relaxed text-doom-dim">{agent.description}</p>
           <div className="flex flex-col gap-1.5">
             <FieldLabel>TASK</FieldLabel>
             <Textarea
@@ -104,9 +104,7 @@ export function LaunchAgentDialog({
               onChange={(event) => setTask(event.target.value)}
               onKeyDown={onTaskKeyDown}
             />
-            <span className="text-[9px] text-doom-faint">
-              enter launches · shift+enter for a new line · @ for files
-            </span>
+            <span className="text-2xs text-doom-faint">enter launches · shift+enter for a new line · @ for files</span>
           </div>
           <div className="flex flex-wrap gap-5">
             <div className="flex flex-col gap-1.5">
@@ -131,12 +129,12 @@ export function LaunchAgentDialog({
                   fork this session
                 </Button>
               </div>
-              <span className="text-[9px] text-doom-faint">fork shares the conversation so far</span>
+              <span className="text-2xs text-doom-faint">fork shares the conversation so far</span>
             </div>
             <div className="flex flex-col gap-1.5">
               <FieldLabel>MODEL</FieldLabel>
               <Select value={model} onValueChange={setModel}>
-                <SelectTrigger data-testid="launch-model" className="h-7 w-full min-w-0 text-[10px] sm:min-w-[200px]">
+                <SelectTrigger data-testid="launch-model" className="h-7 w-full min-w-0 text-xs sm:min-w-[200px]">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -148,22 +146,22 @@ export function LaunchAgentDialog({
                   ))}
                 </SelectContent>
               </Select>
-              <span className="text-[9px] text-doom-faint">a pick becomes model=… on the command</span>
+              <span className="text-2xs text-doom-faint">a pick becomes model=… on the command</span>
             </div>
             <div className="flex flex-col gap-1.5">
               <FieldLabel>CWD</FieldLabel>
-              <span className="flex h-7 items-center text-[10px] text-doom-dim">{abbreviateCwd(cwd)}</span>
-              <span className="text-[9px] text-doom-faint">the session's directory</span>
+              <span className="flex h-7 items-center text-xs text-doom-dim">{abbreviateCwd(cwd)}</span>
+              <span className="text-2xs text-doom-faint">the session's directory</span>
             </div>
           </div>
           <div className="flex flex-col gap-1 rounded-md border border-doom-border bg-doom-deep px-3 py-2">
             <FieldLabel>SENT TO THE SESSION</FieldLabel>
-            <pre data-testid="launch-command" className="whitespace-pre-wrap break-words text-[10px] text-doom-green">
+            <pre data-testid="launch-command" className="whitespace-pre-wrap break-words text-xs text-doom-green">
               {command}
             </pre>
           </div>
           <DialogFooter className="flex-wrap sm:flex-nowrap">
-            <span className="w-full text-[9px] text-doom-faint sm:w-auto">
+            <span className="w-full text-2xs text-doom-faint sm:w-auto">
               the run opens in its own tab once it starts
             </span>
             <span className="min-w-0 flex-1" />

--- a/layers/team/doompi-team/src/web/components/RunControl.stories.tsx
+++ b/layers/team/doompi-team/src/web/components/RunControl.stories.tsx
@@ -1,0 +1,73 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`. The frame sender comes from the
+ * contracts package's own testing fixture rather than a hand-rolled stub.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { SubagentRun } from '../../types/webSubagents.ts';
+import { elapsedRun, RunControl } from './RunControl.tsx';
+
+const NOW = Date.now();
+const MINUTE = 60_000;
+const send = slotPropsFixture({ sessionId: 'runs' }).props.sendSessionFrame;
+
+const run = (overrides: Partial<SubagentRun> & Pick<SubagentRun, 'runId' | 'agent' | 'state'>): SubagentRun => ({
+  rawState: overrides.state,
+  task: 'review the team stories',
+  cwd: '/Users/dev/workspace/doompi',
+  startedAt: NOW - 4 * MINUTE,
+  lastUpdate: NOW,
+  tail: [],
+  ...overrides,
+});
+
+const ROWS: readonly { caption: string; run: SubagentRun; stopping: boolean }[] = [
+  { caption: 'running', run: run({ runId: 'run-01', agent: 'reviewer', state: 'running' }), stopping: false },
+  {
+    caption: 'queued',
+    run: run({ runId: 'run-02', agent: 'scout', state: 'queued', startedAt: NOW }),
+    stopping: false,
+  },
+  { caption: 'stop requested', run: run({ runId: 'run-03', agent: 'tester', state: 'running' }), stopping: true },
+  {
+    caption: 'done',
+    run: run({ runId: 'run-04', agent: 'reviewer', state: 'done', endedAt: NOW - MINUTE }),
+    stopping: false,
+  },
+  {
+    caption: 'failed',
+    run: run({ runId: 'run-05', agent: 'tester', state: 'failed', endedAt: NOW - 2 * MINUTE }),
+    stopping: false,
+  },
+  {
+    caption: 'stopped',
+    run: run({ runId: 'run-06', agent: 'scout', state: 'stopped', endedAt: NOW - 30_000 }),
+    stopping: false,
+  },
+];
+
+const meta = {
+  title: 'Team/RunControl',
+  component: RunControl,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex max-w-md flex-col gap-3 bg-doom-bg p-6">
+      {ROWS.map((row) => (
+        <div
+          key={row.run.runId}
+          className="flex items-center gap-3 rounded-md border border-doom-border-soft bg-doom-panel px-3 py-2"
+        >
+          <span className="w-32 shrink-0 text-2xs text-doom-dim uppercase tracking-widest">{row.caption}</span>
+          <span className="min-w-0 flex-1 truncate text-xs text-doom-faint">{elapsedRun(row.run, NOW)}</span>
+          <RunControl sessionId="runs" run={row.run} stopping={row.stopping} send={send} />
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/layers/team/doompi-team/src/web/components/SubagentToolMessage.stories.tsx
+++ b/layers/team/doompi-team/src/web/components/SubagentToolMessage.stories.tsx
@@ -1,0 +1,104 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`. The props come from the contracts
+ * package's own testing fixture rather than a hand-rolled stub, so a change to
+ * the slot contract breaks this story at the type level.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { SubagentToolMessage } from './SubagentToolMessage.tsx';
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'subagent', ...overrides }).props;
+
+const LAUNCHED = ['started 2 runs:', '  run-8f21 · reviewer', '  run-8f22 · tester'].join('\n');
+
+/** Longer than COLLAPSED_RESULT_LINES, so the card offers the "more line(s)" expander. */
+const FLEET = [
+  'fleet: 3 active, 2 finished',
+  '',
+  'run-8f21 reviewer   running  4m   read · packages/core',
+  'run-8f22 tester     running  4m   bash · pnpm test',
+  'run-8f19 scout      queued   0s',
+  'run-8f14 reviewer   done     11m  summary: two defects filed',
+  'run-8f02 tester     failed   2m   error: typecheck did not pass',
+  '',
+  'tokens 184.2k · cost $0.41',
+  'restore: subagent {action:"restore", id:"run-8f02"}',
+  'steer:   subagent {action:"steer", id:"run-8f21", message:"…"}',
+  'stop:    subagent {action:"stop", id:"run-8f21"}',
+  'suspended: 1 transcript kept',
+  'logs under ~/.pi/agent/doom-runner',
+].join('\n');
+
+const meta = {
+  title: 'Team/SubagentToolMessage',
+  component: SubagentToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex max-w-4xl flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex min-w-0 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">run · two agents launched</span>
+        <SubagentToolMessage
+          {...props({
+            args: {
+              action: 'run',
+              requests: [
+                { agent: 'reviewer', task: 'review the team stories' },
+                { agent: 'tester', task: 'run the affected suites' },
+              ],
+            },
+            output: LAUNCHED,
+          })}
+        />
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">status · fleet, collapsed</span>
+        <SubagentToolMessage {...props({ args: { action: 'status' }, output: FLEET })} />
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">status · one run, still going</span>
+        <SubagentToolMessage
+          {...props({
+            args: { action: 'status', id: 'run-8f21' },
+            output: 'run-8f21 reviewer running 4m\nreading packages/core/doompi-web-contracts',
+            running: true,
+          })}
+        />
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">steer · acknowledged</span>
+        <SubagentToolMessage
+          {...props({
+            args: { action: 'steer', id: 'run-8f21', message: 'skip the layout pass, cover the empty states' },
+            output: 'run-8f21 acknowledged the guidance',
+          })}
+        />
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">agents · no output</span>
+        <SubagentToolMessage {...props({ args: { action: 'agents' }, output: '' })} />
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">stop · failed</span>
+        <SubagentToolMessage
+          {...props({
+            args: { action: 'stop', id: 'run-0000' },
+            output: 'no run named run-0000',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/layers/team/doompi-team/src/web/components/SubagentsPanel.stories.tsx
+++ b/layers/team/doompi-team/src/web/components/SubagentsPanel.stories.tsx
@@ -1,0 +1,105 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`. The slot props come from the contracts
+ * package's own testing fixture, whose `thread` option stands in for the host's
+ * transcript; the fleet comes from the real session store seeded at module scope.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { ReactNode } from 'react';
+import type { SubagentRun } from '../../types/webSubagents.ts';
+import { subagents } from '../stores/subagentsStore.ts';
+import { SubagentsPanel } from './SubagentsPanel.tsx';
+
+const NOW = Date.now();
+const MINUTE = 60_000;
+
+const run = (overrides: Partial<SubagentRun> & Pick<SubagentRun, 'runId' | 'agent' | 'state'>): SubagentRun => ({
+  rawState: overrides.state,
+  task: 'review the team stories batch and report anything that will not mount',
+  cwd: '/Users/dev/workspace/doompi/layers/team/doompi-team',
+  startedAt: NOW - 6 * MINUTE,
+  lastUpdate: NOW,
+  tail: [],
+  ...overrides,
+});
+
+subagents.update('fleet-busy', (current) => ({
+  ...current,
+  stopRequested: ['run-8f22'],
+  runs: [
+    run({
+      runId: 'run-8f21',
+      agent: 'reviewer',
+      state: 'running',
+      taskRef: '6',
+      model: 'anthropic/claude-sonnet-4-5',
+      toolCount: 24,
+      tokens: 184_213,
+    }),
+    run({
+      runId: 'run-8f22',
+      agent: 'tester',
+      state: 'running',
+      startedAt: NOW - 2 * MINUTE,
+      toolCount: 6,
+      tokens: 41_902,
+      task: 'run the affected suites for the file-edit stories',
+    }),
+    run({
+      runId: 'run-8f14',
+      agent: 'reviewer',
+      state: 'done',
+      endedAt: NOW - MINUTE,
+      toolCount: 31,
+      tokens: 210_770,
+      summary: 'two defects filed; the rest of the batch mounts',
+    }),
+    run({
+      runId: 'run-8f02',
+      agent: 'tester',
+      state: 'failed',
+      endedAt: NOW - 3 * MINUTE,
+      toolCount: 9,
+      error: 'typecheck did not pass: src/web/components/RunControl.stories.tsx(12,7)',
+    }),
+  ],
+}));
+
+/** Stands in for the host transcript the cockpit renders into each card. */
+const thread = (threadId: string): ReactNode => (
+  <div className="flex flex-col gap-1 px-3 py-2 text-2xs text-doom-dim">
+    <span className="text-doom-faint">{threadId}</span>
+    <span className="text-doom-text">read src/web/components/SubagentsPanel.tsx</span>
+    <span className="text-doom-text">grep slotPropsFixture packages/core/doompi-web-contracts</span>
+    <span className="text-doom-text">bash pnpm exec oxlint src/web/components</span>
+  </div>
+);
+
+const meta = {
+  title: 'Team/SubagentsPanel',
+  component: SubagentsPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex w-screen flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex min-w-0 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">a fleet, one stop requested</span>
+        <div className="flex h-screen overflow-hidden rounded-md border border-doom-border-soft">
+          <SubagentsPanel {...slotPropsFixture({ sessionId: 'fleet-busy', thread }).props} />
+        </div>
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">nothing launched yet</span>
+        <div className="flex h-96 overflow-hidden rounded-md border border-doom-border-soft">
+          <SubagentsPanel {...slotPropsFixture({ sessionId: 'fleet-empty', thread }).props} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/layers/team/doompi-team/src/web/components/SubagentsPanel.tsx
+++ b/layers/team/doompi-team/src/web/components/SubagentsPanel.tsx
@@ -58,10 +58,10 @@ function WorkLine({ run }: { run: SubagentRun }) {
   if (run.taskRef) {
     return (
       <div className="flex items-center gap-2 px-3 pb-2.5">
-        <Badge tone="violet" size="xs" className="shrink-0 rounded-[3px] bg-doom-violet/10">
+        <Badge tone="violet" size="xs" className="shrink-0 rounded-sm bg-doom-violet/10">
           TASK {run.taskRef}
         </Badge>
-        <span data-testid="run-work" className="min-w-0 truncate text-[10px] text-doom-hi">
+        <span data-testid="run-work" className="min-w-0 truncate text-xs text-doom-hi">
           {firstLine}
         </span>
       </div>
@@ -69,8 +69,8 @@ function WorkLine({ run }: { run: SubagentRun }) {
   }
   return (
     <div className="flex items-center gap-2 px-3 pb-2.5">
-      <span className="shrink-0 text-[8px] font-bold text-doom-faint">PROMPT</span>
-      <span data-testid="run-work" className="min-w-0 truncate text-[10px] text-doom-dim">
+      <span className="shrink-0 text-2xs font-bold text-doom-faint">PROMPT</span>
+      <span data-testid="run-work" className="min-w-0 truncate text-xs text-doom-dim">
         {firstLine}
       </span>
     </div>
@@ -196,11 +196,11 @@ function RunCard({
           onKeyDown={onKeyDown}
         >
           <div className="flex items-center gap-2 px-3 pt-2.5 pb-1.5">
-            <span data-testid="run-agent" className="truncate text-[12px] font-bold text-doom-hi">
+            <span data-testid="run-agent" className="truncate text-sm font-bold text-doom-hi">
               {run.agent}
             </span>
             <span className="min-w-0 flex-1" />
-            <span className="shrink-0 text-[9px] text-doom-faint">{elapsedRun(run, now)}</span>
+            <span className="shrink-0 text-2xs text-doom-faint">{elapsedRun(run, now)}</span>
             <StatusBadge tone={badge.tone} data-testid="run-state">
               {badge.label}
             </StatusBadge>
@@ -217,14 +217,14 @@ function RunCard({
           {run.state === 'failed' && run.error ? (
             <span
               data-testid="run-error"
-              className="truncate border-t border-doom-border-soft px-3 py-1.5 text-[10px] text-doom-red"
+              className="truncate border-t border-doom-border-soft px-3 py-1.5 text-xs text-doom-red"
             >
               {run.error}
             </span>
           ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-3 border-t border-doom-border-soft px-3 py-1.5">
-          <span className="truncate text-[9px] text-doom-faint">
+          <span className="truncate text-2xs text-doom-faint">
             {run.toolCount !== undefined ? `${run.toolCount} tools` : '—'}
             {run.tokens !== undefined ? ` · ${run.tokens.toLocaleString()} tk` : ''}
             {run.model ? ` · ${run.model.split('/').pop() ?? run.model}` : ''}
@@ -247,8 +247,8 @@ function RunCard({
 function SheetRow({ label, value, tone = 'text-doom-dim' }: { label: string; value: string; tone?: string }) {
   return (
     <div className="flex gap-2.5">
-      <span className="w-11 shrink-0 text-[9px] text-doom-faint">{label}</span>
-      <span className={`min-w-0 break-words text-[10px] ${tone}`}>{value}</span>
+      <span className="w-11 shrink-0 text-2xs text-doom-faint">{label}</span>
+      <span className={`min-w-0 break-words text-xs ${tone}`}>{value}</span>
     </div>
   );
 }
@@ -256,10 +256,10 @@ function SheetRow({ label, value, tone = 'text-doom-dim' }: { label: string; val
 function SheetBlock({ label, text, testId, tone }: { label: string; text: string; testId: string; tone?: string }) {
   return (
     <div className="flex flex-col gap-1 rounded-md border border-doom-border bg-doom-deep px-3 py-2.5">
-      <span className="text-[8px] font-bold tracking-[0.14em] text-doom-faint">{label}</span>
+      <span className="text-2xs font-bold tracking-wider text-doom-faint">{label}</span>
       <pre
         data-testid={testId}
-        className={`overflow-x-auto whitespace-pre-wrap break-words text-[10px] leading-relaxed ${tone ?? 'text-doom-text'}`}
+        className={`overflow-x-auto whitespace-pre-wrap break-words text-xs leading-relaxed ${tone ?? 'text-doom-text'}`}
       >
         {text}
       </pre>
@@ -302,7 +302,7 @@ function RunDetailSheet({
           <SheetTitle data-testid="sheet-agent">{run.agent}</SheetTitle>
           <StatusBadge tone={badge.tone}>{badge.label}</StatusBadge>
           <span className="min-w-0 flex-1" />
-          <span className="text-[10px] text-doom-faint">{elapsedRun(run, now)}</span>
+          <span className="text-xs text-doom-faint">{elapsedRun(run, now)}</span>
           {renderSlot(RUN_ACTIONS_SLOT.slot)}
           <RunControl sessionId={sessionId} run={run} stopping={stopping} send={send} />
         </SheetHeader>
@@ -386,11 +386,11 @@ export function SubagentsPanel({
     <div data-testid="subagents-panel" className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
       <div className="flex min-w-0 flex-1 flex-col overflow-y-auto px-3 py-3 sm:px-[26px] sm:py-[18px]">
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2 pb-3">
-          <span className="text-[9px] font-bold tracking-[0.18em] text-doom-faint">SUBAGENTS · this session</span>
+          <span className="text-2xs font-bold tracking-widest text-doom-faint">SUBAGENTS · this session</span>
           <span className="hidden min-w-0 flex-1 sm:block" />
           <span
             data-testid="subagents-tally"
-            className="order-3 w-full text-[9px] text-doom-faint sm:order-none sm:w-auto"
+            className="order-3 w-full text-2xs text-doom-faint sm:order-none sm:w-auto"
           >
             {runs.length === 0 ? 'no runs yet' : `${runningTally} running · ${doneTally} done · ${failedTally} failed`}
           </span>
@@ -439,7 +439,7 @@ export function SubagentsPanel({
                     />
                   ))}
             </div>
-            <span className="pt-3 text-[9px] text-doom-faint">
+            <span className="pt-3 text-2xs text-doom-faint">
               click a card to open the run's thread · the card menu holds details, stop and clear · finished runs leave
               the grid after 10m
             </span>

--- a/layers/team/doompi-team/style-system.config.yaml
+++ b/layers/team/doompi-team/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/layers/team/doompi-team/styles/preview.css
+++ b/layers/team/doompi-team/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/layers/team/doompi-team/tests/unit/childTranscript.test.ts
+++ b/layers/team/doompi-team/tests/unit/childTranscript.test.ts
@@ -12,6 +12,7 @@ import {
   createChildTranscriptWriter,
   formatToolActivity,
   getMessageActivity,
+  getMessageUsageCost,
   getMessageUsageTokens,
 } from '../../src/adapters/process/childTranscript';
 
@@ -179,6 +180,14 @@ describe('message usage metrics', () => {
 
   it('returns undefined when usage is absent', () => {
     expect(getMessageUsageTokens({ role: 'assistant' })).toBeUndefined();
+    expect(getMessageUsageCost({ role: 'assistant' })).toBeUndefined();
+  });
+
+  it('reads cost from either the bare-number or the object encoding, and zero when it is absent', () => {
+    expect(getMessageUsageCost({ role: 'assistant', usage: { cost: 0.0125 } })).toBe(0.0125);
+    expect(getMessageUsageCost({ role: 'assistant', usage: { cost: { total: 0.0125 } } })).toBe(0.0125);
+    expect(getMessageUsageCost({ role: 'assistant', usage: { totalTokens: 7 } })).toBe(0);
+    expect(getMessageUsageCost({ role: 'toolResult', usage: { cost: 9 } })).toBeUndefined();
   });
 });
 

--- a/layers/team/doompi-team/tests/unit/runnerLifecycleRegistration.test.ts
+++ b/layers/team/doompi-team/tests/unit/runnerLifecycleRegistration.test.ts
@@ -59,7 +59,7 @@ class FakeExecution implements RunnerExecutionContract {
   startCalls: Array<{ runId: string; handlers?: RunnerExecutionHandlers }> = [];
   completeCalls: Array<{ success: boolean; summary: string }> = [];
   activities: ActivityState[] = [];
-  progresses: Array<{ tokens?: number; currentTool?: string; toolCount?: number }> = [];
+  progresses: Array<{ tokens?: number; cost?: number; currentTool?: string; toolCount?: number }> = [];
   start(runId: string, handlers?: RunnerExecutionHandlers): () => void {
     this.startCalls.push({ runId, handlers });
     return () => {};
@@ -67,7 +67,7 @@ class FakeExecution implements RunnerExecutionContract {
   setActivity(activity: ActivityState): void {
     this.activities.push(activity);
   }
-  setProgress(progress: { tokens?: number; currentTool?: string; toolCount?: number }): void {
+  setProgress(progress: { tokens?: number; cost?: number; currentTool?: string; toolCount?: number }): void {
     this.progresses.push(progress);
   }
   complete(success: boolean, summary: string): void {
@@ -208,7 +208,7 @@ describe('registerRunnerLifecycle', () => {
     expect(fakes.execution.startCalls).toHaveLength(1);
   });
 
-  it('reports canonical total tokens once and streams a live activity trail', () => {
+  it('reports canonical total tokens and cost once and streams a live activity trail', () => {
     process.env[SUBAGENT_RUN_ID_ENV] = 'run-1';
     const fakes = makeFakes();
     const host = fakePi();
@@ -217,7 +217,14 @@ describe('registerRunnerLifecycle', () => {
     const message = {
       role: 'assistant',
       content: [{ type: 'thinking', thinking: 'Tracing the task state transition' }],
-      usage: { totalTokens: 37, input: 1000, output: 2000, cacheRead: 3000, cacheWrite: 4000 },
+      usage: {
+        totalTokens: 37,
+        input: 1000,
+        output: 2000,
+        cacheRead: 3000,
+        cacheWrite: 4000,
+        cost: { total: 0.0125 },
+      },
     };
     host.fire('message_end', { message });
     host.fire('session_start');
@@ -229,7 +236,7 @@ describe('registerRunnerLifecycle', () => {
 
     expect(fakes.execution.progresses).toEqual([
       { currentTool: 'working: Tracing the task state transition' },
-      { tokens: 37 },
+      { tokens: 37, cost: 0.0125 },
       { toolCount: 1, currentTool: 'Read (src/task.ts)' },
       { currentTool: 'working' },
     ]);

--- a/layers/team/doompi-team/tests/unit/runsBackgroundRunnerExecution.test.ts
+++ b/layers/team/doompi-team/tests/unit/runsBackgroundRunnerExecution.test.ts
@@ -107,18 +107,19 @@ describe('RunnerExecution', () => {
   it('coalesces live progress fields and preserves observed zero values', () => {
     const { execution, statusWriter } = makeExecution();
 
-    execution.setProgress({ tokens: 0, currentTool: 'Read', toolCount: 0 });
+    execution.setProgress({ tokens: 0, cost: 0, currentTool: 'Read', toolCount: 0 });
 
-    expect(statusWriter.status).toMatchObject({ tokens: 0, currentTool: 'Read', toolCount: 0 });
+    expect(statusWriter.status).toMatchObject({ tokens: 0, cost: 0, currentTool: 'Read', toolCount: 0 });
     expect(statusWriter.updateMutators).toHaveLength(1);
   });
 
-  it('does not persist a token field when progress has no token observation', () => {
+  it('does not persist token or cost fields when progress has no usage observation', () => {
     const { execution, statusWriter } = makeExecution();
 
     execution.setProgress({ currentTool: 'Read', toolCount: 0 });
 
     expect(statusWriter.status).not.toHaveProperty('tokens');
+    expect(statusWriter.status).not.toHaveProperty('cost');
     expect(statusWriter.status).toMatchObject({ currentTool: 'Read', toolCount: 0 });
   });
 

--- a/layers/team/doompi-team/tests/unit/tuiRegister.test.ts
+++ b/layers/team/doompi-team/tests/unit/tuiRegister.test.ts
@@ -15,7 +15,7 @@ import {
   SUBAGENT_LIST_COMMAND,
 } from '../../src/adapters/pi/tui/register';
 import type { ManagementActionsContract } from '../../src/adapters/pi/extensions/managementActions';
-import { AGENT_PULSE_FRAMES, FLEET_STATUS_KEY } from '../../src/adapters/pi/tui/fleetStatus';
+import { AGENT_PULSE_FRAMES, COST_STATUS_KEY, FLEET_STATUS_KEY } from '../../src/adapters/pi/tui/fleetStatus';
 import type { AsyncJobTrackerContract, TrackedAsyncJob } from '../../src/adapters/asyncJobTracker';
 import type { PollSchedulerContract, PollSubscription } from '../../src/adapters/pollScheduler';
 
@@ -314,7 +314,7 @@ describe('registerAgentStatus', () => {
     dispose();
     expect(scheduler.unregister).toHaveBeenCalledOnce();
     expect(footerDispose).toHaveBeenCalledOnce();
-    expect(setStatus).toHaveBeenLastCalledWith(FLEET_STATUS_KEY, undefined);
+    expect(setStatus).toHaveBeenCalledWith(FLEET_STATUS_KEY, undefined);
   });
 
   it('publishes every pulse frame for actively working agents', async () => {
@@ -342,6 +342,61 @@ describe('registerAgentStatus', () => {
       .map(([value]) => (value as { compactText?: string } | undefined)?.compactText)
       .filter((value): value is string => Boolean(value));
     expect(new Set(frames)).toEqual(new Set(AGENT_PULSE_FRAMES.map((glyph) => `A ${glyph}`)));
+    dispose();
+  });
+
+  it('keeps the session cost total after the tracker evicts a finished run', async () => {
+    const handlers = new Map<string, (event: unknown, ctx: never) => void>();
+    const pi = {
+      on: (event: string, handler: (event: unknown, ctx: never) => void) => handlers.set(event, handler),
+    } as never;
+    const scheduler = new FakeScheduler();
+    const tracker = new FakeTracker();
+    tracker.jobs = [{ runId: 'run-1', status: 'running', cost: 0.5 }];
+    const setStatus = vi.fn();
+    const ctx = {
+      hasUI: true,
+      sessionManager: { getSessionId: () => 'session-under-test' },
+      ui: { setStatus },
+    } as never;
+    const publishedCosts = (): unknown[] =>
+      setStatus.mock.calls.filter(([key]) => key === COST_STATUS_KEY).map(([, value]) => value);
+
+    const dispose = registerAgentStatus(pi, uiHub, { scheduler, tracker });
+    handlers.get('session_start')?.({}, ctx);
+    tracker.jobs = [{ runId: 'run-1', status: 'completed', cost: 0.57 }];
+    await scheduler.subscriptions[0]?.run();
+    expect(publishedCosts()).toEqual(['0.5', '0.57']);
+
+    // Retention window expired: the tracker dropped the finished run.
+    tracker.jobs = [];
+    await scheduler.subscriptions[0]?.run();
+    expect(publishedCosts()).toEqual(['0.5', '0.57']);
+
+    dispose();
+    expect(setStatus).toHaveBeenLastCalledWith(COST_STATUS_KEY, undefined);
+  });
+
+  it('publishes no cost chip for a session whose runs report nothing spent', async () => {
+    const handlers = new Map<string, (event: unknown, ctx: never) => void>();
+    const pi = {
+      on: (event: string, handler: (event: unknown, ctx: never) => void) => handlers.set(event, handler),
+    } as never;
+    const scheduler = new FakeScheduler();
+    const tracker = new FakeTracker();
+    tracker.jobs = [{ runId: 'run-1', status: 'running', cost: 0 }];
+    const setStatus = vi.fn();
+    const ctx = {
+      hasUI: true,
+      sessionManager: { getSessionId: () => 'session-under-test' },
+      ui: { setStatus },
+    } as never;
+
+    const dispose = registerAgentStatus(pi, uiHub, { scheduler, tracker });
+    handlers.get('session_start')?.({}, ctx);
+    await scheduler.subscriptions[0]?.run();
+
+    expect(setStatus.mock.calls.filter(([key]) => key === COST_STATUS_KEY)).toEqual([]);
     dispose();
   });
 });

--- a/layers/team/doompi-team/vibe-lint.config.yaml
+++ b/layers/team/doompi-team/vibe-lint.config.yaml
@@ -17,3 +17,14 @@ rules:
   no-raw-theme-color: error
   boundary-import-allowlist: error
   file-naming-convention: error
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@agimon-ai/doompi-user-feedback": "workspace:*",
     "@agimon-ai/doompi-voice": "workspace:*",
     "@agimon-ai/doompi-web": "workspace:*",
+    "@agimon-ai/style-system": "0.1.1",
     "@agimon-ai/vibe-lint": "0.0.1-alpha.29",
     "@agimon-ai/vibe-lint-plugin-doom-extension": "workspace:*",
     "@agimon-ai/workflow-mcp": "0.23.19",

--- a/packages/clients/doompi-server/tests/unit/adapters/agentSupervisor.test.ts
+++ b/packages/clients/doompi-server/tests/unit/adapters/agentSupervisor.test.ts
@@ -175,7 +175,9 @@ describe('superviseAgentRelaunches', () => {
     fs.writeFileSync(relaunchFile, serializeRelaunchHandoff({ version: 1, majorMode: 'minimal', operationId: 'op' }));
 
     // The watcher asks for a graceful end first. Wait for the filesystem event
-    // instead of assuming it will arrive within a fixed scheduling window.
+    // instead of assuming it will arrive within a fixed scheduling window; the
+    // case's own timeout has to outlast the two waits below or a slow fs event
+    // fails the test instead of the behaviour.
     await vi.waitFor(() => expect(spawned[0]?.inputEnded).toBe(true), { timeout: 5_000 });
     expect(spawned[0]?.stopped).toBe(false);
 
@@ -184,7 +186,7 @@ describe('superviseAgentRelaunches', () => {
     await settled();
     expect(spawned).toHaveLength(2);
     expect(spawned[1]?.options.args).toEqual(['--name', 'web', '--mode', 'rpc', '--major-mode', 'minimal']);
-  });
+  }, 10_000);
 
   it('treats a malformed relaunch file as a real exit', async () => {
     const { agent, relaunchFile } = await supervise();

--- a/packages/clients/doompi-web/src/adapters/httpServer.ts
+++ b/packages/clients/doompi-web/src/adapters/httpServer.ts
@@ -1548,7 +1548,11 @@ export async function serveWeb(options: WebServerOptions): Promise<WebServer> {
               if (threadSubscriptions.delete(key)) threads.unsubscribe(sessionId, threadId);
               return;
             }
-            if (threadSubscriptions.has(key) || hub.backlog(sessionId) === undefined) return;
+            // Register even when the hub does not know the session yet. The tailer resolves
+            // the journal path lazily on every tick, so the subscription self-heals once the
+            // session appears. Refusing here would drop the request in silence, and the page
+            // only sends it again on a fresh socket.
+            if (threadSubscriptions.has(key)) return;
             threadSubscriptions.set(key, { sessionId, threadId });
             registered?.post(threadBacklog(sessionId, threadId, threads.subscribe(sessionId, threadId)));
             return;

--- a/packages/clients/doompi-web/src/web/app/sessionRuntime.ts
+++ b/packages/clients/doompi-web/src/web/app/sessionRuntime.ts
@@ -37,6 +37,7 @@ import {
   applyThreadFrame,
   dropSessionStore,
   refreshSessionFacts,
+  refreshSessionStats,
   resetSessionStore,
   seedHistoryCursor,
 } from '../stores/sessionStore.ts';
@@ -275,6 +276,12 @@ export function startSessionRuntime(): () => void {
             if (entry?.type === 'custom' && entry.customType === RESOURCE_CATALOG_ENTRY_TYPE) {
               refreshSessionFacts(frame.sessionId);
             }
+          }
+          // Cost and context both move when a message lands, and a turn can
+          // run many messages before it settles. Asking for the figures here
+          // is what keeps the status bar current mid-turn.
+          if (frame.frame.type === 'message_end') {
+            refreshSessionStats(frame.sessionId);
           }
           if (frame.frame.type === 'agent_settled') {
             clearPendingMenu();

--- a/packages/clients/doompi-web/src/web/components/MascotMark.stories.tsx
+++ b/packages/clients/doompi-web/src/web/components/MascotMark.stories.tsx
@@ -1,0 +1,38 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition.
+ */
+import { MascotMark } from './MascotMark.tsx';
+
+const meta = {
+  title: 'Web/MascotMark',
+  component: MascotMark,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">sizes</span>
+        <div className="flex items-end gap-4 text-doom-hi">
+          <MascotMark size={20} />
+          <MascotMark size={24} />
+          <MascotMark size={32} />
+          <MascotMark size={48} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">in a lockup</span>
+        <div className="flex items-center gap-2 text-doom-hi">
+          <span className="text-lg tracking-widest">DOOM</span>
+          <MascotMark size={24} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/clients/doompi-web/src/web/components/QrCode.stories.tsx
+++ b/packages/clients/doompi-web/src/web/components/QrCode.stories.tsx
@@ -1,0 +1,49 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition.
+ *
+ * The modules take `currentColor` and the quiet zone is transparent, so each
+ * variant sets the surface and the text colour the way a caller has to: a
+ * scanner needs the dark modules darker than what surrounds them.
+ */
+import { QrCode } from './QrCode.tsx';
+
+const PAIRING_URL = 'https://doompi-8f21c4.trycloudflare.com/pair#k=7Qb2Xr9LmT4';
+
+const meta = {
+  title: 'Web/QrCode',
+  component: QrCode,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">scannable · light surface</span>
+        <div className="w-fit rounded-md bg-doom-on-selected p-3 text-doom-deep">
+          <QrCode value={PAIRING_URL} label="Pairing QR code" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">sizes</span>
+        <div className="flex w-fit items-end gap-4 rounded-md bg-doom-on-selected p-3 text-doom-deep">
+          <QrCode value={PAIRING_URL} size={72} />
+          <QrCode value={PAIRING_URL} size={120} />
+          <QrCode value={PAIRING_URL} size={208} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">inherits the theme · dark surface</span>
+        <div className="w-fit rounded-md bg-doom-panel p-3 text-doom-hi">
+          <QrCode value={PAIRING_URL} size={120} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/clients/doompi-web/src/web/components/RemoteAccessButton.stories.tsx
+++ b/packages/clients/doompi-web/src/web/components/RemoteAccessButton.stories.tsx
@@ -1,0 +1,58 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition.
+ */
+import { RemoteAccessButton } from './RemoteAccessButton.tsx';
+
+const noop = (): void => undefined;
+
+const meta = {
+  title: 'Web/RemoteAccessButton',
+  component: RemoteAccessButton,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">off</span>
+        <div className="w-fit">
+          <RemoteAccessButton status="off" deviceCount={0} onOpen={noop} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">starting</span>
+        <div className="w-fit">
+          <RemoteAccessButton status="starting" deviceCount={0} onOpen={noop} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">on · one device paired</span>
+        <div className="w-fit">
+          <RemoteAccessButton status="on" deviceCount={1} onOpen={noop} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <div className="w-fit">
+          <RemoteAccessButton status="failed" deviceCount={0} onOpen={noop} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">in the sessions rail header</span>
+        <div className="flex w-fit items-center gap-2 rounded-md border border-doom-border bg-doom-panel px-3 py-2">
+          <span className="text-sm text-doom-hi tracking-wide">DOOM</span>
+          <RemoteAccessButton status="on" deviceCount={3} onOpen={noop} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/clients/doompi-web/src/web/components/ToolRendererBoundary.stories.tsx
+++ b/packages/clients/doompi-web/src/web/components/ToolRendererBoundary.stories.tsx
@@ -1,0 +1,58 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition.
+ *
+ * The boundary draws nothing of its own, so the interesting state is a child
+ * that throws: React catches it, re-runs the render prop with `failed`, and
+ * the host item stands in. The throw is logged once by componentDidCatch.
+ */
+import { ToolRendererBoundary } from './ToolRendererBoundary.tsx';
+
+function PluginItem() {
+  return (
+    <div className="rounded-md border border-doom-border bg-doom-panel px-3 py-2 text-sm text-doom-text">
+      the plugin's own tool item
+    </div>
+  );
+}
+
+function ThrowingPluginItem(): null {
+  throw new Error('the plugin renderer read a field the result does not carry');
+}
+
+function HostFallbackItem() {
+  return (
+    <div className="rounded-md border border-doom-border-soft bg-doom-deep px-3 py-2 text-sm text-doom-dim">
+      read · src/lib/cn.ts
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Web/ToolRendererBoundary',
+  component: ToolRendererBoundary,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">renderer holds</span>
+        <ToolRendererBoundary toolName="read">
+          {(failed) => (failed ? <HostFallbackItem /> : <PluginItem />)}
+        </ToolRendererBoundary>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">renderer threw · host item stands in</span>
+        <ToolRendererBoundary toolName="read">
+          {(failed) => (failed ? <HostFallbackItem /> : <ThrowingPluginItem />)}
+        </ToolRendererBoundary>
+      </div>
+    </div>
+  ),
+};

--- a/packages/clients/doompi-web/src/web/features/activity/ActivityDock.tsx
+++ b/packages/clients/doompi-web/src/web/features/activity/ActivityDock.tsx
@@ -69,7 +69,7 @@ export function ActivityDock({ onClose, onOpenContent }: { onClose: () => void; 
             </StatusBadge>
           ) : null}
         </div>
-        <Button variant="ghost" size="xs" data-testid="activity-close" onClick={onClose} className="text-[10px]">
+        <Button variant="ghost" size="xs" data-testid="activity-close" onClick={onClose} className="text-xs">
           hide
         </Button>
       </div>
@@ -109,7 +109,7 @@ export function ActivityDock({ onClose, onOpenContent }: { onClose: () => void; 
           ) : null}
 
           <div className="border-t border-doom-border px-4 py-3">
-            <span className="text-[9px] leading-relaxed text-doom-faint">
+            <span className="text-2xs leading-relaxed text-doom-faint">
               each group is rendered by the package that owns it; the session's summary line stands in until that
               package publishes per-run detail
             </span>
@@ -143,7 +143,7 @@ function ActivityGroupView({
         <span
           aria-hidden
           data-active={group.active}
-          className={`text-[11px] font-bold ${group.active ? 'animate-pulse text-doom-yellow' : 'text-doom-faint'}`}
+          className={`text-sm font-bold ${group.active ? 'animate-pulse text-doom-yellow' : 'text-doom-faint'}`}
         >
           #
         </span>
@@ -151,7 +151,7 @@ function ActivityGroupView({
             temporary, so the tab strip carries it only while the reader is
             using it. Groups without a panel keep the name as a plain label. */}
         {group.transientTab === undefined ? (
-          <span className="flex-1 text-[11px] font-bold text-doom-text">{group.name}</span>
+          <span className="flex-1 text-sm font-bold text-doom-text">{group.name}</span>
         ) : (
           <Button
             variant="ghost"
@@ -162,7 +162,7 @@ function ActivityGroupView({
               const tab = group.transientTab?.();
               if (tab !== undefined) slotProps.openTransientTab(tab);
             }}
-            className="h-auto flex-1 justify-start px-0 py-0 text-[11px] font-bold text-doom-text hover:underline"
+            className="h-auto flex-1 justify-start px-0 py-0 text-sm font-bold text-doom-text hover:underline"
           >
             {group.name}
           </Button>
@@ -176,7 +176,7 @@ function ActivityGroupView({
       ) : (
         <p
           data-testid={`activity-summary-${group.name}`}
-          className={`px-1 text-[10px] ${group.active ? 'text-doom-yellow' : 'text-doom-faint'}`}
+          className={`px-1 text-xs ${group.active ? 'text-doom-yellow' : 'text-doom-faint'}`}
         >
           {group.summary || 'idle'}
         </p>

--- a/packages/clients/doompi-web/src/web/features/activity/ContextItemDialog.tsx
+++ b/packages/clients/doompi-web/src/web/features/activity/ContextItemDialog.tsx
@@ -85,17 +85,17 @@ export function ContextItemDialog({ sessionId, target, onClose }: ContextItemDia
       <DialogContent width="lg" data-testid="context-item-dialog" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle data-testid="context-item-title">{target.name}</DialogTitle>
-          <span className="text-[9px] text-doom-faint">
+          <span className="text-2xs text-doom-faint">
             {target.itemKind} · {target.owner}
           </span>
         </DialogHeader>
         <DialogBody>
           {error !== null ? (
-            <p data-testid="context-item-error" className="text-[11px] text-doom-dim">
+            <p data-testid="context-item-error" className="text-sm text-doom-dim">
               {error}
             </p>
           ) : detail === null ? (
-            <p data-testid="context-item-loading" className="flex items-center gap-2 text-[11px] text-doom-dim">
+            <p data-testid="context-item-loading" className="flex items-center gap-2 text-sm text-doom-dim">
               <Spinner />
               reading the session's inventory
             </p>
@@ -117,7 +117,7 @@ function ContextItemBody({ detail }: { detail: ContextItemDetail }) {
         <Section title="description">
           <p
             data-testid="context-item-description"
-            className="text-[11px] leading-relaxed whitespace-pre-wrap text-doom-text"
+            className="text-sm leading-relaxed whitespace-pre-wrap text-doom-text"
           >
             {detail.description}
           </p>
@@ -134,7 +134,7 @@ function ContextItemBody({ detail }: { detail: ContextItemDetail }) {
         <Section title="prompt guidelines">
           <ul data-testid="context-item-guidelines" className="flex flex-col gap-1">
             {detail.promptGuidelines.map((line) => (
-              <li key={line} className="text-[11px] leading-relaxed text-doom-dim">
+              <li key={line} className="text-sm leading-relaxed text-doom-dim">
                 {line}
               </li>
             ))}
@@ -154,7 +154,7 @@ function ContextItemBody({ detail }: { detail: ContextItemDetail }) {
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-1">
-      <span className="text-[9px] font-bold tracking-widest text-doom-faint uppercase">{title}</span>
+      <span className="text-2xs font-bold tracking-widest text-doom-faint uppercase">{title}</span>
       {children}
     </div>
   );
@@ -163,7 +163,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 function Pre({ testId, children }: { testId: string; children: string }) {
   return (
     <Panel className="max-h-64 overflow-auto bg-doom-deep px-3 py-2">
-      <pre data-testid={testId} className="text-[11px] leading-relaxed whitespace-pre-wrap text-doom-dim">
+      <pre data-testid={testId} className="text-sm leading-relaxed whitespace-pre-wrap text-doom-dim">
         {children}
       </pre>
     </Panel>
@@ -178,7 +178,7 @@ function ToolCost({ detail }: { detail: Extract<ContextItemDetail, { itemKind: '
       <Row label="system prompt" value={tokens(detail.tokens.promptTokens)} />
       <Row label="total" value={tokens(detail.tokens.totalTokens)} strong />
       {detail.active ? null : (
-        <p className="text-[10px] text-doom-faint">not sent to the model; costs nothing until switched on</p>
+        <p className="text-xs text-doom-faint">not sent to the model; costs nothing until switched on</p>
       )}
     </div>
   );
@@ -189,7 +189,7 @@ function SkillFacts({ detail }: { detail: Extract<ContextItemDetail, { itemKind:
     <div data-testid="context-item-cost" className="flex flex-col gap-1">
       <Row label="listing" value={tokens(detail.tokens)} strong />
       <Row label="file" value={detail.filePath} />
-      {detail.modelInvocable ? null : <p className="text-[10px] text-doom-faint">not offered to the model</p>}
+      {detail.modelInvocable ? null : <p className="text-xs text-doom-faint">not offered to the model</p>}
     </div>
   );
 }
@@ -197,8 +197,8 @@ function SkillFacts({ detail }: { detail: Extract<ContextItemDetail, { itemKind:
 function Row({ label, value, strong = false }: { label: string; value: string; strong?: boolean }) {
   return (
     <div className="flex items-baseline justify-between gap-3">
-      <span className="text-[10px] text-doom-faint">{label}</span>
-      <span className={`truncate text-[10px] ${strong ? 'font-bold text-doom-text' : 'text-doom-dim'}`}>{value}</span>
+      <span className="text-xs text-doom-faint">{label}</span>
+      <span className={`truncate text-xs ${strong ? 'font-bold text-doom-text' : 'text-doom-dim'}`}>{value}</span>
     </div>
   );
 }

--- a/packages/clients/doompi-web/src/web/features/activity/ContextPanel.tsx
+++ b/packages/clients/doompi-web/src/web/features/activity/ContextPanel.tsx
@@ -96,20 +96,20 @@ export function ContextPanel() {
 
       <div className="shrink-0 border-t border-doom-border px-4 py-3">
         <div className="flex items-center justify-between">
-          <span className="text-[10px] font-bold text-doom-text">active</span>
-          <span data-testid="context-total" className="text-[10px] font-bold text-doom-text">
+          <span className="text-xs font-bold text-doom-text">active</span>
+          <span data-testid="context-total" className="text-xs font-bold text-doom-text">
             {tokens(total)}
           </span>
         </div>
         {idle > 0 ? (
           <div className="flex items-center justify-between">
-            <span className="text-[10px] text-doom-faint">inactive</span>
-            <span data-testid="context-inactive" className="text-[10px] text-doom-faint">
+            <span className="text-xs text-doom-faint">inactive</span>
+            <span data-testid="context-inactive" className="text-xs text-doom-faint">
               {`+${tokens(idle)}`}
             </span>
           </div>
         ) : null}
-        <span className="text-[9px] leading-relaxed text-doom-faint">
+        <span className="text-2xs leading-relaxed text-doom-faint">
           {`estimated · ${context?.estimator ?? 'gpt-tokenizer'} BPE · not a billed total`}
         </span>
       </div>
@@ -130,18 +130,18 @@ function ContextGroupView({ group, onSelect }: { group: ContextGroup; onSelect: 
           says "section", so a mode never reads as one more row among the tools
           it brought with it. */}
       <div className="flex items-center gap-2 px-1">
-        <span aria-hidden className="text-[11px] font-bold text-doom-faint">
+        <span aria-hidden className="text-sm font-bold text-doom-faint">
           #
         </span>
-        <span className="flex-1 text-[11px] font-bold text-doom-text">{group.label}</span>
-        <span className="text-[8px] font-bold tracking-widest text-doom-violet uppercase">{group.kind}</span>
-        <span data-testid={`context-subtotal-${group.id}`} className="w-14 text-right text-[10px] text-doom-dim">
+        <span className="flex-1 text-sm font-bold text-doom-text">{group.label}</span>
+        <span className="text-2xs font-bold tracking-widest text-doom-violet uppercase">{group.kind}</span>
+        <span data-testid={`context-subtotal-${group.id}`} className="w-14 text-right text-xs text-doom-dim">
           {tokens(group.tokens)}
         </span>
       </div>
 
       {group.items.length === 0 ? (
-        <p data-testid={`context-pending-${group.id}`} className="px-1 text-[10px] text-doom-faint">
+        <p data-testid={`context-pending-${group.id}`} className="px-1 text-xs text-doom-faint">
           {group.detail || 'no tools or skills reported'}
         </p>
       ) : (
@@ -154,9 +154,9 @@ function ContextGroupView({ group, onSelect }: { group: ContextGroup; onSelect: 
               title={owner.owner}
               className="flex items-center gap-2 px-1 pt-1"
             >
-              <span className="flex-1 truncate text-[10px] text-doom-dim">{ownerLabel(owner.owner)}</span>
-              <span className="text-[9px] text-doom-faint">{SOURCE_LABEL[owner.source]}</span>
-              <span className="w-14 text-right text-[10px] text-doom-dim">{tokens(owner.tokens)}</span>
+              <span className="flex-1 truncate text-xs text-doom-dim">{ownerLabel(owner.owner)}</span>
+              <span className="text-2xs text-doom-faint">{SOURCE_LABEL[owner.source]}</span>
+              <span className="w-14 text-right text-xs text-doom-dim">{tokens(owner.tokens)}</span>
             </div>
             {owner.items.map((item) => (
               // A row is a question as much as a figure: what am I paying for.
@@ -171,12 +171,12 @@ function ContextGroupView({ group, onSelect }: { group: ContextGroup; onSelect: 
                 onClick={() => onSelect({ itemKind: item.itemKind, name: item.name, owner: item.owner })}
                 className="flex-row items-center gap-2 rounded-none py-px pr-1 pl-4"
               >
-                <span className={`flex-1 truncate text-[10px] ${item.active ? 'text-doom-text' : 'text-doom-faint'}`}>
+                <span className={`flex-1 truncate text-xs ${item.active ? 'text-doom-text' : 'text-doom-faint'}`}>
                   {item.name}
                 </span>
                 <span
                   title={item.active ? undefined : 'not sent to the model; costs nothing until switched on'}
-                  className={`w-14 text-right text-[10px] ${item.active ? 'text-doom-dim' : 'text-doom-faint'}`}
+                  className={`w-14 text-right text-xs ${item.active ? 'text-doom-dim' : 'text-doom-faint'}`}
                 >
                   {item.active ? tokens(item.tokens) : `(${tokens(item.tokens)})`}
                 </span>

--- a/packages/clients/doompi-web/src/web/features/connection/RefusedCard.tsx
+++ b/packages/clients/doompi-web/src/web/features/connection/RefusedCard.tsx
@@ -5,8 +5,8 @@ import { useActiveSessionMeta } from '../../stores/sessionsStore.ts';
 function Detail({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-center justify-between gap-3">
-      <span className="shrink-0 text-[10px] text-doom-faint">{label}</span>
-      <span className="truncate text-[10px] text-doom-text">{value}</span>
+      <span className="shrink-0 text-xs text-doom-faint">{label}</span>
+      <span className="truncate text-xs text-doom-text">{value}</span>
     </div>
   );
 }
@@ -43,7 +43,7 @@ export function RefusedCard() {
           <Spinner className="text-doom-red/70" />
         </DialogHeader>
         <div className="flex flex-col gap-3 px-4 py-4">
-          <p className="text-[12px] leading-relaxed text-doom-text">
+          <p className="text-sm leading-relaxed text-doom-text">
             doompi-server holds one client at a time so two views cannot fight over the same agent. Another cockpit is
             attached to this socket right now.
           </p>
@@ -53,7 +53,7 @@ export function RefusedCard() {
             <Detail label="cwd" value={abbreviateCwd(meta.summary.cwd)} />
             <Detail label="retry" value="automatic, with backoff" />
           </div>
-          <p data-testid="refused-hint" className="text-[10px] text-doom-faint">
+          <p data-testid="refused-hint" className="text-xs text-doom-faint">
             close the other cockpit and this one takes over on the next attempt.
           </p>
         </div>

--- a/packages/clients/doompi-web/src/web/features/dialogs/DialogOverlay.tsx
+++ b/packages/clients/doompi-web/src/web/features/dialogs/DialogOverlay.tsx
@@ -83,31 +83,31 @@ export function DialogOverlay() {
           event.preventDefault();
           focusPrompt();
         }}
-        className="rounded-[10px] border-doom-edge-magenta"
+        className="rounded-lg border-doom-edge-magenta"
       >
         <DialogHeader className="h-[42px] border-doom-edge-magenta bg-doom-tint-magenta py-0">
           <DialogTitle data-testid="dialog-title" className="flex items-center gap-2 text-doom-magenta">
             <ShieldIcon className="h-[13px] w-[13px] shrink-0" />
             {dialog.title}
           </DialogTitle>
-          <span className="text-[9px] text-doom-faint">extension · {dialog.method}</span>
+          <span className="text-2xs text-doom-faint">extension · {dialog.method}</span>
         </DialogHeader>
 
         <DialogBody>
           {dialog.message && dialog.method === 'select' ? (
             <Panel data-testid="dialog-command" className="bg-doom-deep px-3 py-2.5">
               <div className="flex gap-2">
-                <span className="text-[12px] text-doom-green">$</span>
+                <span className="text-sm text-doom-green">$</span>
                 <pre
                   data-testid="dialog-message"
-                  className="min-w-0 flex-1 whitespace-pre-wrap break-words text-[12px] leading-relaxed text-doom-hi"
+                  className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm leading-relaxed text-doom-hi"
                 >
                   {dialog.message}
                 </pre>
               </div>
             </Panel>
           ) : dialog.message ? (
-            <p data-testid="dialog-message" className="text-[12px] leading-relaxed text-doom-text">
+            <p data-testid="dialog-message" className="text-sm leading-relaxed text-doom-text">
               {dialog.message}
             </p>
           ) : null}
@@ -143,7 +143,7 @@ export function DialogOverlay() {
         <DialogFooter variant="bar" className="h-auto min-h-[34px]">
           <span
             data-testid="dialog-hints"
-            className="w-full text-[10px] text-doom-faint sm:flex sm:w-auto sm:items-center sm:gap-1.5"
+            className="w-full text-xs text-doom-faint sm:flex sm:w-auto sm:items-center sm:gap-1.5"
           >
             {dialog.method === 'select' ? optionListHint(dialog.options.length) : 'enter confirm'} · <Kbd>esc</Kbd>{' '}
             cancels and tells the agent

--- a/packages/clients/doompi-web/src/web/features/leader/CommandPalette.tsx
+++ b/packages/clients/doompi-web/src/web/features/leader/CommandPalette.tsx
@@ -242,7 +242,7 @@ export function CommandPalette() {
           <StatusBadge tone="accent" size="xs" className="tracking-widest">
             {LEADER_PREFIX}
           </StatusBadge>
-          <span data-testid="palette-path" className="text-[12px] font-bold text-doom-hi">
+          <span data-testid="palette-path" className="text-sm font-bold text-doom-hi">
             {keys.length === 0 ? 'Leader Space' : `${keys.join(' ')} · ${group?.label ?? ''}`}
           </span>
           <CommandInput
@@ -258,7 +258,7 @@ export function CommandPalette() {
             onKeyDown={onSearchKey}
             className="text-right"
           />
-          <span data-testid="palette-count" className="text-[10px] text-doom-faint">
+          <span data-testid="palette-count" className="text-xs text-doom-faint">
             {rowCount}
           </span>
         </CommandHeader>
@@ -281,8 +281,8 @@ export function CommandPalette() {
                     onClick={() => invoke(command.name)}
                     className={cn('w-full gap-2.5 px-3 py-1.5', index === cursor && 'bg-doom-magenta/10')}
                   >
-                    <span className="text-[11px] font-bold text-doom-blue">/{command.name}</span>
-                    <CommandItemLabel className="text-[10px] text-doom-faint">{command.description}</CommandItemLabel>
+                    <span className="text-sm font-bold text-doom-blue">/{command.name}</span>
+                    <CommandItemLabel className="text-xs text-doom-faint">{command.description}</CommandItemLabel>
                   </CommandItem>
                 ))
               )
@@ -311,9 +311,9 @@ export function CommandPalette() {
                   >
                     {option.key}
                   </Kbd>
-                  <CommandItemLabel className="text-[11px] text-doom-text">{option.label}</CommandItemLabel>
+                  <CommandItemLabel className="text-sm text-doom-text">{option.label}</CommandItemLabel>
                   {option.binding ? null : (
-                    <span className="text-[9px] text-doom-faint">
+                    <span className="text-2xs text-doom-faint">
                       {option.children.length} {option.children.length === 1 ? 'key' : 'keys'}
                     </span>
                   )}
@@ -330,9 +330,9 @@ export function CommandPalette() {
                     onClick={() => runPluginCommand(command.id)}
                     className="w-full gap-2.5 px-3 py-1.5 hover:bg-doom-magenta/10"
                   >
-                    <CommandItemLabel className="text-[11px] text-doom-text">{command.title}</CommandItemLabel>
+                    <CommandItemLabel className="text-sm text-doom-text">{command.title}</CommandItemLabel>
                     {command.description ? (
-                      <span className="truncate text-[9px] text-doom-faint">{command.description}</span>
+                      <span className="truncate text-2xs text-doom-faint">{command.description}</span>
                     ) : null}
                   </CommandItem>
                 ))}
@@ -343,19 +343,19 @@ export function CommandPalette() {
           <div data-testid="palette-detail" className="hidden min-w-0 flex-1 flex-col gap-2 px-4 py-3 sm:flex">
             {currentMatch ? (
               <>
-                <span className="text-[12px] font-bold text-doom-blue">/{currentMatch.name}</span>
-                <span className="text-[11px] text-doom-faint">{currentMatch.description}</span>
+                <span className="text-sm font-bold text-doom-blue">/{currentMatch.name}</span>
+                <span className="text-sm text-doom-faint">{currentMatch.description}</span>
               </>
             ) : null}
             {current ? (
               <>
                 <div className="flex items-center gap-2">
-                  <span className="text-[12px] font-bold text-doom-magenta">{pathLabel([...keys, current.key])}</span>
-                  <span className="text-[12px] text-doom-hi">{current.label}</span>
+                  <span className="text-sm font-bold text-doom-magenta">{pathLabel([...keys, current.key])}</span>
+                  <span className="text-sm text-doom-hi">{current.label}</span>
                 </div>
-                {current.detail ? <span className="text-[10px] text-doom-faint">{current.detail}</span> : null}
+                {current.detail ? <span className="text-xs text-doom-faint">{current.detail}</span> : null}
                 {current.binding ? (
-                  <span data-testid="palette-target" className="text-[11px] font-bold text-doom-blue">
+                  <span data-testid="palette-target" className="text-sm font-bold text-doom-blue">
                     {'command' in current.binding ? `/${current.binding.command}` : 'in the cockpit'}
                   </span>
                 ) : (
@@ -367,9 +367,9 @@ export function CommandPalette() {
                         onClick={() => descend(child, [...keys, current.key])}
                         className="min-h-0 gap-3 border-doom-border-soft bg-doom-deep px-3 py-1.5 hover:border-doom-blue/50"
                       >
-                        <span className="w-5 text-center text-[10px] font-bold text-doom-magenta">{child.key}</span>
-                        <span className="text-[11px] font-bold text-doom-hi">{child.label}</span>
-                        <OptionLabel className="truncate text-[10px] text-doom-faint">{child.detail}</OptionLabel>
+                        <span className="w-5 text-center text-xs font-bold text-doom-magenta">{child.key}</span>
+                        <span className="text-sm font-bold text-doom-hi">{child.label}</span>
+                        <OptionLabel className="truncate text-xs text-doom-faint">{child.detail}</OptionLabel>
                       </OptionRow>
                     ))}
                   </div>
@@ -380,7 +380,7 @@ export function CommandPalette() {
         </div>
 
         <CommandFooter className="px-4 py-2.5">
-          <span className="flex items-center gap-1.5 text-[10px] text-doom-faint">
+          <span className="flex items-center gap-1.5 text-xs text-doom-faint">
             {searching ? (
               <>
                 <Kbd>↑↓</Kbd> move · <Kbd>enter</Kbd> run · <Kbd>esc</Kbd> back to keys
@@ -391,7 +391,7 @@ export function CommandPalette() {
               </>
             )}
           </span>
-          <span className="text-[10px] text-doom-dim">
+          <span className="text-xs text-doom-dim">
             {bindings.length} keys · {commands.length} commands
           </span>
         </CommandFooter>

--- a/packages/clients/doompi-web/src/web/features/remote/DevProxyTargets.tsx
+++ b/packages/clients/doompi-web/src/web/features/remote/DevProxyTargets.tsx
@@ -39,7 +39,7 @@ export function DevProxyTargets() {
   return (
     <div className="flex w-full flex-col gap-1.5">
       <SectionLabel>dev sites</SectionLabel>
-      <span className="text-[11px] text-doom-faint">
+      <span className="text-sm text-doom-faint">
         Reach a local dev server from a paired device, on this same address.
       </span>
 
@@ -54,13 +54,13 @@ export function DevProxyTargets() {
               href={`${DEV_PROXY_PREFIX}${target.name}/`}
               target="_blank"
               rel="noreferrer"
-              className="truncate text-xs text-doom-hi underline"
+              className="truncate text-sm text-doom-hi underline"
               data-testid={`dev-proxy-open-${target.name}`}
             >
               {DEV_PROXY_PREFIX}
               {target.name}/
             </a>
-            <span className="truncate text-[10px] text-doom-faint">
+            <span className="truncate text-xs text-doom-faint">
               port {target.port} &middot; set base: &apos;{DEV_PROXY_PREFIX}
               {target.name}/&apos; in the dev server
             </span>
@@ -110,13 +110,13 @@ export function DevProxyTargets() {
           </Button>
         </div>
       ) : (
-        <span className="text-[11px] text-doom-faint">
+        <span className="text-sm text-doom-faint">
           Add a dev site on the host. A paired device can open the ones already listed, but not name new ones.
         </span>
       )}
 
       {state.error === undefined ? null : (
-        <span data-testid="dev-proxy-error" className="text-[11px] text-doom-warn">
+        <span data-testid="dev-proxy-error" className="text-sm text-doom-warn">
           {state.error}
         </span>
       )}

--- a/packages/clients/doompi-web/src/web/features/remote/HandoverProgress.tsx
+++ b/packages/clients/doompi-web/src/web/features/remote/HandoverProgress.tsx
@@ -11,11 +11,11 @@ import { Spinner } from '@agimon-ai/doompi-web-components';
 export function HandoverProgress() {
   return (
     <div className="flex flex-col gap-3" data-testid="remote-handover">
-      <div className="flex items-center gap-2 text-xs text-doom-hi">
+      <div className="flex items-center gap-2 text-sm text-doom-hi">
         <Spinner />
         Moving the cockpit into a container.
       </div>
-      <p className="text-[11px] leading-relaxed text-doom-faint">
+      <p className="text-sm leading-relaxed text-doom-faint">
         This page reconnects on its own when the container is serving, and the code to scan appears then. The first run
         for a new version builds the image, which can take several minutes. Progress is printed in the terminal that
         started the cockpit.

--- a/packages/clients/doompi-web/src/web/features/remote/PairedDeviceList.tsx
+++ b/packages/clients/doompi-web/src/web/features/remote/PairedDeviceList.tsx
@@ -18,11 +18,11 @@ export function PairedDeviceList() {
           className="flex items-center justify-between gap-3 rounded border border-doom-border px-2.5 py-1.5"
         >
           <span className="flex min-w-0 flex-col">
-            <span className="truncate text-xs text-doom-hi">
+            <span className="truncate text-sm text-doom-hi">
               {device.label}
               {device.self ? ' \u00b7 this device' : ''}
             </span>
-            <span className="truncate text-[10px] text-doom-faint">{device.userAgent}</span>
+            <span className="truncate text-xs text-doom-faint">{device.userAgent}</span>
           </span>
           <Button
             variant="ghost"

--- a/packages/clients/doompi-web/src/web/features/remote/PairingApprovalDialog.tsx
+++ b/packages/clients/doompi-web/src/web/features/remote/PairingApprovalDialog.tsx
@@ -33,14 +33,14 @@ export function PairingApprovalDialog() {
           </DialogDescription>
         </DialogHeader>
         <DialogBody className="flex flex-col gap-2">
-          <p data-testid="pairing-approval-agent" className="break-words text-xs text-doom-hi">
+          <p data-testid="pairing-approval-agent" className="break-words text-sm text-doom-hi">
             {request.userAgent}
           </p>
           {/* Labelled as reported rather than stated as fact: anything that can
               reach the tunnel listener can set this header to whatever it likes,
               so it is a clue for the human and never a security decision. */}
-          <p className="text-[11px] text-doom-faint">address reported by the edge: {request.edgeIp}</p>
-          <p className="text-[11px] text-doom-faint">
+          <p className="text-sm text-doom-faint">address reported by the edge: {request.edgeIp}</p>
+          <p className="text-sm text-doom-faint">
             Approving grants the same access you have here, including running shell commands.
           </p>
         </DialogBody>

--- a/packages/clients/doompi-web/src/web/features/remote/RemoteAccessDialog.tsx
+++ b/packages/clients/doompi-web/src/web/features/remote/RemoteAccessDialog.tsx
@@ -51,7 +51,7 @@ export function RemoteAccessDialog() {
         <DialogBody className="flex flex-col gap-5">
           {/* Said before the switch, not after: a paired device can do
               everything the person at this keyboard can do. */}
-          <p className="text-xs leading-relaxed text-doom-faint">
+          <p className="text-sm leading-relaxed text-doom-faint">
             A paired device can prompt the agent, approve its tool calls, and run shell commands as you. Pair only
             devices you hold, and only when you mean to.
           </p>
@@ -61,7 +61,7 @@ export function RemoteAccessDialog() {
           {pairing || moving ? null : <RemoteAccessOptions />}
 
           {state.error === undefined ? null : (
-            <p data-testid="remote-access-error" className="text-xs text-doom-red">
+            <p data-testid="remote-access-error" className="text-sm text-doom-red">
               {state.error}
             </p>
           )}

--- a/packages/clients/doompi-web/src/web/features/remote/RemoteAccessOptions.tsx
+++ b/packages/clients/doompi-web/src/web/features/remote/RemoteAccessOptions.tsx
@@ -24,10 +24,8 @@ export function RemoteAccessOptions() {
     <div className="flex flex-col gap-4">
       <label htmlFor="remote-autoclose-switch" className="flex items-start justify-between gap-4">
         <span className="flex flex-col gap-0.5">
-          <span className="text-xs text-doom-hi">close the tunnel automatically</span>
-          <span className="text-[11px] text-doom-faint">
-            So a tunnel you forgot about does not stay open for weeks.
-          </span>
+          <span className="text-sm text-doom-hi">close the tunnel automatically</span>
+          <span className="text-sm text-doom-faint">So a tunnel you forgot about does not stay open for weeks.</span>
         </span>
         <Switch
           id="remote-autoclose-switch"
@@ -38,7 +36,7 @@ export function RemoteAccessOptions() {
       </label>
       {settings.autoCloseEnabled ? (
         <label htmlFor="remote-autoclose-minutes" className="flex items-center justify-between gap-4 pl-4">
-          <span className="text-[11px] text-doom-faint">after this many minutes</span>
+          <span className="text-sm text-doom-faint">after this many minutes</span>
           <Input
             id="remote-autoclose-minutes"
             data-testid="remote-autoclose-minutes"
@@ -54,8 +52,8 @@ export function RemoteAccessOptions() {
 
       <label htmlFor="remote-expiry-switch" className="flex items-start justify-between gap-4">
         <span className="flex flex-col gap-0.5">
-          <span className="text-xs text-doom-hi">expire paired sessions</span>
-          <span className="text-[11px] text-doom-faint">
+          <span className="text-sm text-doom-hi">expire paired sessions</span>
+          <span className="text-sm text-doom-faint">
             A device that goes quiet, or has simply been paired a long time, has to pair again.
           </span>
         </span>
@@ -68,7 +66,7 @@ export function RemoteAccessOptions() {
       </label>
       {settings.sessionExpiryEnabled ? (
         <div className="flex items-center justify-between gap-4 pl-4">
-          <label htmlFor="remote-idle-minutes" className="flex items-center gap-2 text-[11px] text-doom-faint">
+          <label htmlFor="remote-idle-minutes" className="flex items-center gap-2 text-sm text-doom-faint">
             idle minutes
             <Input
               id="remote-idle-minutes"
@@ -81,7 +79,7 @@ export function RemoteAccessOptions() {
               onChange={(event) => void updateRemoteSettings({ idleMinutes: Number(event.target.value) })}
             />
           </label>
-          <label htmlFor="remote-absolute-hours" className="flex items-center gap-2 text-[11px] text-doom-faint">
+          <label htmlFor="remote-absolute-hours" className="flex items-center gap-2 text-sm text-doom-faint">
             total hours
             <Input
               id="remote-absolute-hours"
@@ -99,8 +97,8 @@ export function RemoteAccessOptions() {
 
       <label htmlFor="remote-sandbox-switch" className="flex items-start justify-between gap-4">
         <span className="flex flex-col gap-0.5">
-          <span className="text-xs text-doom-hi">run the cockpit in a container</span>
-          <span className="text-[11px] text-doom-faint">
+          <span className="text-sm text-doom-hi">run the cockpit in a container</span>
+          <span className="text-sm text-doom-faint">
             The agent gets a shell either way. This decides whether that shell can see the rest of this machine.
           </span>
         </span>
@@ -115,13 +113,13 @@ export function RemoteAccessOptions() {
       </label>
       {settings.sandbox.enabled ? <SandboxWorkspaces workspaces={settings.sandbox.workspaces} /> : null}
       {settings.sandbox.enabled ? (
-        <p className="text-[11px] text-doom-faint">
+        <p className="text-sm text-doom-faint">
           Turning remote access on moves this cockpit into the container and reopens it on the same address. Running
           sessions inside the mounted workspaces move with it; the first start builds the image, which takes a while.
         </p>
       ) : null}
 
-      <p className="text-[11px] text-doom-faint">
+      <p className="text-sm text-doom-faint">
         Switching remote access off always revokes every paired device. Requires <code>cloudflared</code> on PATH.
       </p>
 

--- a/packages/clients/doompi-web/src/web/features/remote/RemoteAccessPairing.tsx
+++ b/packages/clients/doompi-web/src/web/features/remote/RemoteAccessPairing.tsx
@@ -21,7 +21,7 @@ export function RemoteAccessPairing() {
         <SectionLabel>or enter this pairing code</SectionLabel>
         <code
           data-testid="remote-pair-code"
-          className="rounded bg-doom-deep p-2 text-center font-mono text-lg tracking-[0.25em] text-doom-text"
+          className="rounded bg-doom-deep p-2 text-center font-mono text-lg tracking-widest text-doom-text"
         >
           {state.pairCode}
         </code>
@@ -30,17 +30,17 @@ export function RemoteAccessPairing() {
         <SectionLabel>signing-key fingerprint</SectionLabel>
         <code
           data-testid="remote-signing-fingerprint"
-          className="break-all rounded bg-doom-deep p-2 text-center font-mono text-[11px] text-doom-text"
+          className="break-all rounded bg-doom-deep p-2 text-center font-mono text-sm text-doom-text"
         >
           {state.pairFingerprint.match(/.{1,8}/gu)?.join(' ') ?? state.pairFingerprint}
         </code>
-        <p className="text-[11px] text-doom-faint">
+        <p className="text-sm text-doom-faint">
           Compare this on the phone when entering the manual code. Bundle revision {String(state.pairRevision)}.
         </p>
       </div>
       <div className="flex w-full flex-col gap-1">
         <SectionLabel>or open this address</SectionLabel>
-        <code data-testid="remote-pair-url" className="break-all rounded bg-doom-deep p-2 text-[11px] text-doom-faint">
+        <code data-testid="remote-pair-url" className="break-all rounded bg-doom-deep p-2 text-sm text-doom-faint">
           {state.pairUrl}
         </code>
       </div>
@@ -54,7 +54,7 @@ export function RemoteAccessPairing() {
       {state.passkeys?.supported === true ? (
         <div className="flex w-full flex-col gap-1.5 border-t border-doom-border pt-3">
           <SectionLabel>passkeys</SectionLabel>
-          <p className="text-[11px] text-doom-faint">
+          <p className="text-sm text-doom-faint">
             {state.passkeys.count === 0
               ? 'Add one on the device you just paired and it will not need the code again.'
               : `${String(state.passkeys.count)} registered. A paired device signs in with a gesture instead of a code.`}
@@ -64,7 +64,7 @@ export function RemoteAccessPairing() {
           </Button>
         </div>
       ) : state.passkeys?.reason === undefined ? null : (
-        <p data-testid="remote-passkey-unavailable" className="w-full text-[11px] text-doom-faint">
+        <p data-testid="remote-passkey-unavailable" className="w-full text-sm text-doom-faint">
           {state.passkeys.reason}
         </p>
       )}

--- a/packages/clients/doompi-web/src/web/features/remote/SandboxWorkspaces.tsx
+++ b/packages/clients/doompi-web/src/web/features/remote/SandboxWorkspaces.tsx
@@ -38,14 +38,14 @@ export function SandboxWorkspaces({ workspaces }: SandboxWorkspacesProps) {
   return (
     <div className="flex flex-col gap-2 pl-4" data-testid="sandbox-workspaces">
       {workspaces.length === 0 ? (
-        <p className="text-[11px] text-doom-faint">
+        <p className="text-sm text-doom-faint">
           Nothing is mounted yet, so the container would have no directory to work in. Add at least one.
         </p>
       ) : (
         <ul className="flex flex-col gap-1">
           {workspaces.map((workspace) => (
             <li key={workspace} className="flex items-center justify-between gap-2">
-              <code className="truncate text-[11px] text-doom-hi">{workspace}</code>
+              <code className="truncate text-sm text-doom-hi">{workspace}</code>
               <Button
                 variant="ghost"
                 data-testid={`sandbox-workspace-remove-${workspace}`}
@@ -75,7 +75,7 @@ export function SandboxWorkspaces({ workspaces }: SandboxWorkspacesProps) {
           add
         </Button>
       </div>
-      <p className="text-[11px] text-doom-faint">
+      <p className="text-sm text-doom-faint">
         Absolute paths only, mounted at the same path inside. Sessions working anywhere else stay on the host and will
         not appear in the contained cockpit.
       </p>

--- a/packages/clients/doompi-web/src/web/features/selection/SelectionBar.tsx
+++ b/packages/clients/doompi-web/src/web/features/selection/SelectionBar.tsx
@@ -72,7 +72,6 @@ const DEFAULT_ACCENT = { border: 'border-doom-border', title: 'text-doom-hi' };
  * that package, and leaves the chip correct when the package is absent.
  */
 const AGENT_COST_STATUS_KEY = 'doom-team-cost';
-
 const AVAILABILITY_TONE: Readonly<Record<MinorMode['availability'], string>> = {
   on: 'text-doom-hi',
   off: 'text-doom-dim',
@@ -110,10 +109,10 @@ function AxisMenu({ menu, dialog }: { menu: string; dialog: DialogRequest }) {
       className={`w-[420px] ${accent.border}`}
     >
       <PopoverHeader>
-        <span data-testid="dialog-title" className={`text-[10px] font-bold tracking-wide ${accent.title}`}>
+        <span data-testid="dialog-title" className={`text-xs font-bold tracking-wide ${accent.title}`}>
           {MENU_TITLE[menu] ?? menu.toUpperCase()}
         </span>
-        <span className="truncate text-[9px] text-doom-faint">{dialog.title}</span>
+        <span className="truncate text-2xs text-doom-faint">{dialog.title}</span>
       </PopoverHeader>
       <div className="flex max-h-[320px] min-h-0 flex-col">
         <OptionList
@@ -200,7 +199,7 @@ function MinorModesPopup({ modes, onClose }: { modes: MinorMode[]; onClose: () =
     <PopoverContent side="top" align="start" data-testid="minor-popup" className="w-[430px] border-doom-edge-magenta">
       <PopoverHeader>
         <SectionLabel className="tracking-wide text-doom-magenta">minor modes</SectionLabel>
-        <span className="text-[9px] text-doom-faint">{on} on</span>
+        <span className="text-2xs text-doom-faint">{on} on</span>
       </PopoverHeader>
       <div
         role="listbox"
@@ -242,20 +241,20 @@ function MinorModesPopup({ modes, onClose }: { modes: MinorMode[]; onClose: () =
               {mode.name}
             </OptionLabel>
             {mode.detail ? (
-              <span data-testid={`minor-detail-${mode.name}`} className="truncate text-[9px] text-doom-magenta">
+              <span data-testid={`minor-detail-${mode.name}`} className="truncate text-2xs text-doom-magenta">
                 {mode.detail}
               </span>
             ) : null}
             {mode.availability === 'unavailable' && mode.unavailableReason ? (
               <span
                 data-testid={`minor-reason-${mode.name}`}
-                className="min-w-0 flex-1 truncate text-right text-[9px] text-doom-faint/70"
+                className="min-w-0 flex-1 truncate text-right text-2xs text-doom-faint/70"
               >
                 {mode.unavailableReason}
               </span>
             ) : null}
             {mode.availability === 'unavailable' ? (
-              <span className="shrink-0 text-[8px] text-doom-faint/60">n/a</span>
+              <span className="shrink-0 text-2xs text-doom-faint/60">n/a</span>
             ) : (
               <Dot tone={mode.availability === 'on' ? 'magenta' : 'muted'} />
             )}
@@ -301,7 +300,7 @@ function ModelPopup({
     <PopoverContent side="top" align="end" data-testid="model-popup" className="w-[400px] border-doom-edge-yellow">
       <PopoverHeader>
         <SectionLabel className="tracking-wide text-doom-yellow">model</SectionLabel>
-        <span className="truncate text-[9px] text-doom-faint">{agent ? `${agent.provider}/${agent.model}` : ''}</span>
+        <span className="truncate text-2xs text-doom-faint">{agent ? `${agent.provider}/${agent.model}` : ''}</span>
       </PopoverHeader>
       <div className="border-b border-doom-border-soft p-1.5">
         <Input
@@ -310,12 +309,12 @@ function ModelPopup({
           autoFocus
           placeholder="filter models…"
           onChange={(event) => setFilter(event.target.value)}
-          className="w-full px-2 py-1 text-[11px]"
+          className="w-full px-2 py-1 text-sm"
         />
       </div>
       <div role="listbox" aria-label="models" className="flex max-h-[260px] flex-col gap-0.5 overflow-y-auto p-1.5">
         {models.length === 0 ? (
-          <span className="flex items-center gap-2 px-2 py-1.5 text-[10px] text-doom-faint">
+          <span className="flex items-center gap-2 px-2 py-1.5 text-xs text-doom-faint">
             <Spinner label="asking the session for its models" />
             asking the session for its models…
           </span>
@@ -340,11 +339,11 @@ function ModelPopup({
                 current && 'bg-doom-tint-yellow hover:brightness-125',
               )}
             >
-              <span className="w-20 shrink-0 truncate text-[9px] text-doom-faint">{model.provider}</span>
+              <span className="w-20 shrink-0 truncate text-2xs text-doom-faint">{model.provider}</span>
               <OptionLabel density="compact" className={current ? 'text-doom-yellow' : 'text-doom-hi'}>
                 {model.id}
               </OptionLabel>
-              {model.reasoning ? <span className="text-[8px] text-doom-faint">thinks</span> : null}
+              {model.reasoning ? <span className="text-2xs text-doom-faint">thinks</span> : null}
               <Dot tone={current ? 'yellow' : 'muted'} />
             </OptionRow>
           );
@@ -352,7 +351,7 @@ function ModelPopup({
       </div>
       <PopoverFooter className="flex-wrap justify-start gap-1 py-1.5">
         <SectionLabel className="mr-1 tracking-wide">thinking</SectionLabel>
-        {levels.length === 0 ? <span className="text-[9px] text-doom-faint">…</span> : null}
+        {levels.length === 0 ? <span className="text-2xs text-doom-faint">…</span> : null}
         {levels.map((level) => {
           const current = agent?.thinkingLevel === level;
           return (
@@ -367,7 +366,7 @@ function ModelPopup({
                 onClose();
               }}
               className={cn(
-                'text-[10px]',
+                'text-xs',
                 current && 'bg-doom-yellow/25 font-bold text-doom-yellow hover:bg-doom-yellow/25',
               )}
             >
@@ -410,7 +409,6 @@ export function SelectionBar() {
   const reportedAgentCost = Number(statuses[AGENT_COST_STATUS_KEY] ?? '');
   const agentCost = Number.isFinite(reportedAgentCost) ? reportedAgentCost : 0;
   const sessionCost = stats === null ? null : stats.cost + liveCost;
-
   /** The dialog this axis asked for, when the claim named it and it is still open. */
   const dialogFor = (name: string): DialogRequest | null =>
     dialog !== null && claimed !== null && claimed.dialogId === dialog.id && claimed.menu === name ? dialog : null;
@@ -418,12 +416,12 @@ export function SelectionBar() {
 
   const modeClass = cn(
     buttonVariants({ variant: 'primary', size: 'sm' }),
-    'h-[21px] min-w-0 rounded-[3px] px-2 text-doom-rail max-sm:max-w-24 max-sm:flex-1 max-sm:basis-0 max-sm:shrink',
+    'h-[21px] min-w-0 rounded-sm px-2 text-doom-rail max-sm:max-w-24 max-sm:flex-1 max-sm:basis-0 max-sm:shrink',
     selection.pending && 'bg-doom-yellow',
   );
   const axisClass = cn(
     buttonVariants({ variant: 'outline', size: 'sm' }),
-    'h-[21px] min-w-0 rounded-[3px] px-2 max-sm:max-w-28 max-sm:flex-1 max-sm:basis-0 max-sm:shrink',
+    'h-[21px] min-w-0 rounded-sm px-2 max-sm:max-w-28 max-sm:flex-1 max-sm:basis-0 max-sm:shrink',
   );
 
   return (
@@ -439,7 +437,7 @@ export function SelectionBar() {
         claimedDialog={dialogFor('mode')}
         className={modeClass}
       >
-        <span data-testid="selection-mode" className="truncate text-[10px] font-bold tracking-[0.08em]">
+        <span data-testid="selection-mode" className="truncate text-xs font-bold tracking-wide">
           {(selection.majorMode || 'mode').toUpperCase()}
         </span>
       </AxisButton>
@@ -455,7 +453,7 @@ export function SelectionBar() {
         >
           <span
             data-testid={`selection-${axis.name}`}
-            className={`truncate text-[10px] ${axis.multi ? '' : 'font-bold'} ${
+            className={`truncate text-xs ${axis.multi ? '' : 'font-bold'} ${
               axis.values.length > 0 ? (AXIS_TONE[axis.name] ?? 'text-doom-hi') : 'text-doom-faint'
             }`}
           >
@@ -482,16 +480,16 @@ export function SelectionBar() {
             variant={activeMinors.length > 0 ? 'subtle' : 'outline'}
             size="sm"
             className={cn(
-              'h-[21px] min-w-0 rounded-[3px] px-2 max-sm:max-w-24 max-sm:flex-1 max-sm:basis-0 max-sm:shrink',
+              'h-[21px] min-w-0 rounded-sm px-2 max-sm:max-w-24 max-sm:flex-1 max-sm:basis-0 max-sm:shrink',
               activeMinors.length > 0
                 ? 'bg-doom-tint-magenta text-doom-magenta hover:bg-doom-tint-magenta hover:brightness-125'
                 : 'text-doom-faint',
             )}
           >
-            <span data-testid="minor-summary" className="truncate text-[10px] font-bold">
+            <span data-testid="minor-summary" className="truncate text-xs font-bold">
               {activeMinors[0]?.name ?? 'minor'}
             </span>
-            {activeMinors.length > 1 ? <span className="text-[9px]">+{activeMinors.length - 1}</span> : null}
+            {activeMinors.length > 1 ? <span className="text-2xs">+{activeMinors.length - 1}</span> : null}
             <ChevronDownIcon className="h-[10px] w-[10px]" />
           </Button>
         </PopoverTrigger>
@@ -509,10 +507,10 @@ export function SelectionBar() {
       <Popover open={modelOpen} onOpenChange={setModelOpen}>
         <PopoverTrigger asChild>
           <Button data-testid="axis-model" title="model and thinking level" className={axisClass}>
-            <span data-testid="agent-model" className="min-w-0 truncate text-[10px] text-doom-hi">
+            <span data-testid="agent-model" className="min-w-0 truncate text-xs text-doom-hi">
               {agent?.model ?? '—'}
             </span>
-            <span data-testid="agent-thinking" className="text-[10px] text-doom-yellow max-sm:hidden">
+            <span data-testid="agent-thinking" className="text-xs text-doom-yellow max-sm:hidden">
               {agent?.thinkingLevel ?? ''}
             </span>
             <ChevronDownIcon className="h-[10px] w-[10px] text-doom-faint" />
@@ -530,7 +528,7 @@ export function SelectionBar() {
             ? `${stats.contextTokens.toLocaleString()} of ${stats.contextWindow.toLocaleString()} tokens`
             : 'context usage, once the session reports it'
         }
-        className="shrink-0 text-[10px] text-doom-dim max-sm:hidden"
+        className="shrink-0 text-xs text-doom-dim max-sm:hidden"
       >
         {stats?.contextPercent == null ? 'ctx —' : `ctx ${Math.round(stats.contextPercent)}%`}
       </span>
@@ -543,7 +541,7 @@ export function SelectionBar() {
               ? `$${sessionCost.toFixed(2)} session + $${agentCost.toFixed(2)} agents, ${stats.totalTokens.toLocaleString()} tokens this session`
               : `${stats.totalTokens.toLocaleString()} tokens this session`
         }
-        className="shrink-0 text-[10px] text-doom-dim max-sm:hidden"
+        className="shrink-0 text-xs text-doom-dim max-sm:hidden"
       >
         {sessionCost === null ? '' : `$${(sessionCost + agentCost).toFixed(2)}`}
       </span>

--- a/packages/clients/doompi-web/src/web/features/selection/SelectionBar.tsx
+++ b/packages/clients/doompi-web/src/web/features/selection/SelectionBar.tsx
@@ -64,6 +64,15 @@ const MENU_ACCENT: Readonly<Record<string, { border: string; title: string }>> =
 
 const DEFAULT_ACCENT = { border: 'border-doom-border', title: 'text-doom-hi' };
 
+/**
+ * Where the team package reports what its subagent runs have cost this
+ * session, as a plain decimal string. Those runs bill to sessions of their own,
+ * so their spend never reaches this session's stats and has to arrive as a
+ * status. Reading it by name is what keeps the cockpit free of a dependency on
+ * that package, and leaves the chip correct when the package is absent.
+ */
+const AGENT_COST_STATUS_KEY = 'doom-team-cost';
+
 const AVAILABILITY_TONE: Readonly<Record<MinorMode['availability'], string>> = {
   on: 'text-doom-hi',
   off: 'text-doom-dim',
@@ -384,6 +393,7 @@ export function SelectionBar() {
   const catalog = useActiveSession((state) => state.minorModes);
   const agent = useActiveSession((state) => state.agent);
   const stats = useActiveSession((state) => state.stats);
+  const liveCost = useActiveSession((state) => state.liveCost);
   const models = useActiveSession((state) => state.models);
   const thinkingLevels = useActiveSession((state) => state.thinkingLevels);
   const dialog = useActiveSession((state) => state.dialog);
@@ -396,6 +406,10 @@ export function SelectionBar() {
   const axes = selectionAxes(statuses);
   const modes = minorModes(statuses, widgets, catalog);
   const activeMinors = modes.filter((mode) => mode.availability === 'on');
+
+  const reportedAgentCost = Number(statuses[AGENT_COST_STATUS_KEY] ?? '');
+  const agentCost = Number.isFinite(reportedAgentCost) ? reportedAgentCost : 0;
+  const sessionCost = stats === null ? null : stats.cost + liveCost;
 
   /** The dialog this axis asked for, when the claim named it and it is still open. */
   const dialogFor = (name: string): DialogRequest | null =>
@@ -522,10 +536,16 @@ export function SelectionBar() {
       </span>
       <span
         data-testid="top-cost"
-        title={stats ? `${stats.totalTokens.toLocaleString()} tokens this session` : ''}
+        title={
+          stats === null || sessionCost === null
+            ? ''
+            : agentCost > 0
+              ? `$${sessionCost.toFixed(2)} session + $${agentCost.toFixed(2)} agents, ${stats.totalTokens.toLocaleString()} tokens this session`
+              : `${stats.totalTokens.toLocaleString()} tokens this session`
+        }
         className="shrink-0 text-[10px] text-doom-dim max-sm:hidden"
       >
-        {stats ? `$${stats.cost.toFixed(2)}` : ''}
+        {sessionCost === null ? '' : `$${(sessionCost + agentCost).toFixed(2)}`}
       </span>
     </footer>
   );

--- a/packages/clients/doompi-web/src/web/features/session/Composer.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/Composer.tsx
@@ -569,9 +569,9 @@ export function Composer() {
                       }}
                       className="w-full items-baseline gap-2.5 rounded-none px-3 py-1.5"
                     >
-                      <span className="shrink-0 text-[12px] font-bold text-doom-blue">{item.label}</span>
+                      <span className="shrink-0 text-sm font-bold text-doom-blue">{item.label}</span>
                       {item.detail ? (
-                        <OptionLabel density="compact" className="text-[10px] text-doom-dim">
+                        <OptionLabel density="compact" className="text-xs text-doom-dim">
                           {item.detail}
                         </OptionLabel>
                       ) : null}
@@ -586,7 +586,7 @@ export function Composer() {
               </PopoverContent>
             ) : null}
             <div className="flex min-w-0 items-start gap-2 px-2.5 pt-3 sm:gap-2.5 sm:px-3.5">
-              <span className="mt-[3px] shrink-0 select-none text-[13px] leading-none text-doom-green">&gt;</span>
+              <span className="mt-[3px] shrink-0 select-none text-base leading-none text-doom-green">&gt;</span>
               <Textarea
                 variant="bare"
                 ref={inputRef}
@@ -659,7 +659,7 @@ export function Composer() {
                 }}
                 rows={1}
                 placeholder={placeholder}
-                className="min-h-[20px] min-w-0 flex-1 text-[13px] leading-relaxed"
+                className="min-h-[20px] min-w-0 flex-1 text-base leading-relaxed"
               />
             </div>
             {attachments.length > 0 ? (
@@ -668,7 +668,7 @@ export function Composer() {
                   <span
                     key={attachment.id}
                     data-testid={`composer-attachment-${attachment.id}`}
-                    className="flex max-w-full items-center gap-1.5 rounded border border-doom-border bg-doom-panel px-1.5 py-1 text-[10px] text-doom-dim"
+                    className="flex max-w-full items-center gap-1.5 rounded border border-doom-border bg-doom-panel px-1.5 py-1 text-xs text-doom-dim"
                   >
                     {attachment.kind === 'image' ? (
                       <img src={attachment.dataUrl} alt="" className="h-6 w-6 rounded object-cover" />
@@ -696,16 +696,12 @@ export function Composer() {
               </div>
             ) : null}
             {attachmentError ? (
-              <p
-                role="alert"
-                data-testid="composer-attachment-error"
-                className="px-3.5 pt-1.5 text-[10px] text-doom-red"
-              >
+              <p role="alert" data-testid="composer-attachment-error" className="px-3.5 pt-1.5 text-xs text-doom-red">
                 {attachmentError}
               </p>
             ) : null}
             <div className="flex flex-wrap items-center gap-2 px-2.5 pt-2 pb-2.5 sm:flex-nowrap sm:px-3.5">
-              <span data-testid="composer-hint" className="text-[10px] text-doom-faint max-sm:hidden">
+              <span data-testid="composer-hint" className="text-xs text-doom-faint max-sm:hidden">
                 {streaming
                   ? 'enter steers the run · esc aborts'
                   : 'enter sends · shift+enter for a new line · space opens leader'}
@@ -752,7 +748,7 @@ export function Composer() {
                     <label
                       aria-disabled={!attached}
                       data-testid="composer-attach-row"
-                      className={`relative overflow-hidden text-[12px] text-doom-text hover:bg-doom-tint-blue ${optionRowVariants(
+                      className={`relative overflow-hidden text-sm text-doom-text hover:bg-doom-tint-blue ${optionRowVariants(
                         { density: 'compact' },
                       )} ${attached ? '' : 'pointer-events-none opacity-40'}`}
                     >

--- a/packages/clients/doompi-web/src/web/features/session/QueueSheet.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/QueueSheet.tsx
@@ -38,7 +38,7 @@ export function QueueSheet({
         aria-haspopup="dialog"
         aria-expanded={open}
         onClick={() => setOpen(true)}
-        className="mb-2 h-7 w-full justify-between rounded-md border border-doom-border-soft bg-doom-panel/60 px-2.5 text-[10px] text-doom-dim hover:text-doom-hi"
+        className="mb-2 h-7 w-full justify-between rounded-md border border-doom-border-soft bg-doom-panel/60 px-2.5 text-xs text-doom-dim hover:text-doom-hi"
       >
         <span className="flex min-w-0 items-center gap-2">
           <RefreshIcon className="h-3 w-3 shrink-0 text-doom-cyan" />
@@ -61,7 +61,7 @@ export function QueueSheet({
           <span aria-hidden className="mx-auto mt-2 h-1 w-10 shrink-0 rounded-full bg-doom-border" />
           <DialogHeader dismissible closeLabel="close queued messages" className="py-2.5">
             <DialogTitle>queued messages</DialogTitle>
-            <span className="text-[10px] text-doom-faint">{label} waiting</span>
+            <span className="text-xs text-doom-faint">{label} waiting</span>
           </DialogHeader>
           <DialogBody className="overflow-y-auto p-2 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
             <ol className="flex flex-col gap-1.5">
@@ -71,15 +71,11 @@ export function QueueSheet({
                   data-testid="queue-sheet-item"
                   className="flex min-w-0 gap-3 rounded-md border border-doom-border-soft bg-doom-deep px-3 py-2.5"
                 >
-                  <span className="pt-0.5 text-[10px] font-bold text-doom-cyan">
-                    {String(index + 1).padStart(2, '0')}
-                  </span>
+                  <span className="pt-0.5 text-xs font-bold text-doom-cyan">{String(index + 1).padStart(2, '0')}</span>
                   <div className="min-w-0 flex-1">
-                    <p className="whitespace-pre-wrap break-words text-[12px] leading-relaxed text-doom-hi">
-                      {entry.text}
-                    </p>
+                    <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-doom-hi">{entry.text}</p>
                     {entry.images && entry.images.length > 0 ? (
-                      <p className="mt-1 text-[9px] text-doom-faint">
+                      <p className="mt-1 text-2xs text-doom-faint">
                         {entry.images.length} image{entry.images.length === 1 ? '' : 's'} attached
                       </p>
                     ) : null}
@@ -103,7 +99,7 @@ export function QueueSheet({
               {unlisted > 0 ? (
                 <li
                   data-testid="queue-sheet-unlisted"
-                  className="rounded-md border border-dashed border-doom-border px-3 py-2.5 text-[11px] text-doom-faint"
+                  className="rounded-md border border-dashed border-doom-border px-3 py-2.5 text-sm text-doom-faint"
                 >
                   {unlisted} more queued message{unlisted === 1 ? ' is' : 's are'} waiting in the session. Their text is
                   not available in this browser.

--- a/packages/clients/doompi-web/src/web/features/session/Timeline.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/Timeline.tsx
@@ -94,7 +94,7 @@ function Gutter({ label, tone, trailing = false }: { label: string; tone: string
   const placement = trailing
     ? 'w-full text-right sm:w-auto sm:text-left'
     : 'w-full text-left sm:w-11 sm:pt-0.5 sm:text-right';
-  return <span className={`shrink-0 text-[10px] font-bold ${placement} ${tone}`}>{label}</span>;
+  return <span className={`shrink-0 text-xs font-bold ${placement} ${tone}`}>{label}</span>;
 }
 
 /** Two letters from a persona name, so a profile without an icon is still distinct. */
@@ -104,7 +104,7 @@ function personaInitials(name: string): string {
   return letters.toUpperCase() || 'DP';
 }
 
-function SpeakerAvatar({ speaker, identity }: { speaker: 'assistant' | 'user'; identity?: ProfileIdentity }) {
+function SpeakerAvatar({ speaker, identity }: { speaker: 'assistant' | 'user'; identity?: ProfileIdentity | null }) {
   if (speaker === 'assistant') {
     // The icon arrives as a bounded data URL on the journalled identity entry,
     // so a persona without one, or with one that failed to load, still renders.
@@ -156,7 +156,7 @@ function MessageActions({
                 title={action.label}
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() => action.run(userMessage)}
-                className={ActionIcon ? 'border-0 shadow-none' : 'h-6 border-0 px-2 text-[10px] shadow-none'}
+                className={ActionIcon ? 'border-0 shadow-none' : 'h-6 border-0 px-2 text-xs shadow-none'}
               >
                 {ActionIcon ? <ActionIcon aria-hidden={true} className="h-3 w-3" /> : action.label}
               </Button>
@@ -251,7 +251,15 @@ function ToolGroupRow({
     </div>
   );
 }
-const Entry = memo(function Entry({ entry, sessionId }: { entry: TimelineEntry; sessionId: string | null }) {
+const Entry = memo(function Entry({
+  entry,
+  sessionId,
+  sessionIdentity,
+}: {
+  entry: TimelineEntry;
+  sessionId: string | null;
+  sessionIdentity: ProfileIdentity | null;
+}) {
   useWebPluginRegistry();
   const sessionStreaming = useActiveSession((state) => state.streaming);
   const quoteSource = useRef<HTMLDivElement>(null);
@@ -281,7 +289,7 @@ const Entry = memo(function Entry({ entry, sessionId }: { entry: TimelineEntry; 
         <div className="relative min-w-0 flex-1">
           <div
             ref={quoteSource}
-            className="flex flex-col gap-2 rounded-md border border-doom-border-soft bg-doom-deep px-3.5 py-2.5 text-[13px] text-doom-hi"
+            className="flex flex-col gap-2 rounded-md border border-doom-border-soft bg-doom-deep px-3.5 py-2.5 text-base text-doom-hi"
           >
             <MessageMarkdown sessionId={sessionId} text={entry.text} />
             {entry.images && entry.images.length > 0 ? (
@@ -324,7 +332,7 @@ const Entry = memo(function Entry({ entry, sessionId }: { entry: TimelineEntry; 
         data-streaming={entry.streaming}
         className="group/message flex flex-col gap-2 sm:flex-row sm:gap-3"
       >
-        <SpeakerAvatar speaker="assistant" identity={entry.identity} />
+        <SpeakerAvatar speaker="assistant" identity={entry.identity ?? sessionIdentity} />
         <div className="relative min-w-0 flex-1">
           <div className="flex flex-col gap-2">
             {entry.thinking ? (
@@ -332,12 +340,12 @@ const Entry = memo(function Entry({ entry, sessionId }: { entry: TimelineEntry; 
                 data-testid="entry-thinking"
                 // Thinking stays quiet and neutral, even when its Markdown source
                 // uses strong emphasis for status updates.
-                className="text-[11px] font-normal text-doom-dim [&_p]:whitespace-pre-wrap [&_strong]:font-normal [&_strong]:text-doom-dim"
+                className="text-sm font-normal text-doom-dim [&_p]:whitespace-pre-wrap [&_strong]:font-normal [&_strong]:text-doom-dim"
               >
                 <MessageMarkdown sessionId={sessionId} text={entry.thinking} />
               </div>
             ) : null}
-            <div ref={quoteSource} className="text-[13px] text-doom-text">
+            <div ref={quoteSource} className="text-base text-doom-text">
               <MessageMarkdown sessionId={sessionId} text={entry.text} />
               {entry.streaming ? <StreamCursor /> : null}
             </div>
@@ -358,7 +366,7 @@ const Entry = memo(function Entry({ entry, sessionId }: { entry: TimelineEntry; 
     return (
       <div data-testid="entry-settled" className="flex items-center gap-3 sm:pl-14">
         <Separator className="flex-1" />
-        <span className="text-[10px] text-doom-faint">
+        <span className="text-xs text-doom-faint">
           agent settled{entry.tools > 0 ? ` · ${entry.tools} tool${entry.tools === 1 ? '' : 's'}` : ''}
         </span>
         <Separator className="flex-1" />
@@ -374,12 +382,12 @@ const Entry = memo(function Entry({ entry, sessionId }: { entry: TimelineEntry; 
     <div data-testid="entry-notice" data-tone={entry.tone} className="flex gap-2 sm:gap-3">
       {/* One character wide, so it stays beside its line even on a phone. */}
       <span
-        className={`shrink-0 pt-0.5 text-[10px] font-bold sm:w-11 sm:text-right ${isError ? 'text-doom-red' : 'text-doom-faint'}`}
+        className={`shrink-0 pt-0.5 text-xs font-bold sm:w-11 sm:text-right ${isError ? 'text-doom-red' : 'text-doom-faint'}`}
       >
         {isError ? '!' : '·'}
       </span>
       <p
-        className={`min-w-0 flex-1 whitespace-pre-wrap break-words text-[12px] ${isError ? 'text-doom-red' : 'text-doom-dim'}`}
+        className={`min-w-0 flex-1 whitespace-pre-wrap break-words text-sm ${isError ? 'text-doom-red' : 'text-doom-dim'}`}
       >
         {entry.text.split(/(\s+)/u).map((part, index) => {
           const href = noticeHref(part);
@@ -403,7 +411,7 @@ const Entry = memo(function Entry({ entry, sessionId }: { entry: TimelineEntry; 
 function BackgroundWorkNotice() {
   return (
     <output data-testid="background-work-notice" className="mt-auto flex shrink-0 justify-center px-3 pt-2 pb-3">
-      <span className="max-w-lg rounded-md border border-doom-yellow/40 bg-doom-panel px-3 py-2 text-center text-[10px] leading-relaxed text-doom-yellow">
+      <span className="max-w-lg rounded-md border border-doom-yellow/40 bg-doom-panel px-3 py-2 text-center text-xs leading-relaxed text-doom-yellow">
         Background work is still running. The agent will resume when results are ready.
       </span>
     </output>
@@ -437,6 +445,12 @@ export function Transcript({
   compact?: boolean;
 }) {
   const entries = useStore(store, (state) => state.entries);
+  // Pi's protocol transcript carries no persona, and a history window taken from
+  // the middle of a session carries no identity entry either, so an entry from
+  // those paths has no stamp of its own. The fold's current persona is the honest
+  // answer for one of them, and it corrects itself when the identity lands late,
+  // which a stamp written at merge time cannot do.
+  const sessionIdentity = useStore(store, (state) => state.profileIdentity);
   const visibleEntries = useMemo(() => {
     const shown = entries.filter((entry) => entry.kind !== 'queued');
     return limit === undefined ? shown : shown.slice(-limit);
@@ -600,7 +614,7 @@ export function Transcript({
             {unit.kind === 'group' ? (
               <ToolGroupRow name={unit.name} entries={unit.entries} sessionId={sessionId} />
             ) : (
-              <Entry entry={unit.entry} sessionId={sessionId} />
+              <Entry entry={unit.entry} sessionId={sessionId} sessionIdentity={sessionIdentity} />
             )}
           </div>
         ))}

--- a/packages/clients/doompi-web/src/web/features/sessions/NewSessionDialog.tsx
+++ b/packages/clients/doompi-web/src/web/features/sessions/NewSessionDialog.tsx
@@ -140,7 +140,7 @@ export function NewSessionDialog({
         </DialogHeader>
         <DialogBody>
           <label htmlFor="new-session-cwd" className="flex flex-col gap-1">
-            <span className="text-[10px] text-doom-faint">
+            <span className="text-xs text-doom-faint">
               working directory <span className="text-doom-faint/70">(type a folder name or paste a path)</span>
             </span>
             <Input
@@ -172,7 +172,7 @@ export function NewSessionDialog({
                   onMouseDown={(event) => event.preventDefault()}
                   onMouseEnter={() => setHighlight(index)}
                   onClick={() => pick(directory)}
-                  className="w-full px-2.5 py-1 text-[11px]"
+                  className="w-full px-2.5 py-1 text-sm"
                 >
                   {directory}
                 </OptionRow>
@@ -196,7 +196,7 @@ export function NewSessionDialog({
             </div>
           ) : null}
           <label htmlFor="new-session-name" className="flex flex-col gap-1">
-            <span className="text-[10px] text-doom-faint">name (optional)</span>
+            <span className="text-xs text-doom-faint">name (optional)</span>
             <Input
               id="new-session-name"
               data-testid="new-session-name"
@@ -214,7 +214,7 @@ export function NewSessionDialog({
             // worth resizing the dialog for, so it lives in its own scroller.
             <pre
               data-testid="new-session-error"
-              className="max-h-28 overflow-y-auto rounded border border-doom-edge-red bg-doom-tint-red/40 px-2.5 py-2 text-[10px] leading-relaxed whitespace-pre-wrap break-words text-doom-red"
+              className="max-h-28 overflow-y-auto rounded border border-doom-edge-red bg-doom-tint-red/40 px-2.5 py-2 text-xs leading-relaxed whitespace-pre-wrap break-words text-doom-red"
             >
               {error}
             </pre>

--- a/packages/clients/doompi-web/src/web/features/sessions/ResumeSessionDialog.tsx
+++ b/packages/clients/doompi-web/src/web/features/sessions/ResumeSessionDialog.tsx
@@ -107,26 +107,26 @@ export function ResumeSessionDialog({ sessionId, onClose }: { sessionId: string;
                   className="w-full items-start px-2.5 py-2 text-left"
                 >
                   <span className="min-w-0 flex-1">
-                    <span className="block truncate text-[11px] font-bold text-doom-hi">{threadLabel(thread)}</span>
+                    <span className="block truncate text-sm font-bold text-doom-hi">{threadLabel(thread)}</span>
                     {thread.name && thread.firstMessage ? (
-                      <span className="mt-0.5 line-clamp-2 block text-[10px] text-doom-dim">{thread.firstMessage}</span>
+                      <span className="mt-0.5 line-clamp-2 block text-xs text-doom-dim">{thread.firstMessage}</span>
                     ) : null}
                   </span>
-                  <span className="shrink-0 pl-3 text-[9px] text-doom-faint">
+                  <span className="shrink-0 pl-3 text-2xs text-doom-faint">
                     {running ? 'running' : `${thread.messageCount} messages`}
                   </span>
                 </OptionRow>
               );
             })}
             {!loading && visible.length === 0 ? (
-              <p className="px-2.5 py-6 text-center text-[10px] text-doom-faint">
+              <p className="px-2.5 py-6 text-center text-xs text-doom-faint">
                 {query.trim() ? 'no matching threads' : 'no Pi history for this workspace'}
               </p>
             ) : null}
-            {loading ? <p className="px-2.5 py-6 text-center text-[10px] text-doom-faint">loading history…</p> : null}
+            {loading ? <p className="px-2.5 py-6 text-center text-xs text-doom-faint">loading history…</p> : null}
           </div>
           {error ? (
-            <p data-testid="session-resume-error" className="text-[10px] text-doom-red">
+            <p data-testid="session-resume-error" className="text-xs text-doom-red">
               {error}
             </p>
           ) : null}

--- a/packages/clients/doompi-web/src/web/features/sessions/SessionRail.tsx
+++ b/packages/clients/doompi-web/src/web/features/sessions/SessionRail.tsx
@@ -198,7 +198,7 @@ function SessionCard({
         ) : null}
         <span
           data-testid="session-status"
-          className={`text-[11px] leading-snug ${awaitingInput ? 'text-doom-red' : active ? 'line-clamp-2 text-doom-on-selected/85' : 'truncate text-doom-dim'}`}
+          className={`text-sm leading-snug ${awaitingInput ? 'text-doom-red' : active ? 'line-clamp-2 text-doom-on-selected/85' : 'truncate text-doom-dim'}`}
         >
           {restarting ? 'restarting…' : status}
         </span>
@@ -206,7 +206,7 @@ function SessionCard({
       {summary.git ? (
         <span
           data-testid="session-branch"
-          className={`flex items-center gap-[7px] pt-0.5 text-[10px] ${active ? 'text-doom-on-selected/85' : 'text-doom-faint'}`}
+          className={`flex items-center gap-[7px] pt-0.5 text-xs ${active ? 'text-doom-on-selected/85' : 'text-doom-faint'}`}
         >
           <BranchIcon
             className={`h-[10px] w-[10px] shrink-0 ${active ? 'text-doom-on-selected/70' : 'text-doom-faint'}`}
@@ -218,12 +218,12 @@ function SessionCard({
       {/* A nested session's cwd is a generated worktree path that repeats what
           the branch already says, so the child stays lighter than its parent. */}
       {nested ? null : (
-        <span className={`truncate text-[10px] ${active ? 'text-doom-on-selected/70' : 'text-doom-faint'}`}>
+        <span className={`truncate text-xs ${active ? 'text-doom-on-selected/70' : 'text-doom-faint'}`}>
           {abbreviateCwd(summary.cwd)}
         </span>
       )}
       {error ? (
-        <span data-testid="session-error" className="line-clamp-3 text-[10px] break-words text-doom-red">
+        <span data-testid="session-error" className="line-clamp-3 text-xs break-words text-doom-red">
           {error}
         </span>
       ) : null}
@@ -251,7 +251,7 @@ function SessionCard({
               if (event.key === 'Escape') enterMode('view');
             }}
             onBlur={() => enterMode('view')}
-            className="border-doom-blue/60 px-1.5 py-0.5 text-[13px] font-bold"
+            className="border-doom-blue/60 px-1.5 py-0.5 text-base font-bold"
           />
           {details}
         </div>
@@ -276,14 +276,14 @@ function SessionCard({
               />
             ) : null}
             <span
-              className={`min-w-0 flex-1 truncate text-[13px] font-bold ${active ? 'text-doom-on-selected' : 'text-doom-hi'}`}
+              className={`min-w-0 flex-1 truncate text-base font-bold ${active ? 'text-doom-on-selected' : 'text-doom-hi'}`}
             >
               {summary.name || 'untitled'}
             </span>
             {ordinal <= 9 ? (
               <span
                 title={`press ${String(ordinal)} to focus`}
-                className={`flex h-[17px] w-[17px] shrink-0 items-center justify-center rounded-full text-[9px] font-bold transition-opacity group-focus-within:opacity-0 group-hover:opacity-0 ${
+                className={`flex h-[17px] w-[17px] shrink-0 items-center justify-center rounded-full text-2xs font-bold transition-opacity group-focus-within:opacity-0 group-hover:opacity-0 ${
                   active ? 'bg-doom-on-selected/20 text-doom-on-selected' : 'bg-doom-tint-magenta text-doom-magenta'
                 }`}
               >
@@ -426,7 +426,7 @@ export function SessionRail({ onDismiss }: { onDismiss?: () => void }) {
         className="flex items-center justify-between border-b border-doom-border px-4 pt-4 pb-3.5"
       >
         <span className="flex items-center gap-[3px]" aria-label="DoomPi">
-          <span aria-hidden="true" className="text-[15px] font-bold tracking-[0.16em] text-doom-hi">
+          <span aria-hidden="true" className="text-lg font-bold tracking-wider text-doom-hi">
             DOOM
           </span>
           <MascotMark size={22} />
@@ -506,7 +506,7 @@ export function SessionRail({ onDismiss }: { onDismiss?: () => void }) {
               onDismiss?.();
               openNewSession();
             }}
-            className="w-full justify-start px-[11px] text-[11px]"
+            className="w-full justify-start px-[11px] text-sm"
           >
             <PlusIcon className="h-3 w-3" />
             new session
@@ -520,7 +520,7 @@ export function SessionRail({ onDismiss }: { onDismiss?: () => void }) {
         {remote === undefined || remote.status === 'off' ? null : (
           <div
             data-testid="remote-banner"
-            className={`flex flex-col gap-1.5 border-t px-4 py-2 text-[11px] ${
+            className={`flex flex-col gap-1.5 border-t px-4 py-2 text-sm ${
               remote.status === 'failed' ? 'bg-doom-tint-red text-doom-red' : 'bg-doom-tint-yellow text-doom-yellow'
             }`}
           >
@@ -566,7 +566,7 @@ export function SessionRail({ onDismiss }: { onDismiss?: () => void }) {
             </TooltipTrigger>
             <TooltipContent side="top">settings</TooltipContent>
           </Tooltip>
-          <span className="text-[9px] text-doom-faint max-sm:hidden">ctrl+k commands · ctrl+t new session</span>
+          <span className="text-2xs text-doom-faint max-sm:hidden">ctrl+k commands · ctrl+t new session</span>
         </div>
       </div>
 

--- a/packages/clients/doompi-web/src/web/features/sessions/WelcomePanel.tsx
+++ b/packages/clients/doompi-web/src/web/features/sessions/WelcomePanel.tsx
@@ -24,7 +24,7 @@ export function WelcomePanel() {
         <PlusIcon className="h-3 w-3" />
         new session
       </Button>
-      <span className="flex items-center gap-1.5 text-[10px] text-doom-faint">
+      <span className="flex items-center gap-1.5 text-xs text-doom-faint">
         <Kbd>ctrl+t</Kbd> new session · <Kbd>ctrl+k</Kbd> commands
       </span>
     </EmptyState>

--- a/packages/clients/doompi-web/src/web/features/settings/AppearanceSettings.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/AppearanceSettings.tsx
@@ -68,17 +68,17 @@ export function AppearanceSettings() {
             >
               <ThemeSwatch theme={theme} />
               <span className="flex items-center gap-2">
-                <span className={`flex-1 text-[12px] font-bold ${selected ? 'text-doom-blue' : 'text-doom-hi'}`}>
+                <span className={`flex-1 text-sm font-bold ${selected ? 'text-doom-blue' : 'text-doom-hi'}`}>
                   {theme.label}
                 </span>
-                <span className="text-[9px] text-doom-faint">{theme.scheme}</span>
+                <span className="text-2xs text-doom-faint">{theme.scheme}</span>
                 {selected ? <CheckIcon className="h-3 w-3 text-doom-blue" /> : null}
               </span>
             </RadioGroupCard>
           );
         })}
       </RadioGroup>
-      <p className="text-[10px] leading-relaxed text-doom-faint">
+      <p className="text-xs leading-relaxed text-doom-faint">
         a theme is a JSON config of twenty palette tokens; see @agimon-ai/doompi-web-components for the contract.
       </p>
     </div>

--- a/packages/clients/doompi-web/src/web/features/settings/ContributedSettings.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/ContributedSettings.tsx
@@ -66,7 +66,7 @@ function OriginBadge({ origin, scope }: { origin: SettingsOrigin; scope: Setting
   // colouring: it is why an edit at the other scope would appear to do nothing.
   const shadowed = origin === 'repository' && scope === 'global';
   return (
-    <Badge tone={shadowed ? 'yellow' : 'neutral'} className="shrink-0 text-[8px]">
+    <Badge tone={shadowed ? 'yellow' : 'neutral'} className="shrink-0 text-2xs">
       {originLabel(origin, scope)}
     </Badge>
   );
@@ -109,22 +109,22 @@ function FieldRow({ field, view, scope, models, draft, busy, onDraft }: FieldRow
   return (
     <div data-testid={`settings-field-${field.id}`} data-dirty={dirty} className="flex flex-col gap-1 py-2.5">
       <div className="flex min-w-0 flex-wrap items-center gap-2">
-        <span className="min-w-0 flex-1 truncate text-[11px] font-bold text-doom-hi">{field.label}</span>
+        <span className="min-w-0 flex-1 truncate text-sm font-bold text-doom-hi">{field.label}</span>
         {dirty ? (
-          <Badge tone="cyan" data-testid={`settings-dirty-${field.id}`} className="shrink-0 text-[8px]">
+          <Badge tone="cyan" data-testid={`settings-dirty-${field.id}`} className="shrink-0 text-2xs">
             unsaved
           </Badge>
         ) : null}
         {view === undefined ? null : <OriginBadge origin={view.origin} scope={scope} />}
         {locked === undefined ? null : (
-          <Badge tone="neutral" data-testid={`settings-locked-${field.id}`} className="shrink-0 text-[8px]">
+          <Badge tone="neutral" data-testid={`settings-locked-${field.id}`} className="shrink-0 text-2xs">
             {locked}
           </Badge>
         )}
       </div>
 
       {kind === 'info' ? (
-        <span className="text-[11px] text-doom-text">{value || '—'}</span>
+        <span className="text-sm text-doom-text">{value || '—'}</span>
       ) : kind === 'toggle' ? (
         <Switch
           data-testid={`settings-toggle-${field.id}`}
@@ -138,7 +138,7 @@ function FieldRow({ field, view, scope, models, draft, busy, onDraft }: FieldRow
           disabled={busy || locked !== undefined}
           onValueChange={(next) => onDraft(field, next === INHERIT_VALUE ? null : next)}
         >
-          <SelectTrigger data-testid={`settings-select-${field.id}`} className="text-[11px]">
+          <SelectTrigger data-testid={`settings-select-${field.id}`} className="text-sm">
             <SelectValue placeholder={field.placeholder ?? 'inherit'} />
           </SelectTrigger>
           <SelectContent>
@@ -168,20 +168,20 @@ function FieldRow({ field, view, scope, models, draft, busy, onDraft }: FieldRow
           // A blank field means "inherit": the parser rejects an empty value, so
           // clearing the key is how the file spells it.
           onChange={(event) => onDraft(field, event.target.value === '' ? null : event.target.value)}
-          className="text-[11px]"
+          className="text-sm"
         />
       )}
 
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
         {field.detail === undefined ? null : (
-          <span className="min-w-0 basis-full text-[9px] leading-relaxed text-doom-faint min-[480px]:basis-auto min-[480px]:flex-1">
+          <span className="min-w-0 basis-full text-2xs leading-relaxed text-doom-faint min-[480px]:basis-auto min-[480px]:flex-1">
             {field.detail}
           </span>
         )}
         {/* The config key earns its place on a page that writes a config file,
             but it is reference, not prose: it wraps instead of running off the
             edge, and never squeezes the sentence beside it. */}
-        <code className="min-w-0 max-w-full break-all text-[9px] text-doom-faint/70 min-[480px]:shrink-0">
+        <code className="min-w-0 max-w-full break-all text-2xs text-doom-faint/70 min-[480px]:shrink-0">
           {keyOf(field)}
         </code>
         {dirty ? (
@@ -191,7 +191,7 @@ function FieldRow({ field, view, scope, models, draft, busy, onDraft }: FieldRow
             data-testid={`settings-revert-${field.id}`}
             disabled={busy}
             onClick={() => onDraft(field, undefined)}
-            className="shrink-0 text-[9px]"
+            className="shrink-0 text-2xs"
           >
             revert
           </Button>
@@ -202,7 +202,7 @@ function FieldRow({ field, view, scope, models, draft, busy, onDraft }: FieldRow
             data-testid={`settings-clear-${field.id}`}
             disabled={busy}
             onClick={() => onDraft(field, null)}
-            className="shrink-0 text-[9px]"
+            className="shrink-0 text-2xs"
           >
             clear override
           </Button>
@@ -322,14 +322,14 @@ export function ContributedSettings({ section, scope, repoRoot = '' }: Contribut
     <div data-testid={`settings-contributed-${section.id}`} className="flex flex-col gap-3">
       <SettingsSectionHeader title={section.label} detail={section.detail}>
         {scope === 'repository' && repoRoot === '' ? (
-          <span data-testid="settings-no-repositories" className="shrink-0 text-[9px] text-doom-faint">
+          <span data-testid="settings-no-repositories" className="shrink-0 text-2xs text-doom-faint">
             pick a repository above to edit its config
           </span>
         ) : null}
       </SettingsSectionHeader>
 
       {error === '' ? null : (
-        <p data-testid="settings-error" className="text-[11px] leading-relaxed text-doom-red">
+        <p data-testid="settings-error" className="text-sm leading-relaxed text-doom-red">
           {error}
         </p>
       )}
@@ -359,7 +359,7 @@ export function ContributedSettings({ section, scope, repoRoot = '' }: Contribut
           loading={busy}
           disabled={busy || !canSaveSettings({ dirty: dirtyFields.length, scope, repoRoot })}
           onClick={() => void save()}
-          className="text-[10px]"
+          className="text-xs"
         >
           save
         </Button>
@@ -370,14 +370,14 @@ export function ContributedSettings({ section, scope, repoRoot = '' }: Contribut
             data-testid="settings-discard"
             disabled={busy}
             onClick={discard}
-            className="text-[10px]"
+            className="text-xs"
           >
             discard
           </Button>
         )}
         <span
           data-testid="settings-save-note"
-          className="min-w-0 basis-full text-[9px] leading-relaxed text-doom-faint min-[480px]:basis-auto min-[480px]:flex-1"
+          className="min-w-0 basis-full text-2xs leading-relaxed text-doom-faint min-[480px]:basis-auto min-[480px]:flex-1"
         >
           {dirtyFields.length > 0
             ? `${String(dirtyFields.length)} unsaved · writing to ${scope === 'global' ? 'the global config' : 'this repository'}`

--- a/packages/clients/doompi-web/src/web/features/settings/ImageSettings.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/ImageSettings.tsx
@@ -57,12 +57,12 @@ export function ImageSettings() {
         detail="how large an image may be when it reaches a model. applies to images the agent reads and to the ones you attach here; Pi's own settings screen writes the same file."
       />
       {error === undefined ? null : (
-        <p data-testid="image-settings-error" className="text-[11px] text-doom-red">
+        <p data-testid="image-settings-error" className="text-sm text-doom-red">
           {error}
         </p>
       )}
       {images === undefined ? (
-        <p className="text-[11px] text-doom-dim">reading the machine's image settings…</p>
+        <p className="text-sm text-doom-dim">reading the machine's image settings…</p>
       ) : (
         <div className="flex flex-col gap-3 rounded border border-doom-border bg-doom-panel p-3">
           <label className="flex items-center gap-3">
@@ -73,14 +73,14 @@ export function ImageSettings() {
               onCheckedChange={(checked) => void save({ autoResize: checked })}
             />
             <span className="flex flex-col gap-0.5">
-              <span className="text-[11px] font-bold text-doom-hi">auto-resize images</span>
-              <span className="text-[9px] leading-relaxed text-doom-faint">
+              <span className="text-sm font-bold text-doom-hi">auto-resize images</span>
+              <span className="text-2xs leading-relaxed text-doom-faint">
                 off sends every image at the size it arrived, which a provider may reject for the whole conversation.
               </span>
             </span>
           </label>
           <div className="flex flex-col gap-1">
-            <span className="text-[11px] font-bold text-doom-hi">longest edge</span>
+            <span className="text-sm font-bold text-doom-hi">longest edge</span>
             <div className="flex items-center gap-2">
               <Input
                 data-testid="image-max-dimension"
@@ -89,7 +89,7 @@ export function ImageSettings() {
                 spellCheck={false}
                 disabled={busy || !images.autoResize}
                 onChange={(event) => setDraft(event.target.value)}
-                className="w-28 text-[11px]"
+                className="w-28 text-sm"
               />
               <Button
                 size="sm"
@@ -100,7 +100,7 @@ export function ImageSettings() {
                 save
               </Button>
             </div>
-            <span className="text-[9px] leading-relaxed text-doom-faint">
+            <span className="text-2xs leading-relaxed text-doom-faint">
               pixels, between {images.minDimension} and {images.maxAllowedDimension}. a value outside that range is
               clamped, because Pi resizes every tool result at {images.maxAllowedDimension} whatever this says.
             </span>

--- a/packages/clients/doompi-web/src/web/features/settings/LoginFlowDialog.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/LoginFlowDialog.tsx
@@ -20,7 +20,7 @@ const linkClass = 'inline break-all decoration-doom-blue/40 hover:decoration-doo
 function FlowEvent({ event }: { event: LoginEvent }) {
   if (event.type === 'auth_url') {
     return (
-      <div className="flex flex-col gap-1 text-[11px] text-doom-text">
+      <div className="flex flex-col gap-1 text-sm text-doom-text">
         <span>open this link to authorize:</span>
         <Button asChild variant="link" size="xs" className={linkClass}>
           <a data-testid="login-flow-auth-url" href={event.url} target="_blank" rel="noreferrer">
@@ -33,7 +33,7 @@ function FlowEvent({ event }: { event: LoginEvent }) {
   }
   if (event.type === 'device_code') {
     return (
-      <div className="flex flex-col gap-1 text-[11px] text-doom-text">
+      <div className="flex flex-col gap-1 text-sm text-doom-text">
         <span>
           enter code{' '}
           <span data-testid="login-flow-device-code" className="font-bold text-doom-hi">
@@ -49,7 +49,7 @@ function FlowEvent({ event }: { event: LoginEvent }) {
   }
   if (event.type === 'info') {
     return (
-      <div className="flex flex-col gap-1 text-[11px] text-doom-text">
+      <div className="flex flex-col gap-1 text-sm text-doom-text">
         <span>{event.message}</span>
         {event.links?.map((link) => (
           <a key={link.url} href={link.url} target="_blank" rel="noreferrer" className={linkClass}>
@@ -59,7 +59,7 @@ function FlowEvent({ event }: { event: LoginEvent }) {
       </div>
     );
   }
-  return <span className="text-[11px] text-doom-dim">{event.message}</span>;
+  return <span className="text-sm text-doom-dim">{event.message}</span>;
 }
 
 function PromptField({
@@ -80,7 +80,7 @@ function PromptField({
   if (prompt.type === 'select') {
     return (
       <div data-testid="login-prompt" data-prompt-type={prompt.type} className="flex flex-col gap-2">
-        <span className="text-[11px] text-doom-text">{prompt.message}</span>
+        <span className="text-sm text-doom-text">{prompt.message}</span>
         <div className="flex flex-col gap-1">
           {(prompt.options ?? []).map((option) => (
             <Button
@@ -90,8 +90,8 @@ function PromptField({
               onClick={() => onSelect(option.id)}
               className="h-auto flex-col items-start gap-0.5 px-2.5 py-1.5 text-left whitespace-normal focus-visible:border-doom-blue/50 focus-visible:ring-0"
             >
-              <span className="text-[11px] text-doom-hi">{option.label}</span>
-              {option.description ? <span className="text-[10px] text-doom-faint">{option.description}</span> : null}
+              <span className="text-sm text-doom-hi">{option.label}</span>
+              {option.description ? <span className="text-xs text-doom-faint">{option.description}</span> : null}
             </Button>
           ))}
         </div>
@@ -100,12 +100,12 @@ function PromptField({
   }
   return (
     <label data-testid="login-prompt" data-prompt-type={prompt.type} className="flex flex-col gap-1">
-      <span className="text-[11px] text-doom-text">{prompt.message}</span>
+      <span className="text-sm text-doom-text">{prompt.message}</span>
       {/* The provider redirects to a loopback address that belongs to whichever
           machine the browser runs on, so a remote tab lands on an error page.
           The URL still carries the code, which is what this asks for. */}
       {remote && prompt.type === 'manual_code' ? (
-        <span data-testid="login-prompt-remote-hint" className="text-[10px] text-doom-faint">
+        <span data-testid="login-prompt-remote-hint" className="text-xs text-doom-faint">
           the page it sends you to will not load from here. copy the whole address from your browser's address bar and
           paste it below.
         </span>
@@ -185,7 +185,7 @@ export function LoginFlowDialog({
       <DialogContent width="md" data-testid="login-flow" data-status={flow.status} aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>sign in to {flow.providerName}</DialogTitle>
-          <span className="text-[10px] text-doom-faint">{METHOD_LABEL[flow.type]}</span>
+          <span className="text-xs text-doom-faint">{METHOD_LABEL[flow.type]}</span>
         </DialogHeader>
         <DialogBody>
           {flow.events.length > 0 ? (
@@ -208,13 +208,13 @@ export function LoginFlowDialog({
             />
           ) : null}
           {running && !prompt ? (
-            <p data-testid="login-flow-waiting" className="flex items-center gap-2 text-[11px] text-doom-dim">
+            <p data-testid="login-flow-waiting" className="flex items-center gap-2 text-sm text-doom-dim">
               <Spinner />
               {flow.events.length === 0 ? 'starting…' : `waiting for ${flow.providerName}…`}
             </p>
           ) : null}
           {outcome ? (
-            <p data-testid="login-flow-result" className={`text-[11px] ${outcome.className}`}>
+            <p data-testid="login-flow-result" className={`text-sm ${outcome.className}`}>
               {outcome.text}
             </p>
           ) : null}

--- a/packages/clients/doompi-web/src/web/features/settings/NotificationSettings.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/NotificationSettings.tsx
@@ -48,10 +48,10 @@ export function NotificationSettings() {
         detail="open pages receive full live notification text. a closed installed app receives only a generic live alert, with no session content and no replay after downtime."
       />
       <div className="flex flex-col items-start gap-2 rounded border border-doom-border bg-doom-panel p-3">
-        <p data-testid="notification-permission-status" className="text-[11px] text-doom-dim">
+        <p data-testid="notification-permission-status" className="text-sm text-doom-dim">
           {STATUS_COPY[status]}
         </p>
-        <p data-testid="push-subscription-status" className="text-[11px] text-doom-dim">
+        <p data-testid="push-subscription-status" className="text-sm text-doom-dim">
           {PUSH_COPY[pushStatus]}
         </p>
         {pushStatus === 'enabled' ? (
@@ -64,7 +64,7 @@ export function NotificationSettings() {
           </Button>
         ) : null}
         {status === 'denied' ? (
-          <p className="text-[11px] text-doom-dim">enable notifications for this site in your browser settings</p>
+          <p className="text-sm text-doom-dim">enable notifications for this site in your browser settings</p>
         ) : null}
       </div>
     </div>

--- a/packages/clients/doompi-web/src/web/features/settings/PluginSettings.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/PluginSettings.tsx
@@ -40,12 +40,12 @@ export function PluginSettings() {
       />
       <div className="flex flex-col gap-2">
         <SectionLabel>installed</SectionLabel>
-        <p className="text-[11px] leading-relaxed text-doom-faint">
+        <p className="text-sm leading-relaxed text-doom-faint">
           the web plugins compiled into this bundle; doompi sync rebuilds it from the packages installed in the
           composition.
         </p>
         {plugins.length === 0 ? (
-          <p data-testid="settings-plugins-empty" className="text-[11px] text-doom-dim">
+          <p data-testid="settings-plugins-empty" className="text-sm text-doom-dim">
             no web plugins in this bundle. run doompi sync to bundle the installed packages.
           </p>
         ) : (
@@ -57,10 +57,10 @@ export function PluginSettings() {
                 className="flex flex-col gap-0.5 bg-transparent px-3 py-2 min-[480px]:flex-row min-[480px]:items-baseline min-[480px]:gap-3"
               >
                 <li data-testid={`settings-plugin-${plugin.id}`}>
-                  <span className="text-[12px] font-bold text-doom-hi">{plugin.id}</span>
+                  <span className="text-sm font-bold text-doom-hi">{plugin.id}</span>
                   {/* Wraps rather than truncates: a clipped "2 lea…" tells the
                       reader less than nothing about what the plugin contributed. */}
-                  <span className="min-w-0 w-full text-[10px] leading-relaxed text-doom-faint min-[480px]:w-auto min-[480px]:flex-1">
+                  <span className="min-w-0 w-full text-xs leading-relaxed text-doom-faint min-[480px]:w-auto min-[480px]:flex-1">
                     {contributions(plugin).join(' · ') || 'no contributions'}
                   </span>
                 </li>
@@ -72,12 +72,12 @@ export function PluginSettings() {
 
       <div className="flex flex-col gap-2">
         <SectionLabel>install diagnostics</SectionLabel>
-        <p className="text-[11px] leading-relaxed text-doom-faint">
+        <p className="text-sm leading-relaxed text-doom-faint">
           plugins are independent, so when two want the same tab, tool, group, or key the install keeps one and records
           the other here rather than failing the page.
         </p>
         {diagnostics.length === 0 ? (
-          <p data-testid="settings-plugin-diagnostics-empty" className="text-[11px] text-doom-dim">
+          <p data-testid="settings-plugin-diagnostics-empty" className="text-sm text-doom-dim">
             nothing to resolve: no two plugins wanted the same name.
           </p>
         ) : (
@@ -89,10 +89,10 @@ export function PluginSettings() {
                 className="flex flex-col gap-0.5 bg-transparent px-3 py-2"
               >
                 <li data-testid={`settings-plugin-diagnostic-${diagnostic.pluginId}`} data-kind={diagnostic.kind}>
-                  <span className="text-[10px] font-bold text-doom-yellow">
+                  <span className="text-xs font-bold text-doom-yellow">
                     {diagnostic.pluginId} · {diagnostic.kind}
                   </span>
-                  <span className="text-[10px] leading-snug text-doom-dim">{diagnostic.message}</span>
+                  <span className="text-xs leading-snug text-doom-dim">{diagnostic.message}</span>
                 </li>
               </Panel>
             ))}

--- a/packages/clients/doompi-web/src/web/features/settings/ProviderSettings.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/ProviderSettings.tsx
@@ -35,15 +35,15 @@ function ProviderRow({
     >
       <li data-testid={`provider-${provider.id}`} data-authenticated={authenticated}>
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <span className="truncate text-[12px] font-bold text-doom-hi">{provider.name}</span>
-          <span className="truncate text-[10px] text-doom-faint">{provider.id}</span>
+          <span className="truncate text-sm font-bold text-doom-hi">{provider.name}</span>
+          <span className="truncate text-xs text-doom-faint">{provider.id}</span>
         </div>
         {/* State is read, not pressed. It used to wear the same outlined chip as
             the sign-in button beside it, so forty rows offered what looked like
             two buttons each. Only the actions keep a border. */}
         <span
           data-testid={`provider-status-${provider.id}`}
-          className={`flex shrink-0 items-center gap-1.5 self-start text-[10px] min-[560px]:self-auto ${
+          className={`flex shrink-0 items-center gap-1.5 self-start text-xs min-[560px]:self-auto ${
             authenticated ? 'text-doom-green' : 'text-doom-faint'
           }`}
         >
@@ -76,7 +76,7 @@ function ProviderRow({
           </Button>
         ) : null}
         {provider.methods.length === 0 ? (
-          <span className="text-[10px] text-doom-faint">ambient credentials only</span>
+          <span className="text-xs text-doom-faint">ambient credentials only</span>
         ) : null}
       </li>
     </Panel>
@@ -187,12 +187,12 @@ export function ProviderSettings() {
         detail="sign in to the model providers Pi can use. credentials land in Pi's auth.json on this machine, so every session shares them."
       />
       {error ? (
-        <p data-testid="provider-settings-error" className="text-[11px] leading-relaxed text-doom-red">
+        <p data-testid="provider-settings-error" className="text-sm leading-relaxed text-doom-red">
           {error}
         </p>
       ) : null}
       {providers === null && !error ? (
-        <p className="flex items-center gap-2 text-[11px] text-doom-faint">
+        <p className="flex items-center gap-2 text-sm text-doom-faint">
           <Spinner label="reading providers" />
           reading providers…
         </p>
@@ -207,7 +207,7 @@ export function ProviderSettings() {
               onChange={(event) => setFilter(event.target.value)}
               className="flex-1"
             />
-            <span className="shrink-0 text-right text-[10px] text-doom-faint">
+            <span className="shrink-0 text-right text-xs text-doom-faint">
               {authenticatedCount} of {providers.length} signed in
             </span>
           </div>

--- a/packages/clients/doompi-web/src/web/features/settings/RemoteControlSettings.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/RemoteControlSettings.tsx
@@ -21,7 +21,7 @@ export function RemoteControlSettings() {
       />
 
       {state.view === undefined ? (
-        <p className="flex items-center gap-2 text-[11px] text-doom-faint">
+        <p className="flex items-center gap-2 text-sm text-doom-faint">
           <Spinner label="reading remote control settings" />
           reading remote control settings…
         </p>
@@ -29,7 +29,7 @@ export function RemoteControlSettings() {
         <TunnelSettings tunnel={state.view.settings.tunnel} />
       )}
 
-      <p className="text-[11px] leading-relaxed text-doom-faint">
+      <p className="text-sm leading-relaxed text-doom-faint">
         install <code>cloudflared</code> on this machine before turning remote access on. the remote access dialog
         remains the place to start the tunnel, pair devices, and turn access off.
       </p>

--- a/packages/clients/doompi-web/src/web/features/settings/RepositorySettings.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/RepositorySettings.tsx
@@ -32,7 +32,7 @@ const ORIGIN_LABEL: Readonly<Record<SettingsOrigin, string>> = {
 
 function OriginBadge({ origin }: { origin: SettingsOrigin }) {
   return (
-    <Badge tone={origin === 'repository' ? 'cyan' : 'neutral'} className="shrink-0 text-[8px]">
+    <Badge tone={origin === 'repository' ? 'cyan' : 'neutral'} className="shrink-0 text-2xs">
       {ORIGIN_LABEL[origin]}
     </Badge>
   );
@@ -85,16 +85,16 @@ function SingleAxis({
   return (
     <div data-testid={`repository-axis-${id}`} data-dirty={dirty} className="flex flex-col gap-1.5 py-3">
       <div className="flex min-w-0 flex-wrap items-center gap-2">
-        <span className="min-w-0 flex-1 text-[11px] font-bold text-doom-hi">{label}</span>
+        <span className="min-w-0 flex-1 text-sm font-bold text-doom-hi">{label}</span>
         {dirty ? (
-          <Badge tone="cyan" className="text-[8px]">
+          <Badge tone="cyan" className="text-2xs">
             unsaved
           </Badge>
         ) : null}
         <OriginBadge origin={origin} />
       </div>
       <Select value={selected} disabled={busy} onValueChange={(next) => onChange(next === INHERIT_VALUE ? null : next)}>
-        <SelectTrigger data-testid={`repository-select-${id}`} className="text-[11px]">
+        <SelectTrigger data-testid={`repository-select-${id}`} className="text-sm">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -107,7 +107,7 @@ function SingleAxis({
         </SelectContent>
       </Select>
       <div className="flex min-w-0 flex-col items-stretch gap-1.5 min-[480px]:flex-row min-[480px]:items-start min-[480px]:gap-2">
-        <span className="min-w-0 flex-1 text-[9px] leading-relaxed text-doom-faint">
+        <span className="min-w-0 flex-1 text-2xs leading-relaxed text-doom-faint">
           {optionDetail(options, shown) || detail}
         </span>
         {dirty ? (
@@ -116,7 +116,7 @@ function SingleAxis({
             size="xs"
             disabled={busy}
             onClick={onRevert}
-            className="self-end text-[9px] min-[480px]:shrink-0 min-[480px]:self-auto"
+            className="self-end text-2xs min-[480px]:shrink-0 min-[480px]:self-auto"
           >
             revert
           </Button>
@@ -126,7 +126,7 @@ function SingleAxis({
             size="xs"
             disabled={busy}
             onClick={() => onChange(null)}
-            className="self-end text-[9px] min-[480px]:shrink-0 min-[480px]:self-auto"
+            className="self-end text-2xs min-[480px]:shrink-0 min-[480px]:self-auto"
           >
             clear override
           </Button>
@@ -156,9 +156,9 @@ function DomainsAxis({ view, draft, dirty, busy, onChange, onRevert }: DomainsAx
   return (
     <div data-testid="repository-axis-domains" data-dirty={dirty} className="flex flex-col gap-2 py-3">
       <div className="flex min-w-0 flex-wrap items-center gap-2">
-        <span className="min-w-0 flex-1 text-[11px] font-bold text-doom-hi">domains</span>
+        <span className="min-w-0 flex-1 text-sm font-bold text-doom-hi">domains</span>
         {dirty ? (
-          <Badge tone="cyan" className="text-[8px]">
+          <Badge tone="cyan" className="text-2xs">
             unsaved
           </Badge>
         ) : null}
@@ -177,29 +177,29 @@ function DomainsAxis({ view, draft, dirty, busy, onChange, onRevert }: DomainsAx
               disabled={busy}
               title={domain.description}
               onClick={() => onChange(toggled(domain.name))}
-              className={active ? 'text-[9px] text-doom-blue' : 'text-[9px] text-doom-dim'}
+              className={active ? 'text-2xs text-doom-blue' : 'text-2xs text-doom-dim'}
             >
               {domain.name}
             </Button>
           );
         })}
         {view.catalogs.domains.length === 0 ? (
-          <span className="text-[10px] text-doom-faint">no domains are configured.</span>
+          <span className="text-xs text-doom-faint">no domains are configured.</span>
         ) : null}
       </div>
       <div className="flex min-w-0 flex-wrap items-center gap-2">
-        <span className="min-w-0 flex-1 text-[9px] text-doom-faint">
+        <span className="min-w-0 flex-1 text-2xs text-doom-faint">
           {selected.length === 0 ? 'No domains selected.' : selected.join(', ')}
         </span>
-        <Button variant="ghost" size="xs" disabled={busy} onClick={() => onChange([])} className="text-[9px]">
+        <Button variant="ghost" size="xs" disabled={busy} onClick={() => onChange([])} className="text-2xs">
           select none
         </Button>
         {dirty ? (
-          <Button variant="ghost" size="xs" disabled={busy} onClick={onRevert} className="text-[9px]">
+          <Button variant="ghost" size="xs" disabled={busy} onClick={onRevert} className="text-2xs">
             revert
           </Button>
         ) : axis.origin === 'repository' ? (
-          <Button variant="ghost" size="xs" disabled={busy} onClick={() => onChange(null)} className="text-[9px]">
+          <Button variant="ghost" size="xs" disabled={busy} onClick={() => onChange(null)} className="text-2xs">
             clear override
           </Button>
         ) : null}
@@ -296,13 +296,13 @@ export function RepositorySettings({ repository }: { repository: SettingsReposit
       />
 
       {repository === null ? (
-        <p data-testid="repository-settings-empty" className="text-[11px] text-doom-faint">
+        <p data-testid="repository-settings-empty" className="text-sm text-doom-faint">
           open a session inside a .doom or Git repository to configure it here.
         </p>
       ) : null}
 
       {error === '' ? null : (
-        <p data-testid="repository-settings-error" className="text-[11px] text-doom-red">
+        <p data-testid="repository-settings-error" className="text-sm text-doom-red">
           {error}
         </p>
       )}
@@ -353,16 +353,16 @@ export function RepositorySettings({ repository }: { repository: SettingsReposit
               loading={busy}
               disabled={busy || dirty === 0}
               onClick={() => void save()}
-              className="text-[10px]"
+              className="text-xs"
             >
               save defaults
             </Button>
             {dirty === 0 ? null : (
-              <Button variant="ghost" size="xs" disabled={busy} onClick={() => setDrafts({})} className="text-[10px]">
+              <Button variant="ghost" size="xs" disabled={busy} onClick={() => setDrafts({})} className="text-xs">
                 discard
               </Button>
             )}
-            <span className="min-w-0 basis-full text-[9px] text-doom-faint min-[480px]:basis-auto min-[480px]:flex-1">
+            <span className="min-w-0 basis-full text-2xs text-doom-faint min-[480px]:basis-auto min-[480px]:flex-1">
               {dirty > 0 ? `${String(dirty)} unsaved ${dirty === 1 ? 'axis' : 'axes'}` : note}
             </span>
           </footer>

--- a/packages/clients/doompi-web/src/web/features/settings/RepositoryWorkspace.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/RepositoryWorkspace.tsx
@@ -82,11 +82,11 @@ export function RepositoryWorkspace({ current }: { current: SettingsSection }) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex min-w-0 shrink-0 flex-wrap items-center gap-2 border-b border-doom-border bg-doom-panel px-3 py-2 sm:px-5 lg:px-6">
-        <span className="order-1 shrink-0 text-[9px] font-bold text-doom-faint sm:order-none">repository</span>
+        <span className="order-1 shrink-0 text-2xs font-bold text-doom-faint sm:order-none">repository</span>
         <Select value={repositoryId} disabled={loading || repositories.length === 0} onValueChange={selectRepository}>
           <SelectTrigger
             data-testid="repository-workspace-picker"
-            className="order-4 w-full text-[10px] sm:order-none sm:w-[min(360px,45vw)]"
+            className="order-4 w-full text-xs sm:order-none sm:w-[min(360px,45vw)]"
           >
             <SelectValue placeholder={loading ? 'loading repositories' : 'pick a repository'} />
           </SelectTrigger>
@@ -104,7 +104,7 @@ export function RepositoryWorkspace({ current }: { current: SettingsSection }) {
             {repository.active ? 'active' : 'recent'}
           </Badge>
         )}
-        <span className="order-5 w-full min-w-0 truncate text-[9px] text-doom-faint/70 sm:order-none sm:w-auto sm:flex-1">
+        <span className="order-5 w-full min-w-0 truncate text-2xs text-doom-faint/70 sm:order-none sm:w-auto sm:flex-1">
           {repository?.path}
         </span>
         <Button
@@ -119,7 +119,7 @@ export function RepositoryWorkspace({ current }: { current: SettingsSection }) {
               setLoading(false);
             });
           }}
-          className="order-3 ml-auto text-[9px] sm:order-none sm:ml-0"
+          className="order-3 ml-auto text-2xs sm:order-none sm:ml-0"
         >
           refresh
         </Button>

--- a/packages/clients/doompi-web/src/web/features/settings/SettingsMenu.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/SettingsMenu.tsx
@@ -37,7 +37,7 @@ function SectionLinks({
       >
         {/* Title only: each page repeats its own detail in the panel header, and
             eight stacked descriptions made the menu taller than the page. */}
-        <span className={`truncate text-[12px] font-bold ${current ? 'text-doom-blue' : 'text-doom-hi'}`}>
+        <span className={`truncate text-sm font-bold ${current ? 'text-doom-blue' : 'text-doom-hi'}`}>
           {section.label}
         </span>
       </Link>
@@ -65,8 +65,8 @@ export function SettingsMenu({ active, workspace }: { active: string | undefined
           <span className="flex min-w-0 items-center gap-2.5">
             <GearIcon className="h-3.5 w-3.5 shrink-0 text-doom-blue" />
             <span className="flex min-w-0 flex-col gap-0.5">
-              <span className="truncate text-[11px] font-bold text-doom-hi">{current?.label ?? workspace}</span>
-              <span className="truncate text-[9px] font-normal text-doom-faint">{current?.detail}</span>
+              <span className="truncate text-sm font-bold text-doom-hi">{current?.label ?? workspace}</span>
+              <span className="truncate text-2xs font-normal text-doom-faint">{current?.detail}</span>
             </span>
           </span>
           <ChevronUpIcon className="h-3.5 w-3.5 shrink-0 text-doom-faint" />
@@ -77,7 +77,7 @@ export function SettingsMenu({ active, workspace }: { active: string | undefined
         data-testid="settings-menu"
         className="hidden w-[220px] shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-doom-border px-2.5 py-3 lg:flex"
       >
-        <span className="px-[11px] pb-1 pt-0.5 text-[9px] font-bold uppercase tracking-wide text-doom-faint">
+        <span className="px-[11px] pb-1 pt-0.5 text-2xs font-bold uppercase tracking-wide text-doom-faint">
           {workspace}
         </span>
         <SectionLinks active={active} sections={sections} />

--- a/packages/clients/doompi-web/src/web/features/settings/SettingsSectionHeader.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/SettingsSectionHeader.tsx
@@ -23,12 +23,10 @@ export function SettingsSectionHeader({
   return (
     <header className="flex min-w-0 flex-col gap-1">
       <div className="flex min-w-0 flex-wrap items-center gap-2">
-        <h2 className="text-[13px] font-bold text-doom-hi">{title}</h2>
+        <h2 className="text-base font-bold text-doom-hi">{title}</h2>
         {children}
       </div>
-      {detail === undefined || detail === '' ? null : (
-        <p className="text-[11px] leading-relaxed text-doom-dim">{detail}</p>
-      )}
+      {detail === undefined || detail === '' ? null : <p className="text-sm leading-relaxed text-doom-dim">{detail}</p>}
     </header>
   );
 }

--- a/packages/clients/doompi-web/src/web/features/settings/TunnelSettings.tsx
+++ b/packages/clients/doompi-web/src/web/features/settings/TunnelSettings.tsx
@@ -57,8 +57,8 @@ export function TunnelSettings({ tunnel }: { tunnel: TunnelConfig }) {
   return (
     <section className="flex flex-col gap-3" data-testid="remote-tunnel-settings">
       <div className="flex flex-col gap-0.5">
-        <span className="text-xs text-doom-hi">cloudflare tunnel</span>
-        <span className="text-[11px] text-doom-faint">use a named tunnel for a stable custom domain and passkeys.</span>
+        <span className="text-sm text-doom-hi">cloudflare tunnel</span>
+        <span className="text-sm text-doom-faint">use a named tunnel for a stable custom domain and passkeys.</span>
       </div>
 
       <RadioGroup
@@ -68,18 +68,18 @@ export function TunnelSettings({ tunnel }: { tunnel: TunnelConfig }) {
         aria-label="cloudflare tunnel type"
       >
         <RadioGroupCard value="quick" data-testid="remote-tunnel-quick">
-          <span className="block text-xs text-doom-hi">quick tunnel</span>
-          <span className="block text-[10px] text-doom-faint">no account, rotating address</span>
+          <span className="block text-sm text-doom-hi">quick tunnel</span>
+          <span className="block text-xs text-doom-faint">no account, rotating address</span>
         </RadioGroupCard>
         <RadioGroupCard value="named" data-testid="remote-tunnel-named">
-          <span className="block text-xs text-doom-hi">named tunnel</span>
-          <span className="block text-[10px] text-doom-faint">your domain, durable access</span>
+          <span className="block text-sm text-doom-hi">named tunnel</span>
+          <span className="block text-xs text-doom-faint">your domain, durable access</span>
         </RadioGroupCard>
       </RadioGroup>
 
       {draft.kind === 'named' ? (
         <div className="flex flex-col gap-2 rounded-md border border-doom-border bg-doom-deep p-3">
-          <label htmlFor="remote-tunnel-hostname" className="flex flex-col gap-1 text-[11px] text-doom-faint">
+          <label htmlFor="remote-tunnel-hostname" className="flex flex-col gap-1 text-sm text-doom-faint">
             hostname
             <Input
               id="remote-tunnel-hostname"
@@ -91,9 +91,9 @@ export function TunnelSettings({ tunnel }: { tunnel: TunnelConfig }) {
             />
           </label>
           {invalidHostname ? (
-            <p className="text-[10px] text-doom-red">enter a hostname only, without https://, a port, or a path.</p>
+            <p className="text-xs text-doom-red">enter a hostname only, without https://, a port, or a path.</p>
           ) : null}
-          <label htmlFor="remote-tunnel-token-file" className="flex flex-col gap-1 text-[11px] text-doom-faint">
+          <label htmlFor="remote-tunnel-token-file" className="flex flex-col gap-1 text-sm text-doom-faint">
             token file
             <Input
               id="remote-tunnel-token-file"
@@ -103,11 +103,11 @@ export function TunnelSettings({ tunnel }: { tunnel: TunnelConfig }) {
               onChange={(event) => updateNamed({ tokenFile: event.target.value })}
             />
           </label>
-          <p className="text-[10px] text-doom-faint">
+          <p className="text-xs text-doom-faint">
             store the cloudflare connector token in this local file. the token itself is never saved in browser
             settings.
           </p>
-          <details className="text-[11px] text-doom-faint">
+          <details className="text-sm text-doom-faint">
             <summary className="cursor-pointer text-doom-text">locally managed tunnel options</summary>
             <div className="mt-2 flex flex-col gap-2">
               <label htmlFor="remote-tunnel-name" className="flex flex-col gap-1">
@@ -136,7 +136,7 @@ export function TunnelSettings({ tunnel }: { tunnel: TunnelConfig }) {
       ) : null}
 
       <div className="flex flex-col items-stretch gap-2 min-[480px]:flex-row min-[480px]:items-center min-[480px]:justify-between min-[480px]:gap-3">
-        <span className="text-[10px] leading-relaxed text-doom-faint">
+        <span className="text-xs leading-relaxed text-doom-faint">
           changes apply the next time remote access starts.
         </span>
         <Button

--- a/packages/clients/doompi-web/src/web/features/status/TopBar.tsx
+++ b/packages/clients/doompi-web/src/web/features/status/TopBar.tsx
@@ -111,7 +111,7 @@ export function TopBar({
             title="show sessions"
             aria-label="show sessions"
             onClick={onShowSessions}
-            className="shrink-0 text-[16px] text-doom-dim md:hidden"
+            className="shrink-0 text-lg text-doom-dim md:hidden"
           >
             <span aria-hidden>☰</span>
           </Button>
@@ -130,7 +130,7 @@ export function TopBar({
               if (event.key === 'Escape') setRenaming(false);
             }}
             onBlur={commitRename}
-            className="h-6 w-44 shrink-0 border-doom-blue/60 px-1.5 text-[13px] font-bold"
+            className="h-6 w-44 shrink-0 border-doom-blue/60 px-1.5 text-base font-bold"
           />
         ) : (
           <Button
@@ -142,7 +142,7 @@ export function TopBar({
               setDraft(title);
               setRenaming(true);
             }}
-            className="h-6 max-w-24 shrink-0 truncate px-1 text-[13px] font-bold text-doom-hi max-sm:hidden sm:max-w-44"
+            className="h-6 max-w-24 shrink-0 truncate px-1 text-base font-bold text-doom-hi max-sm:hidden sm:max-w-44"
           >
             {title}
           </Button>

--- a/packages/clients/doompi-web/src/web/lib/sessionModel.ts
+++ b/packages/clients/doompi-web/src/web/lib/sessionModel.ts
@@ -151,6 +151,14 @@ export interface SessionState {
   streaming: boolean;
   settled: boolean;
   stats: SessionStats | null;
+  /**
+   * Cost the assistant message now streaming has run up, on top of `stats`.
+   *
+   * Pi answers `get_session_stats` once per message at best, so without this
+   * the cost chip sits still for the length of a turn. Zero whenever no
+   * message is streaming or the provider has not reported yet.
+   */
+  liveCost: number;
   agent: AgentInfo | null;
   commands: CommandInfo[];
   /** Models the session offered, empty until the picker asks. */
@@ -210,6 +218,7 @@ export const initialSessionState: SessionState = {
   streaming: false,
   settled: false,
   stats: null,
+  liveCost: 0,
   agent: null,
   commands: [],
   models: [],
@@ -451,6 +460,11 @@ function applyResponse(state: SessionState, frame: Frame): SessionState {
         contextTokens: usage ? asNumber(usage.tokens) : null,
         contextWindow: usage ? asNumber(usage.contextWindow) : null,
       },
+      // This answer already counts the message the delta was tracking, so
+      // keeping the delta would bill it twice. Clearing it here rather than at
+      // `message_end` is what stops the chip dipping while the answer is in
+      // flight.
+      liveCost: 0,
     };
   }
 
@@ -469,6 +483,24 @@ function applyResponse(state: SessionState, frame: Frame): SessionState {
   }
 
   return state;
+}
+
+/**
+ * Folds the streaming message's own cost into the view model.
+ *
+ * Pi builds `message_update.usage` from the in-progress message's usage, not
+ * from a session running total, so this is added to the last figure Pi
+ * reported rather than replacing it. Providers that only price a message once
+ * it completes report zero here, and the chip then steps at each message
+ * instead of streaming, which is the provider's granularity showing through
+ * rather than a fault.
+ */
+function applyLiveUsage(state: SessionState, frame: Frame): SessionState {
+  if (asString(frame.type) !== 'message_update') return state;
+  const usage = isRecord(frame.usage) ? frame.usage : undefined;
+  const cost = usage && isRecord(usage.cost) ? (asNumber(usage.cost.total) ?? 0) : 0;
+  if (state.liveCost === cost) return state;
+  return { ...state, liveCost: cost };
 }
 
 function applyStatus(state: SessionState, frame: Frame): SessionState {
@@ -731,6 +763,12 @@ export interface ReduceSessionOptions {
 }
 
 export function reduceSession(state: SessionState, frame: Frame, options: ReduceSessionOptions = {}): SessionState {
+  // Usage is read before the transcript filter below because a session whose
+  // transcript the protocol owns still bills for its messages.
+  return reduceFrame(applyLiveUsage(state, frame), frame, options);
+}
+
+function reduceFrame(state: SessionState, frame: Frame, options: ReduceSessionOptions): SessionState {
   const type = asString(frame.type);
   if (options.transcriptFromProtocol && TRANSCRIPT_FRAMES.has(type)) {
     if (type === 'tool_execution_start') {

--- a/packages/clients/doompi-web/src/web/routes/CockpitPage.tsx
+++ b/packages/clients/doompi-web/src/web/routes/CockpitPage.tsx
@@ -127,7 +127,7 @@ export function CockpitPage() {
         {transferLabel !== null ? (
           <output
             data-testid="voice-transfer-transition"
-            className="border-b border-doom-cyan/30 bg-doom-cyan/10 px-4 py-2 text-center text-[11px] font-bold tracking-wide text-doom-cyan"
+            className="border-b border-doom-cyan/30 bg-doom-cyan/10 px-4 py-2 text-center text-sm font-bold tracking-wide text-doom-cyan"
           >
             Transferring voice to {transferLabel}...
           </output>
@@ -175,7 +175,7 @@ export function CockpitPage() {
           data-testid="activity-show"
           title="show the activity dock"
           onClick={() => setDockOpen(true)}
-          className="hidden h-auto shrink-0 rounded-none border-l border-doom-border bg-doom-rail px-2 py-3 text-[9px] tracking-widest text-doom-dim hover:bg-doom-rail lg:flex"
+          className="hidden h-auto shrink-0 rounded-none border-l border-doom-border bg-doom-rail px-2 py-3 text-2xs tracking-widest text-doom-dim hover:bg-doom-rail lg:flex"
           style={{ writingMode: 'vertical-rl' }}
         >
           ACTIVITY

--- a/packages/clients/doompi-web/src/web/routes/SettingsPage.tsx
+++ b/packages/clients/doompi-web/src/web/routes/SettingsPage.tsx
@@ -71,11 +71,11 @@ export function SettingsPage() {
               title="show sessions"
               aria-label="show sessions"
               onClick={() => setRailOpen(true)}
-              className="shrink-0 text-[16px] text-doom-dim md:hidden"
+              className="shrink-0 text-lg text-doom-dim md:hidden"
             >
               <span aria-hidden>☰</span>
             </Button>
-            <span className="truncate text-[13px] font-bold text-doom-hi">settings</span>
+            <span className="truncate text-base font-bold text-doom-hi">settings</span>
           </span>
           <nav
             className="order-3 col-span-2 flex w-full items-center gap-0.5 rounded-md border border-doom-border bg-doom-panel p-0.5 sm:order-none sm:w-auto"

--- a/packages/clients/doompi-web/src/web/stores/sessionStore.ts
+++ b/packages/clients/doompi-web/src/web/stores/sessionStore.ts
@@ -313,6 +313,16 @@ export function refreshSessionFacts(sessionId: string): void {
   sendFrame(sessionId, getCommandsCommand());
 }
 
+/**
+ * Asks only for the usage figures, cheap enough to run once per message.
+ *
+ * `refreshSessionFacts` costs three round trips because it also re-reads the
+ * state and the command list, and neither of those changes mid-turn.
+ */
+export function refreshSessionStats(sessionId: string): void {
+  sendFrame(sessionId, getSessionStatsCommand());
+}
+
 /** Asks what the model picker lists; Pi's answer depends on the current model. */
 export function loadModelChoices(sessionId: string | null = activeSessionId()): void {
   if (sessionId === null) return;

--- a/packages/clients/doompi-web/style-system.config.yaml
+++ b/packages/clients/doompi-web/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-web-app

--- a/packages/clients/doompi-web/tests/e2e/status.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/status.spec.ts
@@ -43,6 +43,62 @@ test('shows context usage and cost the session reports', async ({ page, cockpit 
   await expect(page.getByTestId('top-context')).toHaveText('ctx 41%');
   await expect(page.getByTestId('top-cost')).toHaveText('$0.84');
 });
+
+test('raises the cost while a message is still streaming', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForCommand('get_session_stats');
+
+  cockpit.session.emit({
+    type: 'response',
+    command: 'get_session_stats',
+    success: true,
+    data: { tokens: { total: 105_000 }, cost: 0.84 },
+  });
+  await expect(page.getByTestId('top-cost')).toHaveText('$0.84');
+
+  // Pi reports the in-progress message's own usage, so the chip has to add it
+  // to the last figure rather than wait for the turn to settle.
+  cockpit.session.emit({ type: 'message_update', usage: { cost: { total: 0.07 } } });
+  await expect(page.getByTestId('top-cost')).toHaveText('$0.91');
+});
+
+test('asks for the usage figures once a message lands', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForCommand('get_session_stats');
+  const before = cockpit.session.received.filter((frame) => frame.type === 'get_session_stats').length;
+
+  cockpit.session.emit({ type: 'message_end' });
+
+  await expect
+    .poll(() => cockpit.session.received.filter((frame) => frame.type === 'get_session_stats').length)
+    .toBeGreaterThan(before);
+});
+
+test('folds subagent spend into one cost figure', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForCommand('get_session_stats');
+
+  cockpit.session.emit({
+    type: 'response',
+    command: 'get_session_stats',
+    success: true,
+    data: { tokens: { total: 105_000 }, cost: 1.84 },
+  });
+  await expect(page.getByTestId('top-cost')).toHaveText('$1.84');
+
+  // Subagents bill to sessions of their own; the team package reports their
+  // total the same way any package reports a footer status.
+  cockpit.session.emit({
+    type: 'extension_ui_request',
+    id: 'st-doom-team-cost',
+    method: 'setStatus',
+    statusKey: 'doom-team-cost',
+    statusText: '0.57',
+  });
+
+  await expect(page.getByTestId('top-cost')).toHaveText('$2.41');
+  await expect(page.getByTestId('top-cost')).toHaveAttribute('title', /\$1\.84 session \+ \$0\.57 agents/);
+});
 test('refreshes the facts once a run settles', async ({ page, cockpit }) => {
   await page.goto(cockpit.url);
   await cockpit.session.waitForCommand('get_session_stats');

--- a/packages/clients/doompi-web/tests/integration/bridge.test.ts
+++ b/packages/clients/doompi-web/tests/integration/bridge.test.ts
@@ -220,6 +220,20 @@ describe('the hub bridge', () => {
     expect(JSON.stringify(frames)).not.toContain(session.token);
   });
 
+  it('answers a thread subscription for a session it does not know yet instead of dropping it', async () => {
+    const { server } = await bridge();
+    const { socket, frames } = await openSocket(server.url);
+
+    // A page that reconnects after the hub restarts can ask for a thread before
+    // the session is registered again. Refusing in silence left that thread
+    // frozen for the life of the tab, because the page only asks once per socket.
+    socket.send(JSON.stringify({ type: 'subscribe_thread', sessionId: 'not-registered-yet', threadId: 'run-1' }));
+    await waitFor(() => frames.some((frame) => frame.type === 'thread_backlog'), 'the thread backlog');
+
+    const backlog = frames.find((frame) => frame.type === 'thread_backlog');
+    expect(backlog).toMatchObject({ sessionId: 'not-registered-yet', threadId: 'run-1', frames: [] });
+  });
+
   it('routes commands to the session and its events back to subscribers', async () => {
     const { server, session } = await bridge();
     const { socket, frames } = await openSocket(server.url);

--- a/packages/clients/doompi-web/tests/unit/Timeline.test.ts
+++ b/packages/clients/doompi-web/tests/unit/Timeline.test.ts
@@ -59,3 +59,43 @@ describe('Timeline user-message actions', () => {
     expect(markup.match(/data-testid="entry-quote"/g)).toHaveLength(4);
   });
 });
+
+describe('Timeline persona avatar', () => {
+  it('falls back to the fold persona for an assistant entry rebuilt without one', () => {
+    const store = new Store({
+      ...initialSessionState,
+      profileIdentity: { profile: 'ponytail', name: 'Ponytail' },
+      entries: [{ kind: 'assistant' as const, id: 'a1', text: 'hi', thinking: '', streaming: false }],
+    });
+
+    const markup = renderToStaticMarkup(
+      createElement(Transcript, { store, sessionId: 'session-1', empty: createElement('div') }),
+    );
+
+    expect(markup).toContain('aria-label="Ponytail"');
+  });
+
+  it('keeps the persona a message was written under over the fold persona', () => {
+    const store = new Store({
+      ...initialSessionState,
+      profileIdentity: { profile: 'ponytail', name: 'Ponytail' },
+      entries: [
+        {
+          kind: 'assistant' as const,
+          id: 'a1',
+          text: 'hi',
+          thinking: '',
+          streaming: false,
+          identity: { profile: 'rhea', name: 'Rhea' },
+        },
+      ],
+    });
+
+    const markup = renderToStaticMarkup(
+      createElement(Transcript, { store, sessionId: 'session-1', empty: createElement('div') }),
+    );
+
+    expect(markup).toContain('aria-label="Rhea"');
+    expect(markup).not.toContain('aria-label="Ponytail"');
+  });
+});

--- a/packages/clients/doompi-web/tests/unit/sessionModel.test.ts
+++ b/packages/clients/doompi-web/tests/unit/sessionModel.test.ts
@@ -533,6 +533,58 @@ describe('reduceSession', () => {
     expect(state.stats?.contextPercent).toBeNull();
   });
 
+  it('bills the streaming message on top of the last figure Pi reported', () => {
+    const reported = reduceSession(initialSessionState, {
+      type: 'response',
+      command: 'get_session_stats',
+      data: { tokens: { total: 105_000 }, cost: 0.84 },
+    });
+
+    const streaming = reduceSession(reported, {
+      type: 'message_update',
+      usage: { cost: { total: 0.07 } },
+    });
+
+    expect(streaming.stats?.cost).toBe(0.84);
+    expect(streaming.liveCost).toBe(0.07);
+  });
+
+  it('drops the streaming delta once Pi counts the message', () => {
+    const streaming = reduceSession(initialSessionState, {
+      type: 'message_update',
+      usage: { cost: { total: 0.07 } },
+    });
+    expect(streaming.liveCost).toBe(0.07);
+
+    const counted = reduceSession(streaming, {
+      type: 'response',
+      command: 'get_session_stats',
+      data: { tokens: { total: 105_000 }, cost: 0.91 },
+    });
+
+    // 0.91 already includes the 0.07; keeping the delta would bill it twice.
+    expect(counted.stats?.cost).toBe(0.91);
+    expect(counted.liveCost).toBe(0);
+  });
+
+  it('reads streaming usage even when the protocol owns the transcript', () => {
+    const state = reduceSession(
+      initialSessionState,
+      { type: 'message_update', usage: { cost: { total: 0.05 } } },
+      { transcriptFromProtocol: true },
+    );
+
+    expect(state.liveCost).toBe(0.05);
+  });
+
+  it('reports no live cost for a provider that prices only on completion', () => {
+    const state = reduceSession(initialSessionState, {
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_delta', delta: 'hi' },
+    });
+
+    expect(state.liveCost).toBe(0);
+  });
   it('keeps only well-formed commands', () => {
     const state = reduceSession(initialSessionState, {
       type: 'response',

--- a/packages/clients/doompi-web/vibe-lint.config.yaml
+++ b/packages/clients/doompi-web/vibe-lint.config.yaml
@@ -30,3 +30,14 @@ boundaries:
       - src/pwa/**
       - src/types
       - src/types/**
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/packages/core/doompi-ui/package.json
+++ b/packages/core/doompi-ui/package.json
@@ -29,7 +29,8 @@
     "dist",
     "src/web",
     "src/exports/webClient.ts",
-    "themes"
+    "themes",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -192,6 +193,7 @@
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "5.0.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsdown": "0.23.0",
     "typescript": "7.0.2",
     "vitest": "5.0.0"

--- a/packages/core/doompi-ui/src/web/components/FindToolMessage.stories.tsx
+++ b/packages/core/doompi-ui/src/web/components/FindToolMessage.stories.tsx
@@ -1,0 +1,72 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the tool contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { FindToolMessage } from './FindToolMessage.tsx';
+
+const MATCHES = [
+  'src/web/components/FindToolMessage.tsx:10:export function FindToolMessage(props',
+  'src/web/components/LsToolMessage.tsx:10:export function LsToolMessage(props',
+  'src/web/components/ListingBody.tsx:9:export function ListingBody({',
+  'src/web/components/WriteToolMessage.tsx:47:export function WriteToolMessage({',
+  'src/web/lib/builtinToolView.ts:57:export function writeCallView(args',
+  'src/web/lib/builtinToolView.ts:70:export function findCallView(args',
+].join('\n');
+
+const result = (details: unknown = null) => ({ content: [{ type: 'text', text: MATCHES }], details });
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'find', ...overrides }).props;
+
+const args = { pattern: 'export function', path: 'src/web' };
+
+const meta = {
+  title: 'Ui/FindToolMessage',
+  component: FindToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <FindToolMessage {...props({ args, running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete</span>
+        <FindToolMessage {...props({ args, result: result(), output: MATCHES })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · result limit reached</span>
+        <FindToolMessage
+          {...props({
+            args: { ...args, limit: 6 },
+            result: result({ resultLimitReached: 6 }),
+            output: MATCHES,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <FindToolMessage
+          {...props({
+            args: { pattern: '[unclosed', path: 'src/web' },
+            result: { content: [{ type: 'text', text: 'invalid regex: missing ]' }], details: null },
+            output: 'invalid regex: missing ]',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-ui/src/web/components/ListingBody.stories.tsx
+++ b/packages/core/doompi-ui/src/web/components/ListingBody.stories.tsx
@@ -1,0 +1,65 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the tool contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { ListingBody } from './ListingBody.tsx';
+
+/** Past the twenty-line collapsed budget, so the collapsed body reports what it hid. */
+const ENTRIES = Array.from({ length: 26 }, (_, index) => `src/web/components/Panel${String(index + 1)}.tsx`).join('\n');
+
+const result = (details: unknown = null) => ({ content: [{ type: 'text', text: ENTRIES }], details });
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'ls', args: { path: 'src/web' }, ...overrides }).props;
+
+const body = { tool: 'ls', limitKey: 'entryLimitReached', limitUnit: 'entries' };
+
+const meta = {
+  title: 'Ui/ListingBody',
+  component: ListingBody,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <ListingBody {...body} expanded={false} props={props({ running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">collapsed · twenty of twenty-six</span>
+        <ListingBody {...body} expanded={false} props={props({ result: result(), output: ENTRIES })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">collapsed · entry limit reached</span>
+        <ListingBody
+          {...body}
+          expanded={false}
+          props={props({ result: result({ entryLimitReached: 26 }), output: ENTRIES })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <ListingBody
+          {...body}
+          expanded={false}
+          props={props({
+            result: { content: [{ type: 'text', text: 'ENOENT: no such directory' }], details: null },
+            output: 'ENOENT: no such directory',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-ui/src/web/components/LsToolMessage.stories.tsx
+++ b/packages/core/doompi-ui/src/web/components/LsToolMessage.stories.tsx
@@ -1,0 +1,65 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the tool contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { LsToolMessage } from './LsToolMessage.tsx';
+
+const ENTRIES = ['components/', 'lib/', 'stores/', 'index.ts', 'plugin.ts', 'toolRenderers.ts'].join('\n');
+
+const result = (details: unknown = null) => ({ content: [{ type: 'text', text: ENTRIES }], details });
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'ls', ...overrides }).props;
+
+const args = { path: 'src/web' };
+
+const meta = {
+  title: 'Ui/LsToolMessage',
+  component: LsToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <LsToolMessage {...props({ args, running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete</span>
+        <LsToolMessage {...props({ args, result: result(), output: ENTRIES })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · entry limit reached</span>
+        <LsToolMessage
+          {...props({
+            args: { ...args, limit: 6 },
+            result: result({ entryLimitReached: 6 }),
+            output: ENTRIES,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <LsToolMessage
+          {...props({
+            args: { path: 'src/nowhere' },
+            result: { content: [{ type: 'text', text: 'ENOENT: no such directory' }], details: null },
+            output: 'ENOENT: no such directory',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-ui/src/web/components/WriteToolMessage.stories.tsx
+++ b/packages/core/doompi-ui/src/web/components/WriteToolMessage.stories.tsx
@@ -1,0 +1,78 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the tool contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { WriteToolMessage } from './WriteToolMessage.tsx';
+
+/** Past the ten-line collapsed budget, so the preview reports what it hid. */
+const CONTENT = [
+  "import { clsx, type ClassValue } from 'clsx';",
+  "import { twMerge } from 'tailwind-merge';",
+  '',
+  '/** The one class merger every component uses. */',
+  'export function cn(...inputs: ClassValue[]) {',
+  '  return twMerge(clsx(inputs));',
+  '}',
+  '',
+  'export function cx(...inputs: ClassValue[]) {',
+  '  return clsx(inputs);',
+  '}',
+  '',
+  'export const noop = () => undefined;',
+].join('\n');
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'write', ...overrides }).props;
+
+const args = { path: 'src/lib/cn.ts', content: CONTENT };
+
+const meta = {
+  title: 'Ui/WriteToolMessage',
+  component: WriteToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running · preview so far</span>
+        <WriteToolMessage {...props({ args, running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · ten of thirteen lines</span>
+        <WriteToolMessage {...props({ args, result: { content: [], details: null } })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · path opens a tab</span>
+        <WriteToolMessage
+          {...props({
+            args,
+            result: { content: [], details: null },
+            fileTab: (path) => ({ id: `file-${path}`, label: path, panel: () => null }),
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <WriteToolMessage
+          {...props({
+            args,
+            result: { content: [{ type: 'text', text: 'EACCES: permission denied' }], details: null },
+            output: 'EACCES: permission denied',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-ui/style-system.config.yaml
+++ b/packages/core/doompi-ui/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/core/doompi-ui/styles/preview.css
+++ b/packages/core/doompi-ui/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/core/doompi-ui/vibe-lint.config.yaml
+++ b/packages/core/doompi-ui/vibe-lint.config.yaml
@@ -29,3 +29,14 @@ rules:
         "@agimon-ai/doompi-ui": platform
         "@agimon-ai/doompi-mcp": integration
         "@agimon-ai/doompi": host
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/packages/core/doompi-web-components/src/components/Accordion.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Accordion.stories.tsx
@@ -1,0 +1,62 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ *
+ * Both accordions carry a default value so the open panel paints without a
+ * click: the renderer screenshots the first frame.
+ */
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from './Accordion.tsx';
+
+const meta = {
+  title: 'Components/Accordion',
+  component: Accordion,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+const SHELL = 'w-96 rounded-md border border-doom-border bg-doom-panel px-3';
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">type single</span>
+        <Accordion type="single" defaultValue="a" collapsible className={SHELL}>
+          <AccordionItem value="a">
+            <AccordionTrigger>request headers</AccordionTrigger>
+            <AccordionContent>
+              Only one item stays open. The chevron rotates from the trigger&apos;s open state.
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="b">
+            <AccordionTrigger>response body</AccordionTrigger>
+            <AccordionContent>Collapsed until its trigger is pressed.</AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="c">
+            <AccordionTrigger>timing</AccordionTrigger>
+            <AccordionContent>The last item drops its bottom rule.</AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">type multiple</span>
+        <Accordion type="multiple" defaultValue={['a', 'c']} className={SHELL}>
+          <AccordionItem value="a">
+            <AccordionTrigger>tool calls</AccordionTrigger>
+            <AccordionContent>Any number of items may be open at once.</AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="b">
+            <AccordionTrigger>diagnostics</AccordionTrigger>
+            <AccordionContent>Closed.</AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="c">
+            <AccordionTrigger>usage</AccordionTrigger>
+            <AccordionContent>Open alongside the first item.</AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Accordion.tsx
+++ b/packages/core/doompi-web-components/src/components/Accordion.tsx
@@ -24,7 +24,7 @@ export function AccordionTrigger({ className, children, ...props }: ComponentPro
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          'flex flex-1 cursor-pointer items-center justify-between gap-2 py-2 text-left text-[11px] text-doom-hi outline-none transition-colors hover:text-doom-blue focus-visible:text-doom-blue [&[data-state=open]>svg]:rotate-180',
+          'flex flex-1 cursor-pointer items-center justify-between gap-2 py-2 text-left text-sm text-doom-hi outline-none transition-colors hover:text-doom-blue focus-visible:text-doom-blue [&[data-state=open]>svg]:rotate-180',
           className,
         )}
         {...props}
@@ -40,7 +40,7 @@ export function AccordionContent({ className, ...props }: ComponentProps<typeof 
   return (
     <AccordionPrimitive.Content
       data-slot="accordion-content"
-      className={cn('overflow-hidden pb-2 text-[11px] text-doom-dim', className)}
+      className={cn('overflow-hidden pb-2 text-sm text-doom-dim', className)}
       {...props}
     />
   );

--- a/packages/core/doompi-web-components/src/components/AnsiText.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/AnsiText.stories.tsx
@@ -1,0 +1,41 @@
+import { AnsiLine, AnsiText } from './AnsiText.tsx';
+
+const LOG = [
+  '\u001B[32mPASS\u001B[0m src/app.test.ts \u001B[2m12 tests\u001B[0m',
+  '\u001B[33mWARN\u001B[0m unused import in \u001B[36msrc/lib/cn.ts\u001B[0m',
+  '\u001B[31mFAIL\u001B[0m \u001B[1;35mtimeout\u001B[0m after 30s',
+].join('\n');
+
+const ATTRIBUTES =
+  '\u001B[1mbold\u001B[0m \u001B[2mfaint\u001B[0m \u001B[3mitalic\u001B[0m \u001B[4munderline\u001B[0m \u001B[7minverse\u001B[0m \u001B[38;5;208m256 colour\u001B[0m';
+
+const meta = {
+  title: 'Components/AnsiText',
+  component: AnsiText,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">block</span>
+        <AnsiText text={LOG} className="font-mono text-sm text-doom-text" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">attributes</span>
+        <AnsiText text={ATTRIBUTES} className="font-mono text-sm text-doom-text" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">line by line</span>
+        <div className="flex flex-col font-mono text-sm text-doom-text">
+          {LOG.split('\n').map((line, index) => (
+            <AnsiLine key={index} line={line} />
+          ))}
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Avatar.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Avatar.stories.tsx
@@ -1,0 +1,44 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Avatar, AvatarFallback } from './Avatar.tsx';
+import { UserIcon } from '../icons/icons.ts';
+
+/** Avatar declares no variants; the size is whatever the caller hands it. */
+const SIZES = [
+  ['sm', 'h-5 w-5'],
+  ['md', 'h-6 w-6'],
+  ['lg', 'h-8 w-8'],
+] as const;
+
+const meta = {
+  title: 'Components/Avatar',
+  component: Avatar,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      {SIZES.map(([name, size]) => (
+        <div key={name} className="flex flex-col gap-2">
+          <span className="text-2xs text-doom-dim uppercase tracking-widest">size {name}</span>
+          <div className="flex flex-wrap items-center gap-2">
+            <Avatar aria-label="Initials" className={size}>
+              <AvatarFallback>DP</AvatarFallback>
+            </Avatar>
+            <Avatar aria-label="Icon" className={size}>
+              <AvatarFallback>
+                <UserIcon aria-hidden="true" className="h-3 w-3" />
+              </AvatarFallback>
+            </Avatar>
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Avatar.tsx
+++ b/packages/core/doompi-web-components/src/components/Avatar.tsx
@@ -27,7 +27,7 @@ export function AvatarFallback({ className, ...props }: ComponentProps<typeof Av
   return (
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
-      className={cn('flex h-full w-full items-center justify-center text-[10px] font-bold text-doom-dim', className)}
+      className={cn('flex h-full w-full items-center justify-center text-xs font-bold text-doom-dim', className)}
       {...props}
     />
   );

--- a/packages/core/doompi-web-components/src/components/Badge.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Badge.stories.tsx
@@ -1,0 +1,40 @@
+/*
+ * Story fixtures are plain CSF objects rather than `Meta`/`StoryObj` from
+ * Storybook: the renderer parses these files statically and mounts the exported
+ * `render`, so no Storybook runtime is installed and importing its types would
+ * add a dependency nothing here needs.
+ *
+ * `Playground` is the name the DoomPi style-system extension renders by default
+ * when a story file is written or edited.
+ */
+import { Badge } from './Badge.tsx';
+import { CHIP_TONES } from '../types/tone.ts';
+
+const SIZES = ['xs', 'sm', 'md', 'lg'] as const;
+
+const meta = {
+  title: 'Components/Badge',
+  component: Badge,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      {SIZES.map((size) => (
+        <div key={size} className="flex flex-col gap-2">
+          <span className="text-2xs text-doom-dim uppercase tracking-widest">size {size}</span>
+          <div className="flex flex-wrap items-center gap-2">
+            {CHIP_TONES.map((tone) => (
+              <Badge key={tone} tone={tone} size={size}>
+                {tone}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Badge.tsx
+++ b/packages/core/doompi-web-components/src/components/Badge.tsx
@@ -20,10 +20,10 @@ export const badgeVariants = cva('inline-flex items-center gap-1.5 whitespace-no
     } satisfies Record<ChipTone, string>,
     /** The same rungs Button names, so a chip can sit beside a button of any size. */
     size: {
-      xs: 'px-1.5 py-0.5 text-[8px] font-bold',
-      sm: 'px-2 py-0.5 text-[10px]',
-      md: 'px-2.5 py-1 text-[11px]',
-      lg: 'px-3 py-1.5 text-[12px]',
+      xs: 'px-1.5 py-0.5 text-2xs font-bold',
+      sm: 'px-2 py-0.5 text-xs',
+      md: 'px-2.5 py-1 text-sm',
+      lg: 'px-3 py-1.5 text-base',
     },
   },
   defaultVariants: { tone: 'neutral', size: 'sm' },

--- a/packages/core/doompi-web-components/src/components/Breadcrumb.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Breadcrumb.stories.tsx
@@ -1,0 +1,49 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Breadcrumb } from './Breadcrumb.tsx';
+
+const DEEP_PATH = 'packages/core/doompi-web-components/src/components/Breadcrumb.tsx';
+
+const meta = {
+  title: 'Components/Breadcrumb',
+  component: Breadcrumb,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">single segment</span>
+        <Breadcrumb path="README.md" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">short path, nothing collapses</span>
+        <Breadcrumb path="src/components/Badge.tsx" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">deep path, default keep 4</span>
+        <Breadcrumb path={DEEP_PATH} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">keep 2</span>
+        <Breadcrumb path={DEEP_PATH} keep={2} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">keep 6</span>
+        <Breadcrumb path={DEEP_PATH} keep={6} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">truncated by a narrow container</span>
+        <div className="flex w-48 rounded-md border border-doom-border bg-doom-deep px-2 py-1">
+          <Breadcrumb path={DEEP_PATH} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Breadcrumb.tsx
+++ b/packages/core/doompi-web-components/src/components/Breadcrumb.tsx
@@ -54,7 +54,7 @@ export function Breadcrumb({ path, keep, className, 'data-testid': testId }: Bre
             data-slot="breadcrumb"
             data-testid={testId}
             title={undefined}
-            className={cn('flex min-w-0 items-baseline gap-1 truncate font-mono text-[12px]', className)}
+            className={cn('flex min-w-0 items-baseline gap-1 truncate font-mono text-sm', className)}
           >
             {segments.map((segment, index) => (
               // Segments repeat in a path (src/app/src), so the index is what

--- a/packages/core/doompi-web-components/src/components/Button.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Button.stories.tsx
@@ -1,0 +1,48 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Button } from './Button.tsx';
+
+const SIZES = ['xs', 'sm', 'md', 'lg'] as const;
+const VARIANTS = ['outline', 'primary', 'ghost', 'danger', 'danger-outline', 'success', 'link'] as const;
+
+const meta = {
+  title: 'Components/Button',
+  component: Button,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      {SIZES.map((size) => (
+        <div key={size} className="flex flex-col gap-2">
+          <span className="text-2xs text-doom-dim uppercase tracking-widest">size {size}</span>
+          <div className="flex flex-wrap items-center gap-2">
+            {VARIANTS.map((variant) => (
+              <Button key={variant} variant={variant} size={size}>
+                {variant}
+              </Button>
+            ))}
+          </div>
+        </div>
+      ))}
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">states</span>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button loading loadingLabel="Working">
+            loading
+          </Button>
+          <Button disabled>disabled</Button>
+          <Button size="icon" aria-label="icon">
+            +
+          </Button>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Button.tsx
+++ b/packages/core/doompi-web-components/src/components/Button.tsx
@@ -19,10 +19,10 @@ export const buttonVariants = cva(
         link: 'text-doom-blue hover:underline',
       },
       size: {
-        xs: 'h-5 rounded px-1.5 text-[9px]',
-        sm: 'h-6 px-2.5 text-[10px]',
-        md: 'h-7 px-3 text-[11px]',
-        lg: 'h-8 px-3.5 text-[12px]',
+        xs: 'h-5 rounded px-1.5 text-2xs',
+        sm: 'h-6 px-2.5 text-xs',
+        md: 'h-7 px-3 text-sm',
+        lg: 'h-8 px-3.5 text-base',
         icon: 'h-5 w-5 rounded p-0',
         'icon-md': 'h-7 w-7 p-0',
         /**

--- a/packages/core/doompi-web-components/src/components/Checkbox.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Checkbox.stories.tsx
@@ -1,0 +1,50 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Checkbox } from './Checkbox.tsx';
+
+/** Every checked state Radix models; passing `checked` with no handler keeps the story static. */
+const STATES = [
+  ['unchecked', false],
+  ['checked', true],
+  ['indeterminate', 'indeterminate'],
+] as const;
+
+const meta = {
+  title: 'Components/Checkbox',
+  component: Checkbox,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state</span>
+        <div className="flex flex-wrap items-start gap-4">
+          {STATES.map(([name, checked]) => (
+            <div key={name} className="flex flex-col items-center gap-2">
+              <Checkbox checked={checked} aria-label={name} />
+              <span className="text-2xs text-doom-dim uppercase tracking-widest">{name}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">disabled</span>
+        <div className="flex flex-wrap items-start gap-4">
+          {STATES.map(([name, checked]) => (
+            <div key={name} className="flex flex-col items-center gap-2">
+              <Checkbox disabled checked={checked} aria-label={`${name} disabled`} />
+              <span className="text-2xs text-doom-dim uppercase tracking-widest">{name}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Checkbox.tsx
+++ b/packages/core/doompi-web-components/src/components/Checkbox.tsx
@@ -9,7 +9,7 @@ export function Checkbox({ className, ...props }: ComponentProps<typeof Checkbox
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        'flex h-3.5 w-3.5 shrink-0 cursor-pointer items-center justify-center rounded-[3px] border border-doom-border bg-doom-deep outline-none transition-colors focus-visible:ring-2 focus-visible:ring-doom-blue/50 disabled:pointer-events-none disabled:opacity-40 data-[state=checked]:border-doom-blue data-[state=indeterminate]:border-doom-blue',
+        'flex h-3.5 w-3.5 shrink-0 cursor-pointer items-center justify-center rounded-sm border border-doom-border bg-doom-deep outline-none transition-colors focus-visible:ring-2 focus-visible:ring-doom-blue/50 disabled:pointer-events-none disabled:opacity-40 data-[state=checked]:border-doom-blue data-[state=indeterminate]:border-doom-blue',
         className,
       )}
       {...props}

--- a/packages/core/doompi-web-components/src/components/CodeBlock.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/CodeBlock.stories.tsx
@@ -1,0 +1,39 @@
+import { CodeBlock } from './CodeBlock.tsx';
+
+const TYPESCRIPT = [
+  'export function label(session: Session): string {',
+  '  // the id is the fallback name',
+  '  return session.title ?? session.id;',
+  '}',
+].join('\n');
+
+const PLAIN = ['no fence language, so no grammar', 'and the block stays plain text'].join('\n');
+
+const MERMAID = 'graph TD; A-->B;';
+
+const meta = {
+  title: 'Components/CodeBlock',
+  component: CodeBlock,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">language-typescript</span>
+        <CodeBlock text={TYPESCRIPT} className="language-typescript" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">bare fence</span>
+        <CodeBlock text={PLAIN} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">language-mermaid</span>
+        <CodeBlock text={MERMAID} className="language-mermaid" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/CodeBlock.tsx
+++ b/packages/core/doompi-web-components/src/components/CodeBlock.tsx
@@ -33,7 +33,7 @@ export function CodeBlock({ text, className }: CodeBlockProps) {
       <SyntaxText
         text={text}
         grammar={fenceGrammarOf(language)}
-        className="overflow-x-auto text-[12px] leading-relaxed text-doom-text"
+        className="overflow-x-auto text-sm leading-relaxed text-doom-text"
       />
     );
   return (

--- a/packages/core/doompi-web-components/src/components/CodeEditor.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/CodeEditor.stories.tsx
@@ -1,0 +1,38 @@
+import { CodeEditor } from './CodeEditor.tsx';
+
+const CODE = [
+  "import { cn } from './cn.ts';",
+  '',
+  'export function label(name: string): string {',
+  "  return cn('doom', name);",
+  '}',
+].join('\n');
+
+const PATH = 'src/label.ts';
+
+const meta = {
+  title: 'Components/CodeEditor',
+  component: CodeEditor,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">editable</span>
+        <CodeEditor value={CODE} path={PATH} className="h-40" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">read only</span>
+        <CodeEditor value={CODE} path={PATH} readOnly className="h-40" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">no wrapping, plain text</span>
+        <CodeEditor value={CODE} lineWrapping={false} className="h-40" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/CodeEditorView.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/CodeEditorView.stories.tsx
@@ -1,0 +1,38 @@
+import { CodeEditorView } from './CodeEditorView.tsx';
+
+const CODE = [
+  "import { cn } from './cn.ts';",
+  '',
+  'export function label(name: string): string {',
+  "  return cn('doom', name);",
+  '}',
+].join('\n');
+
+const PATH = 'src/label.ts';
+
+const meta = {
+  title: 'Components/CodeEditorView',
+  component: CodeEditorView,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">editable</span>
+        <CodeEditorView value={CODE} path={PATH} className="h-40" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">read only</span>
+        <CodeEditorView value={CODE} path={PATH} readOnly className="h-40" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">no wrapping, plain text</span>
+        <CodeEditorView value={CODE} lineWrapping={false} className="h-40" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Collapsible.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Collapsible.stories.tsx
@@ -1,0 +1,56 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ *
+ * `open` is passed rather than `defaultOpen` so both states paint side by side
+ * without a click.
+ */
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './Collapsible.tsx';
+
+const meta = {
+  title: 'Components/Collapsible',
+  component: Collapsible,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+const SHELL = 'w-80 overflow-hidden rounded-md border border-doom-border bg-doom-panel';
+const TRIGGER = 'flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-sm text-doom-hi';
+const CONTENT = 'border-t border-doom-border-soft bg-doom-deep px-3 py-2 text-sm text-doom-dim';
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state open</span>
+        <Collapsible open className={SHELL}>
+          <CollapsibleTrigger className={TRIGGER}>
+            environment
+            <span className="text-2xs text-doom-faint uppercase tracking-wider">hide</span>
+          </CollapsibleTrigger>
+          <CollapsibleContent className={CONTENT}>
+            NODE_ENV=production
+            <br />
+            DOOM_LOG_LEVEL=info
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state closed</span>
+        <Collapsible open={false} className={SHELL}>
+          <CollapsibleTrigger className={TRIGGER}>
+            environment
+            <span className="text-2xs text-doom-faint uppercase tracking-wider">show</span>
+          </CollapsibleTrigger>
+          <CollapsibleContent className={CONTENT}>
+            NODE_ENV=production
+            <br />
+            DOOM_LOG_LEVEL=info
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Command.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Command.stories.tsx
@@ -1,0 +1,79 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. The palette parts are rendered inline rather than through
+ * CommandDialog, so the surface paints without opening a dialog.
+ */
+import {
+  CommandEmpty,
+  CommandFooter,
+  CommandGroup,
+  CommandGroupLabel,
+  CommandHeader,
+  CommandInput,
+  CommandItem,
+  CommandItemLabel,
+  CommandList,
+} from './Command.tsx';
+
+const meta = {
+  title: 'Components/Command',
+  component: CommandList,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">palette · grouped rows</span>
+        <div className="flex w-full max-w-md flex-col overflow-hidden rounded-md border border-doom-border bg-doom-panel">
+          <CommandHeader>
+            <CommandInput defaultValue="rev" placeholder="type a command" />
+          </CommandHeader>
+          <CommandList className="max-h-64">
+            <CommandGroup>
+              <CommandGroupLabel>session</CommandGroupLabel>
+              <CommandItem active marker="1">
+                <CommandItemLabel>review the working diff</CommandItemLabel>
+              </CommandItem>
+              <CommandItem marker="2">
+                <CommandItemLabel>revert the last edit</CommandItemLabel>
+              </CommandItem>
+            </CommandGroup>
+            <CommandGroup>
+              <CommandGroupLabel>tools</CommandGroupLabel>
+              <CommandItem marker="3">
+                <CommandItemLabel>run the affected tests</CommandItemLabel>
+              </CommandItem>
+              <CommandItem marker="·" disabled>
+                <CommandItemLabel>restart the runtime (disabled)</CommandItemLabel>
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+          <CommandFooter>
+            <span>enter run</span>
+            <span>esc close</span>
+          </CommandFooter>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">palette · nothing matched</span>
+        <div className="flex w-full max-w-md flex-col overflow-hidden rounded-md border border-doom-border bg-doom-panel">
+          <CommandHeader>
+            <CommandInput defaultValue="zzz" placeholder="type a command" />
+          </CommandHeader>
+          <CommandList>
+            <CommandEmpty>no command matches “zzz”</CommandEmpty>
+          </CommandList>
+          <CommandFooter>
+            <span>enter run</span>
+            <span>esc close</span>
+          </CommandFooter>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Command.tsx
+++ b/packages/core/doompi-web-components/src/components/Command.tsx
@@ -88,7 +88,7 @@ export function CommandGroupLabel({ className, ...props }: ComponentProps<'div'>
   return (
     <div
       data-slot="command-group-label"
-      className={cn('px-2 pt-2 pb-1 text-[8px] font-bold tracking-[0.14em] text-doom-faint uppercase', className)}
+      className={cn('px-2 pt-2 pb-1 text-2xs font-bold tracking-wider text-doom-faint uppercase', className)}
       {...props}
     />
   );
@@ -109,7 +109,7 @@ export function CommandEmpty({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       data-slot="command-empty"
-      className={cn('px-2 py-6 text-center text-[11px] text-doom-faint', className)}
+      className={cn('px-2 py-6 text-center text-sm text-doom-faint', className)}
       {...props}
     />
   );
@@ -121,7 +121,7 @@ export function CommandFooter({ className, ...props }: ComponentProps<'div'>) {
     <div
       data-slot="command-footer"
       className={cn(
-        'flex min-h-[30px] shrink-0 items-center justify-between gap-3 border-t border-doom-border-soft bg-doom-deep px-3 text-[9px] text-doom-faint',
+        'flex min-h-[30px] shrink-0 items-center justify-between gap-3 border-t border-doom-border-soft bg-doom-deep px-3 text-2xs text-doom-faint',
         className,
       )}
       {...props}

--- a/packages/core/doompi-web-components/src/components/CopyButton.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/CopyButton.stories.tsx
@@ -1,0 +1,39 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ *
+ * The control owns its own clipboard call, so it takes no callback: rendered
+ * and never clicked, nothing reaches `navigator.clipboard`.
+ */
+import { CopyButton } from './CopyButton.tsx';
+
+const meta = {
+  title: 'Components/CopyButton',
+  component: CopyButton,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">default</span>
+        <CopyButton text="packages/core/doompi-web-components/src/components/CopyButton.tsx" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">beside the text it copies</span>
+        <div className="flex items-center gap-2 rounded-md border border-doom-border bg-doom-deep px-2 py-1">
+          <span className="truncate font-mono text-sm text-doom-text">sk-doom-0000-1111-2222</span>
+          <CopyButton text="sk-doom-0000-1111-2222" />
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">at full opacity</span>
+        <CopyButton text="pnpm nx run doompi-web-components:test" className="opacity-100" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Dialog.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Dialog.stories.tsx
@@ -1,0 +1,103 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ *
+ * Every root is `open`, so all three widths paint at once. A DialogContent is
+ * portalled to document.body and centred with `fixed top-1/2 -translate-y-1/2`,
+ * so two of the three take a `top`/`bottom` override to claim their own slot in
+ * the 800px-tall render viewport instead of stacking on the centre.
+ */
+import { Button } from './Button.tsx';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './Dialog.tsx';
+
+const meta = {
+  title: 'Components/Dialog',
+  component: Dialog,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+const LABEL = 'text-2xs text-doom-dim uppercase tracking-widest';
+
+export const Playground = {
+  render: () => (
+    <div className="flex min-h-96 flex-col gap-6 bg-doom-bg p-6">
+      <span className={LABEL}>dialog renders over this surface</span>
+
+      <Dialog open>
+        <DialogContent width="sm" className="top-6 translate-y-0">
+          <DialogHeader>
+            <DialogTitle>discard draft</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <span className={LABEL}>width sm / footer plain</span>
+            <DialogDescription>The narrow preset: one question, two answers, nothing to read.</DialogDescription>
+            <DialogFooter>
+              <Button variant="ghost" size="sm">
+                cancel
+              </Button>
+              <Button variant="danger" size="sm">
+                discard
+              </Button>
+            </DialogFooter>
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open>
+        <DialogContent width="md">
+          <DialogHeader dismissible>
+            <DialogTitle>rename session</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <span className={LABEL}>width md / header dismissible</span>
+            <DialogDescription>
+              The default preset, with the close control the header hides unless `dismissible` is set.
+            </DialogDescription>
+          </DialogBody>
+          <DialogFooter variant="bar">
+            <span className="text-2xs text-doom-faint">esc to close</span>
+            <Button variant="primary" size="sm">
+              save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open>
+        <DialogContent width="lg" className="top-auto bottom-6 translate-y-0">
+          <DialogHeader>
+            <DialogTitle>run configuration</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <span className={LABEL}>width lg / footer bar</span>
+            <DialogDescription>
+              The wide preset, for a body that holds a form or a diff rather than a sentence.
+            </DialogDescription>
+          </DialogBody>
+          <DialogFooter variant="bar">
+            <span className="text-2xs text-doom-faint">changes apply to new runs</span>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm">
+                cancel
+              </Button>
+              <Button variant="primary" size="sm">
+                apply
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Dialog.tsx
+++ b/packages/core/doompi-web-components/src/components/Dialog.tsx
@@ -128,7 +128,7 @@ export function DialogTitle({ className, ...props }: ComponentProps<typeof Dialo
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('text-[12px] font-bold tracking-wide text-doom-hi', className)}
+      className={cn('text-sm font-bold tracking-wide text-doom-hi', className)}
       {...props}
     />
   );
@@ -138,7 +138,7 @@ export function DialogDescription({ className, ...props }: ComponentProps<typeof
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn('text-[11px] leading-relaxed text-doom-dim', className)}
+      className={cn('text-sm leading-relaxed text-doom-dim', className)}
       {...props}
     />
   );

--- a/packages/core/doompi-web-components/src/components/Dot.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Dot.stories.tsx
@@ -1,0 +1,42 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Dot } from './Dot.tsx';
+import { DOT_TONES } from '../types/tone.ts';
+
+const SIZES = ['xs', 'sm', 'md', 'lg'] as const;
+
+const meta = {
+  title: 'Components/Dot',
+  component: Dot,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      {SIZES.map((size) => (
+        <div key={size} className="flex flex-col gap-2">
+          <span className="text-2xs text-doom-dim uppercase tracking-widest">size {size}</span>
+          <div className="flex flex-wrap items-center gap-3">
+            {DOT_TONES.map((tone) => (
+              <Dot key={tone} tone={tone} size={size} />
+            ))}
+          </div>
+        </div>
+      ))}
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">pulse</span>
+        <div className="flex flex-wrap items-center gap-3">
+          {DOT_TONES.map((tone) => (
+            <Dot key={tone} tone={tone} size="lg" pulse />
+          ))}
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/DropdownMenu.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/DropdownMenu.stories.tsx
@@ -1,0 +1,74 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. The menu is held `open` because the renderer screenshots without
+ * interacting, and the content portals to document.body, so the wrapper
+ * reserves the height the portal draws into.
+ */
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from './DropdownMenu.tsx';
+
+const meta = {
+  title: 'Components/DropdownMenu',
+  component: DropdownMenu,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex min-h-96 flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">open menu · every item variant</span>
+        <DropdownMenu open modal={false}>
+          <DropdownMenuTrigger className="w-fit rounded-sm border border-doom-border bg-doom-panel px-2.5 py-1 text-sm text-doom-hi">
+            session
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            <DropdownMenuLabel>session</DropdownMenuLabel>
+            <DropdownMenuGroup>
+              <DropdownMenuItem>
+                open
+                <DropdownMenuShortcut>⌘O</DropdownMenuShortcut>
+              </DropdownMenuItem>
+              <DropdownMenuItem indented>indented row</DropdownMenuItem>
+              <DropdownMenuItem disabled>disabled row</DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuCheckboxItem checked>wrap lines</DropdownMenuCheckboxItem>
+            <DropdownMenuCheckboxItem checked={false}>show timestamps</DropdownMenuCheckboxItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuRadioGroup value="sonnet">
+              <DropdownMenuRadioItem value="sonnet">sonnet</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="opus">opus</DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuSub open>
+              <DropdownMenuSubTrigger>export</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem>markdown</DropdownMenuItem>
+                <DropdownMenuItem>json</DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem variant="destructive">delete session</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/DropdownMenu.tsx
+++ b/packages/core/doompi-web-components/src/components/DropdownMenu.tsx
@@ -42,7 +42,7 @@ export function DropdownMenuContent({
 }
 
 export const dropdownMenuItemVariants = cva(
-  'flex w-full cursor-pointer items-center gap-2 px-2.5 py-1.5 text-left text-[11px] outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-40 data-[highlighted]:bg-doom-deep',
+  'flex w-full cursor-pointer items-center gap-2 px-2.5 py-1.5 text-left text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-40 data-[highlighted]:bg-doom-deep',
   {
     variants: {
       variant: {
@@ -164,7 +164,7 @@ export function DropdownMenuLabel({ className, ...props }: ComponentProps<typeof
   return (
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
-      className={cn('px-2.5 py-1 text-[8px] font-bold tracking-[0.14em] text-doom-faint uppercase', className)}
+      className={cn('px-2.5 py-1 text-2xs font-bold tracking-wider text-doom-faint uppercase', className)}
       {...props}
     />
   );
@@ -175,7 +175,7 @@ export function DropdownMenuShortcut({ className, ...props }: ComponentProps<'sp
   return (
     <span
       data-slot="dropdown-menu-shortcut"
-      className={cn('ml-auto shrink-0 text-[10px] tracking-[0.08em] text-doom-faint', className)}
+      className={cn('ml-auto shrink-0 text-xs tracking-wide text-doom-faint', className)}
       {...props}
     />
   );

--- a/packages/core/doompi-web-components/src/components/EmptyState.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/EmptyState.stories.tsx
@@ -1,0 +1,57 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Button } from './Button.tsx';
+import { EmptyState } from './EmptyState.tsx';
+
+const meta = {
+  title: 'Components/EmptyState',
+  component: EmptyState,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">title only</span>
+        <EmptyState title="no sessions yet" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">with description</span>
+        <EmptyState title="no sessions yet" description="A session appears here as soon as one starts in the rail." />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">with actions</span>
+        <EmptyState title="nothing to review" description="Every run in this window finished without a diff.">
+          <div className="flex items-center gap-2">
+            <Button variant="primary" size="sm">
+              new session
+            </Button>
+            <Button variant="outline" size="sm">
+              open the log
+            </Button>
+          </div>
+        </EmptyState>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">inside a panel</span>
+        <div className="flex h-40 rounded-md border border-doom-border bg-doom-deep">
+          <EmptyState title="no output" description="This tool call returned nothing." />
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">as child, an empty list row</span>
+        <ul className="flex flex-col rounded-md border border-doom-border">
+          <EmptyState asChild title="no results">
+            <li />
+          </EmptyState>
+        </ul>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/EmptyState.tsx
+++ b/packages/core/doompi-web-components/src/components/EmptyState.tsx
@@ -24,8 +24,8 @@ export function EmptyState({ title, description, children, className, asChild = 
       {...props}
     >
       <div className="flex w-[520px] max-w-full flex-col items-center gap-3 text-center">
-        <span className="text-[14px] font-bold text-doom-hi">{title}</span>
-        {description ? <span className="text-[11px] leading-relaxed text-doom-dim">{description}</span> : null}
+        <span className="text-base font-bold text-doom-hi">{title}</span>
+        {description ? <span className="text-sm leading-relaxed text-doom-dim">{description}</span> : null}
         {children}
       </div>
     </Component>

--- a/packages/core/doompi-web-components/src/components/HashlineLines.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/HashlineLines.stories.tsx
@@ -1,0 +1,50 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. The fixtures are what hashlineBody hands the component: a read is
+ * one file's anchored lines, a grep groups matches under each path.
+ */
+import type { PresentedLine } from '../lib/hashlineView.ts';
+import { HashlineLines } from './HashlineLines.tsx';
+
+const READ_LINES: readonly PresentedLine[] = [
+  {
+    type: 'tagged',
+    value: { line: 7, content: 'export function cn(...inputs: ClassValue[]): string {', marker: undefined },
+  },
+  { type: 'tagged', value: { line: 8, content: '  return twMerge(clsx(inputs));', marker: undefined } },
+  { type: 'tagged', value: { line: 9, content: '}', marker: undefined } },
+  { type: 'plain', text: '[10 of 24 lines shown]' },
+];
+
+const GREP_LINES: readonly PresentedLine[] = [
+  { type: 'file', path: 'src/components/Badge.tsx' },
+  { type: 'tagged', value: { line: 3, content: "import { cn } from '../lib/cn.ts';", marker: 'match' } },
+  { type: 'tagged', value: { line: 4, content: '', marker: 'context' } },
+  { type: 'file', path: 'src/components/Tabs.tsx' },
+  { type: 'tagged', value: { line: 5, content: "import { cn } from '../lib/cn.ts';", marker: 'match' } },
+  { type: 'tagged', value: { line: 6, content: '', marker: 'context' } },
+];
+
+const meta = {
+  title: 'Components/HashlineLines',
+  component: HashlineLines,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">read · anchored lines with a notice</span>
+        <HashlineLines className="text-sm" lines={READ_LINES} gutter={1} path="src/lib/cn.ts" />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">grep · file headings and markers</span>
+        <HashlineLines className="text-sm" lines={GREP_LINES} gutter={1} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Input.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Input.stories.tsx
@@ -1,0 +1,47 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Input } from './Input.tsx';
+
+const VARIANTS = ['default', 'bare'] as const;
+const SIZES = ['xs', 'sm', 'md', 'lg'] as const;
+
+const meta = {
+  title: 'Components/Input',
+  component: Input,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      {VARIANTS.map((variant) => (
+        <div key={variant} className="flex flex-col gap-3">
+          <span className="text-2xs text-doom-dim uppercase tracking-widest">variant {variant}</span>
+          {SIZES.map((size) => (
+            <div key={size} className="flex flex-col gap-1">
+              <span className="text-2xs text-doom-dim uppercase tracking-widest">size {size}</span>
+              <Input variant={variant} size={size} defaultValue={`${variant} ${size}`} className="w-64" />
+            </div>
+          ))}
+        </div>
+      ))}
+      <div className="flex flex-col gap-1">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state placeholder</span>
+        <Input placeholder="search sessions" className="w-64" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state invalid</span>
+        <Input aria-invalid defaultValue="not a path" className="w-64" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state disabled</span>
+        <Input disabled defaultValue="locked while the run is live" className="w-64" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Input.tsx
+++ b/packages/core/doompi-web-components/src/components/Input.tsx
@@ -18,10 +18,10 @@ export const fieldVariants = cva(
       },
       /** The same rungs Button names, so a field and the button beside it line up. */
       size: {
-        xs: 'px-1.5 py-0.5 text-[10px]',
-        sm: 'px-2 py-1 text-[11px]',
-        md: 'px-2.5 py-1.5 text-[12px]',
-        lg: 'px-3 py-2 text-[13px]',
+        xs: 'px-1.5 py-0.5 text-2xs',
+        sm: 'px-2 py-1 text-xs',
+        md: 'px-2.5 py-1.5 text-sm',
+        lg: 'px-3 py-2 text-base',
       },
     },
     compoundVariants: [

--- a/packages/core/doompi-web-components/src/components/Kbd.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Kbd.stories.tsx
@@ -1,0 +1,40 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Kbd } from './Kbd.tsx';
+
+const KEYS = ['SPC', 'C-c', 'g', '⏎', '⌘K'] as const;
+
+const meta = {
+  title: 'Components/Kbd',
+  component: Kbd,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">keys</span>
+        <div className="flex flex-wrap items-center gap-2">
+          {KEYS.map((key) => (
+            <Kbd key={key}>{key}</Kbd>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">leader hint</span>
+        <div className="flex flex-wrap items-center gap-1.5 text-xs text-doom-faint">
+          <Kbd>SPC</Kbd>
+          <Kbd>g</Kbd>
+          <Kbd>s</Kbd>
+          <span>go to sessions</span>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Kbd.tsx
+++ b/packages/core/doompi-web-components/src/components/Kbd.tsx
@@ -7,7 +7,7 @@ export function Kbd({ className, ...props }: ComponentProps<'kbd'>) {
     <kbd
       data-slot="kbd"
       className={cn(
-        'inline-flex items-center rounded bg-doom-deep px-1.5 py-0.5 font-mono text-[8px] font-bold text-doom-faint',
+        'inline-flex items-center rounded bg-doom-deep px-1.5 py-0.5 font-mono text-2xs font-bold text-doom-faint',
         className,
       )}
       {...props}

--- a/packages/core/doompi-web-components/src/components/Label.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Label.stories.tsx
@@ -1,0 +1,40 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Label } from './Label.tsx';
+import { Checkbox } from './Checkbox.tsx';
+
+const meta = {
+  title: 'Components/Label',
+  component: Label,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">default</span>
+        <Label htmlFor="story-label-name">Session name</Label>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">wrapping a control</span>
+        <Label>
+          <Checkbox checked aria-label="Stream tokens" />
+          Stream tokens
+        </Label>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">disabled control</span>
+        <div className="flex items-center gap-1.5">
+          <Label htmlFor="story-label-disabled">Notify on finish</Label>
+          <Checkbox id="story-label-disabled" disabled checked={false} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Label.tsx
+++ b/packages/core/doompi-web-components/src/components/Label.tsx
@@ -8,7 +8,7 @@ export function Label({ className, ...props }: ComponentProps<typeof LabelPrimit
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        'flex items-center gap-1.5 text-[10px] text-doom-faint select-none has-[+:disabled]:opacity-50',
+        'flex items-center gap-1.5 text-xs text-doom-faint select-none has-[+:disabled]:opacity-50',
         className,
       )}
       {...props}

--- a/packages/core/doompi-web-components/src/components/Markdown.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Markdown.stories.tsx
@@ -1,0 +1,37 @@
+import { Markdown } from './Markdown.tsx';
+
+const DOC = [
+  '## Release notes',
+  '',
+  '**Ships today:** the `--watch` flag, plus a [changelog](https://example.com).',
+  '',
+  '- pty output streams again',
+  '- `src/app.ts` reloads in place',
+  '',
+  '```ts',
+  "export const version = '2.1.0';",
+  '```',
+].join('\n');
+
+const meta = {
+  title: 'Components/Markdown',
+  component: Markdown,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">document</span>
+        <Markdown text={DOC} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">with file links</span>
+        <Markdown text={DOC} onFileLink={(text) => (text.endsWith('.ts') ? () => undefined : undefined)} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Markdown.tsx
+++ b/packages/core/doompi-web-components/src/components/Markdown.tsx
@@ -5,7 +5,7 @@ import { CodeBlock } from './CodeBlock.tsx';
 
 const REMARK_PLUGINS = [remarkGfm];
 
-const CODE_CLASS = 'rounded bg-doom-deep px-1 py-px font-mono text-[12px] text-doom-green';
+const CODE_CLASS = 'rounded bg-doom-deep px-1 py-px font-mono text-sm text-doom-green';
 
 /**
  * What a piece of inline code opens, when the host knows.
@@ -103,7 +103,7 @@ function Pre({ children }: ComponentProps<'pre'>) {
   const code = isValidElement<{ className?: string; children?: ReactNode }>(children) ? children : undefined;
   if (code === undefined)
     return (
-      <pre className="overflow-x-auto rounded border border-doom-border bg-doom-deep p-2.5 text-[12px] leading-relaxed">
+      <pre className="overflow-x-auto rounded border border-doom-border bg-doom-deep p-2.5 text-sm leading-relaxed">
         {children}
       </pre>
     );
@@ -121,17 +121,17 @@ const COMPONENTS: Components = {
   ul: ({ children }) => <ul className="list-disc pl-5">{children}</ul>,
   ol: ({ children }) => <ol className="list-decimal pl-5">{children}</ol>,
   li: ({ children }) => <li className="whitespace-pre-wrap break-words">{children}</li>,
-  h1: ({ children }) => <h1 className="text-[15px] font-bold text-doom-hi">{children}</h1>,
-  h2: ({ children }) => <h2 className="text-[14px] font-bold text-doom-hi">{children}</h2>,
-  h3: ({ children }) => <h3 className="text-[13px] font-bold text-doom-hi">{children}</h3>,
-  h4: ({ children }) => <h4 className="text-[13px] font-bold text-doom-text">{children}</h4>,
+  h1: ({ children }) => <h1 className="text-lg font-bold text-doom-hi">{children}</h1>,
+  h2: ({ children }) => <h2 className="text-base font-bold text-doom-hi">{children}</h2>,
+  h3: ({ children }) => <h3 className="text-base font-bold text-doom-hi">{children}</h3>,
+  h4: ({ children }) => <h4 className="text-base font-bold text-doom-text">{children}</h4>,
   blockquote: ({ children }) => (
     <blockquote className="border-l-2 border-doom-border pl-3 text-doom-dim">{children}</blockquote>
   ),
   hr: () => <hr className="border-doom-border-soft" />,
   table: ({ children }) => (
     <div className="overflow-x-auto">
-      <table className="border-collapse text-[12px]">{children}</table>
+      <table className="border-collapse text-sm">{children}</table>
     </div>
   ),
   th: ({ children }) => (

--- a/packages/core/doompi-web-components/src/components/MediaPreview.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/MediaPreview.stories.tsx
@@ -1,0 +1,46 @@
+import { MediaPreview } from './MediaPreview.tsx';
+
+const IMAGE =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='90'%3E%3Crect width='160' height='90' fill='gray'/%3E%3C/svg%3E";
+
+// An empty payload: the player chrome is the variant here, not decoded frames.
+const VIDEO = 'data:video/mp4,';
+
+// A one page PDF with no content stream, so the canvas draws an empty page.
+const PDF =
+  'data:application/pdf;base64,JVBERi0xLjQKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2JqCjIgMCBvYmo8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iagozIDAgb2JqPDwvVHlwZS9QYWdlL1BhcmVudCAyIDAgUi9NZWRpYUJveFswIDAgMTgwIDkwXT4+ZW5kb2JqCnRyYWlsZXI8PC9Sb290IDEgMCBSPj4=';
+
+const meta = {
+  title: 'Components/MediaPreview',
+  component: MediaPreview,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">image</span>
+        <MediaPreview src={IMAGE} path="assets/logo.svg" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">video</span>
+        <MediaPreview src={VIDEO} path="clips/demo.mp4" className="max-h-40" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">pdf</span>
+        <MediaPreview src={PDF} path="docs/spec.pdf" className="h-64" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">download</span>
+        <MediaPreview src={IMAGE} path="reports/summary.docx" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">kind overrides the path</span>
+        <MediaPreview src={IMAGE} path="assets/logo.svg" kind="download" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/MermaidDiagram.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/MermaidDiagram.stories.tsx
@@ -1,0 +1,28 @@
+import { MermaidDiagram } from './MermaidDiagram.tsx';
+
+const GRAPH = 'graph TD; A-->B;';
+
+const LABELLED = 'graph LR; A[prompt]-->B[reply];';
+
+const meta = {
+  title: 'Components/MermaidDiagram',
+  component: MermaidDiagram,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">two nodes</span>
+        <MermaidDiagram code={GRAPH} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">labelled, left to right</span>
+        <MermaidDiagram code={LABELLED} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/MessageItem.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/MessageItem.stories.tsx
@@ -1,0 +1,92 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. Every card is rendered in the state it should be screenshotted in,
+ * so nothing here waits on the expand toggle.
+ */
+import { STATUS_TONES } from '../types/tone.ts';
+import {
+  MessageItem,
+  MessageItemBody,
+  MessageItemGroup,
+  MessageItemHeader,
+  MessageItemStatus,
+} from './MessageItem.tsx';
+
+const meta = {
+  title: 'Components/MessageItem',
+  component: MessageItem,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">card · one per tone</span>
+        <div className="flex max-w-lg flex-col gap-2">
+          {STATUS_TONES.map((tone) => (
+            <MessageItem key={tone} tone={tone} expandable defaultExpanded>
+              <MessageItemHeader title="bash">
+                <span className="min-w-0 truncate text-doom-faint">pnpm test doompi-web-components</span>
+              </MessageItemHeader>
+              <MessageItemBody>
+                <MessageItemStatus tone={tone}>{tone}</MessageItemStatus>
+              </MessageItemBody>
+            </MessageItem>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">card · collapsed with more hint</span>
+        <div className="max-w-lg">
+          <MessageItem tone="ok" expandable>
+            <MessageItemHeader title="read">
+              <span className="min-w-0 truncate text-doom-faint">src/lib/cn.ts</span>
+            </MessageItemHeader>
+            <MessageItemStatus expands className="px-3 pb-2">
+              12 more lines
+            </MessageItemStatus>
+          </MessageItem>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">group · items become rows</span>
+        <div className="max-w-lg">
+          <MessageItemGroup tone="error" title="bash" summary="3 calls">
+            <MessageItem tone="ok">
+              <MessageItemHeader title="bash">
+                <span className="min-w-0 truncate text-doom-faint">pnpm install</span>
+              </MessageItemHeader>
+            </MessageItem>
+            <MessageItem tone="running">
+              <MessageItemHeader title="bash">
+                <span className="min-w-0 truncate text-doom-faint">pnpm build</span>
+              </MessageItemHeader>
+            </MessageItem>
+            <MessageItem tone="error" defaultExpanded>
+              <MessageItemHeader title="bash">
+                <span className="min-w-0 truncate text-doom-faint">pnpm test</span>
+              </MessageItemHeader>
+              <MessageItemBody>exit code 1</MessageItemBody>
+            </MessageItem>
+          </MessageItemGroup>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">status · one glyph per tone</span>
+        <div className="flex flex-wrap items-center gap-4 text-sm">
+          {STATUS_TONES.map((tone) => (
+            <MessageItemStatus key={tone} tone={tone}>
+              {tone}
+            </MessageItemStatus>
+          ))}
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/MessageItem.tsx
+++ b/packages/core/doompi-web-components/src/components/MessageItem.tsx
@@ -139,7 +139,7 @@ export function MessageItemGroup({
   return (
     <MessageItemGroupContext.Provider value={{ tone: tone ?? 'neutral' }}>
       <div data-slot="message-item-group" className={cn(messageItemVariants({ tone }), className)} {...props}>
-        <div className="flex min-h-8 items-center gap-2 border-doom-border-soft border-b px-[11px] text-[11px] text-doom-dim">
+        <div className="flex min-h-8 items-center gap-2 border-doom-border-soft border-b px-[11px] text-sm text-doom-dim">
           <span className="shrink-0 font-bold text-doom-hi">{title}</span>
           <span className="min-w-0 flex-1 truncate text-doom-faint">{summary}</span>
           {label !== null && label !== '' ? <StatusBadge tone={tone ?? 'neutral'}>{label}</StatusBadge> : null}
@@ -194,7 +194,7 @@ export function MessageItemHeader({ className, title, badge, children, ...props 
   return (
     <div
       data-slot="message-item-header"
-      className={cn('flex min-h-8 items-center gap-2 px-[11px] text-[11px] text-doom-dim', className)}
+      className={cn('flex min-h-8 items-center gap-2 px-[11px] text-sm text-doom-dim', className)}
       {...props}
     >
       {group === null ? <span className="shrink-0 font-bold text-doom-hi">{title}</span> : null}
@@ -228,7 +228,7 @@ export function MessageItemBody({ className, ...props }: ComponentProps<'div'>) 
   return (
     <div
       data-slot="message-item-body"
-      className={cn('border-t border-doom-border-soft bg-doom-deep px-3 py-2 text-[11px] text-doom-dim', className)}
+      className={cn('border-t border-doom-border-soft bg-doom-deep px-3 py-2 text-sm text-doom-dim', className)}
       {...props}
     />
   );

--- a/packages/core/doompi-web-components/src/components/MessageLines.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/MessageLines.stories.tsx
@@ -1,0 +1,59 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. The tone row is generated from MESSAGE_LINE_TONES, so a tone added
+ * to the vocabulary shows up here without an edit.
+ */
+import { MESSAGE_LINE_TONES } from '../types/tone.ts';
+import { type MessageLine, MessageLines } from './MessageLines.tsx';
+
+const TONES: readonly MessageLine[] = MESSAGE_LINE_TONES.map((tone) => ({
+  text: `${tone} · the quick brown fox jumps`,
+  tone,
+}));
+
+const EMPHASIS: readonly MessageLine[] = [
+  { text: 'bold', tone: 'hi', bold: true },
+  { text: 'plain', tone: 'hi' },
+  { text: 'indented', tone: 'dim', indent: true },
+  { text: 'bold and indented', tone: 'dim', bold: true, indent: true },
+];
+
+const BODY: readonly MessageLine[] = [
+  { text: 'pnpm test doompi-web-components', tone: 'hi', bold: true },
+  { text: '3 files changed', tone: 'text' },
+  { text: 'src/components/MessageLines.tsx', tone: 'dim', indent: true },
+  { text: 'src/types/tone.ts', tone: 'dim', indent: true },
+  { text: '42 passed', tone: 'success' },
+  { text: '1 flaky', tone: 'warning' },
+  { text: '1 failed', tone: 'error', bold: true },
+  { text: 'rerun with --reporter=verbose', tone: 'muted' },
+];
+
+const meta = {
+  title: 'Components/MessageLines',
+  component: MessageLines,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">tone · every line tone</span>
+        <MessageLines className="text-sm" lines={TONES} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">bold and indent</span>
+        <MessageLines className="text-sm" lines={EMPHASIS} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">body · a tool result</span>
+        <MessageLines className="text-sm" lines={BODY} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/OptionList.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/OptionList.stories.tsx
@@ -1,0 +1,50 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. The cursor is controlled by the surface, so the fixture pins one
+ * and the callbacks do nothing.
+ */
+import { OptionList } from './OptionList.tsx';
+
+const MODELS = ['claude sonnet', 'claude opus', 'qwen3 coder', 'gpt-5 codex'] as const;
+
+const noop = () => undefined;
+
+const meta = {
+  title: 'Components/OptionList',
+  component: OptionList,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">density comfortable</span>
+        <OptionList
+          className="max-w-sm"
+          density="comfortable"
+          options={MODELS}
+          cursor={0}
+          onCursorChange={noop}
+          onSelect={noop}
+          testIdPrefix="model-comfortable-option"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">density compact</span>
+        <OptionList
+          className="max-w-sm rounded-md bg-doom-panel"
+          density="compact"
+          options={MODELS}
+          cursor={2}
+          onCursorChange={noop}
+          onSelect={noop}
+          testIdPrefix="model-compact-option"
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/OptionList.tsx
+++ b/packages/core/doompi-web-components/src/components/OptionList.tsx
@@ -14,8 +14,8 @@ export const optionListVariants = cva('flex min-h-0 flex-1 flex-col overflow-y-a
 export const optionRowVariants = cva('flex shrink-0 cursor-pointer items-center text-left outline-none', {
   variants: {
     density: {
-      compact: 'gap-2.5 rounded-[5px] px-2 py-[7px]',
-      comfortable: 'min-h-[42px] gap-3 rounded-md border px-[11px] py-2 text-[12px] text-doom-text transition-colors',
+      compact: 'gap-2.5 rounded-md px-2 py-[7px]',
+      comfortable: 'min-h-[42px] gap-3 rounded-md border px-[11px] py-2 text-sm text-doom-text transition-colors',
     },
     active: { true: '', false: '' },
   },
@@ -30,8 +30,8 @@ export const optionRowVariants = cva('flex shrink-0 cursor-pointer items-center 
 export const optionMarkerVariants = cva('flex shrink-0 items-center justify-center rounded-full font-bold', {
   variants: {
     density: {
-      compact: 'h-[15px] w-[15px] border border-doom-border text-[8px] text-doom-faint',
-      comfortable: 'h-[18px] w-[18px] bg-doom-deep text-[10px] text-doom-dim',
+      compact: 'h-[15px] w-[15px] border border-doom-border text-2xs text-doom-faint',
+      comfortable: 'h-[18px] w-[18px] bg-doom-deep text-xs text-doom-dim',
     },
   },
   defaultVariants: { density: 'comfortable' },
@@ -77,7 +77,7 @@ export function OptionLabel({
       data-slot="option-label"
       className={cn(
         'min-w-0 flex-1',
-        density === 'compact' ? 'truncate text-[12px] text-doom-text' : 'break-words',
+        density === 'compact' ? 'truncate text-sm text-doom-text' : 'break-words',
         className,
       )}
       {...props}

--- a/packages/core/doompi-web-components/src/components/Panel.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Panel.stories.tsx
@@ -1,0 +1,54 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Panel, PanelBody, PanelHeader } from './Panel.tsx';
+
+const meta = {
+  title: 'Components/Panel',
+  component: Panel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+const LABEL = 'text-2xs text-doom-dim uppercase tracking-widest';
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-wrap items-start gap-6">
+        <div className="flex flex-col gap-2">
+          <span className={LABEL}>surface only</span>
+          <Panel className="w-72 px-3 py-2 text-sm text-doom-dim">
+            The bordered card with nothing inside it but its own padding.
+          </Panel>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <span className={LABEL}>header and body</span>
+          <Panel className="w-72">
+            <PanelHeader>
+              <span className="text-sm font-bold text-doom-hi">bash</span>
+              <span className="text-2xs text-doom-faint uppercase tracking-wider">exit 0</span>
+            </PanelHeader>
+            <PanelBody>pnpm nx run doompi-web-components:test</PanelBody>
+          </Panel>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <span className={LABEL}>as child</span>
+          <Panel asChild>
+            <section className="w-72">
+              <PanelHeader>
+                <span className="text-sm font-bold text-doom-hi">session 04</span>
+              </PanelHeader>
+              <PanelBody>A list row rendered as the panel itself, not wrapped in one.</PanelBody>
+            </section>
+          </Panel>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Panel.tsx
+++ b/packages/core/doompi-web-components/src/components/Panel.tsx
@@ -31,7 +31,7 @@ export function PanelBody({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       data-slot="panel-body"
-      className={cn('border-t border-doom-border-soft bg-doom-deep px-3 py-2 text-[11px] text-doom-dim', className)}
+      className={cn('border-t border-doom-border-soft bg-doom-deep px-3 py-2 text-sm text-doom-dim', className)}
       {...props}
     />
   );

--- a/packages/core/doompi-web-components/src/components/PdfPreview.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/PdfPreview.stories.tsx
@@ -1,0 +1,24 @@
+import { PdfPreview } from './PdfPreview.tsx';
+
+// A one page PDF with no content stream, so the canvas draws an empty page.
+const PDF =
+  'data:application/pdf;base64,JVBERi0xLjQKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2JqCjIgMCBvYmo8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iagozIDAgb2JqPDwvVHlwZS9QYWdlL1BhcmVudCAyIDAgUi9NZWRpYUJveFswIDAgMTgwIDkwXT4+ZW5kb2JqCnRyYWlsZXI8PC9Sb290IDEgMCBSPj4=';
+
+const meta = {
+  title: 'Components/PdfPreview',
+  component: PdfPreview,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">single page</span>
+        <PdfPreview src={PDF} path="docs/spec.pdf" className="h-64" data-testid="pdf-preview" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/PdfPreview.tsx
+++ b/packages/core/doompi-web-components/src/components/PdfPreview.tsx
@@ -1,7 +1,9 @@
-import { getDocument, type PDFDocumentProxy, type PDFPageProxy } from 'pdfjs-dist/webpack.mjs';
+import type { PDFDocumentProxy, PDFPageProxy } from 'pdfjs-dist/webpack.mjs';
 import { useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { cn } from '../lib/cn.ts';
 import { Button } from './Button.tsx';
+
+type PdfLoadingTask = ReturnType<typeof import('pdfjs-dist/webpack.mjs').getDocument>;
 
 export interface PdfNormalizedRectangle {
   x: number;
@@ -88,22 +90,29 @@ export function PdfPreview({ src, path, className, controllerRef, 'data-testid':
   const [error, setError] = useState<string | undefined>();
 
   useEffect(() => {
-    const loading = getDocument({ url: src });
     let disposed = false;
-    void loading.promise
-      .then((document) => {
-        if (disposed) return;
-        documentRef.current = document;
-        setError(undefined);
-        setPage(1);
-        setPageState({ ...EMPTY_STATE, pageCount: document.numPages });
+    let loading: PdfLoadingTask | undefined;
+    // pdfjs is imported on demand: `pdfjs-dist/webpack.mjs` spins up its worker
+    // at module scope, so a static import would make every consumer of this
+    // package pay for the worker whether or not it ever shows a PDF.
+    void import('pdfjs-dist/webpack.mjs')
+      .then(({ getDocument }) => {
+        if (disposed) return undefined;
+        loading = getDocument({ url: src });
+        return loading.promise.then((document) => {
+          if (disposed) return;
+          documentRef.current = document;
+          setError(undefined);
+          setPage(1);
+          setPageState({ ...EMPTY_STATE, pageCount: document.numPages });
+        });
       })
       .catch((reason: unknown) => {
         if (!disposed) setError(reason instanceof Error ? reason.message : String(reason));
       });
     return () => {
       disposed = true;
-      void loading.destroy();
+      void loading?.destroy();
       renderTask.current?.cancel();
       renderTask.current = null;
       documentRef.current = null;
@@ -162,7 +171,7 @@ export function PdfPreview({ src, path, className, controllerRef, 'data-testid':
 
   return (
     <section data-testid={testId} data-kind="pdf" className={cn('flex min-h-0 flex-col gap-2', className)}>
-      <div className="flex items-center justify-between gap-2 text-[10px] text-doom-faint">
+      <div className="flex items-center justify-between gap-2 text-xs text-doom-faint">
         <span>{path}</span>
         <div className="flex items-center gap-2">
           <Button
@@ -186,7 +195,7 @@ export function PdfPreview({ src, path, className, controllerRef, 'data-testid':
           </Button>
         </div>
       </div>
-      {error === undefined ? null : <output className="text-[10px] text-doom-red">{error}</output>}
+      {error === undefined ? null : <output className="text-xs text-doom-red">{error}</output>}
       <div className="min-h-0 overflow-auto rounded border border-doom-border bg-doom-deep">
         <canvas ref={canvasRef} aria-label={path} className="mx-auto block max-w-full" />
       </div>

--- a/packages/core/doompi-web-components/src/components/Popover.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Popover.stories.tsx
@@ -1,0 +1,88 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ *
+ * Every root is `open` so the anchored content paints without a click. The
+ * content is portalled and positioned against its trigger, so the triggers sit
+ * in a three-column grid and the wrapper keeps a min-height for the drop.
+ */
+import { Button } from './Button.tsx';
+import { Popover, PopoverContent, PopoverFooter, PopoverHeader, PopoverTrigger } from './Popover.tsx';
+
+const meta = {
+  title: 'Components/Popover',
+  component: Popover,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+const LABEL = 'text-2xs text-doom-dim uppercase tracking-widest';
+
+export const Playground = {
+  render: () => (
+    <div className="flex min-h-96 flex-col gap-6 bg-doom-bg p-6">
+      <div className="grid grid-cols-3 items-start gap-6">
+        <div className="flex flex-col gap-2">
+          <span className={LABEL}>align start / body only</span>
+          <Popover open>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm">
+                branch
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-64">
+              <div className="flex flex-col gap-1 px-3 py-2 text-sm text-doom-dim">
+                <span className="text-doom-hi">main</span>
+                <span>feat/style-system</span>
+                <span>fix/toast-viewport</span>
+              </div>
+            </PopoverContent>
+          </Popover>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <span className={LABEL}>align center / header and footer</span>
+          <Popover open>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm">
+                model
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="center" className="w-64">
+              <PopoverHeader>
+                <span className="text-sm font-bold text-doom-hi">pick a model</span>
+              </PopoverHeader>
+              <div className="flex flex-col gap-1 px-3 py-2 text-sm text-doom-dim">
+                <span className="text-doom-hi">sonnet</span>
+                <span>opus</span>
+              </div>
+              <PopoverFooter>
+                <span>enter to select</span>
+                <span>esc to close</span>
+              </PopoverFooter>
+            </PopoverContent>
+          </Popover>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <span className={LABEL}>align end / side right</span>
+          <Popover open>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm">
+                usage
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-64">
+              <PopoverHeader>
+                <span className="text-sm font-bold text-doom-hi">this run</span>
+              </PopoverHeader>
+              <div className="px-3 py-2 text-sm text-doom-dim">18.4k in / 2.1k out</div>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Popover.tsx
+++ b/packages/core/doompi-web-components/src/components/Popover.tsx
@@ -64,7 +64,7 @@ export function PopoverFooter({ className, ...props }: ComponentProps<'div'>) {
     <div
       data-slot="popover-footer"
       className={cn(
-        'flex min-h-[30px] shrink-0 items-center justify-between gap-3 border-t border-doom-border-soft bg-doom-deep px-3 text-[9px] text-doom-faint',
+        'flex min-h-[30px] shrink-0 items-center justify-between gap-3 border-t border-doom-border-soft bg-doom-deep px-3 text-2xs text-doom-faint',
         className,
       )}
       {...props}

--- a/packages/core/doompi-web-components/src/components/Progress.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Progress.stories.tsx
@@ -1,0 +1,37 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Progress } from './Progress.tsx';
+
+const VALUES = [0, 25, 50, 75, 100] as const;
+
+const meta = {
+  title: 'Components/Progress',
+  component: Progress,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      {VALUES.map((value) => (
+        <div key={value} className="flex flex-col gap-2">
+          <span className="text-2xs text-doom-dim uppercase tracking-widest">value {value}</span>
+          <Progress value={value} className="w-64" />
+        </div>
+      ))}
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">indeterminate</span>
+        <Progress className="w-64" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">full width</span>
+        <Progress value={40} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/RadioGroup.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/RadioGroup.stories.tsx
@@ -1,0 +1,58 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. Each group carries a `defaultValue` so the checked state paints
+ * without a click.
+ */
+import { RadioGroup, RadioGroupCard, RadioGroupItem } from './RadioGroup.tsx';
+
+const meta = {
+  title: 'Components/RadioGroup',
+  component: RadioGroup,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">items · checked, unchecked, disabled</span>
+        <RadioGroup defaultValue="auto">
+          <div className="flex items-center gap-2">
+            <RadioGroupItem id="approval-auto" value="auto" />
+            <label htmlFor="approval-auto" className="text-sm text-doom-hi">
+              auto approve
+            </label>
+          </div>
+          <div className="flex items-center gap-2">
+            <RadioGroupItem id="approval-ask" value="ask" />
+            <label htmlFor="approval-ask" className="text-sm text-doom-hi">
+              ask every time
+            </label>
+          </div>
+          <div className="flex items-center gap-2">
+            <RadioGroupItem id="approval-never" value="never" disabled />
+            <label htmlFor="approval-never" className="text-sm text-doom-hi">
+              never (disabled)
+            </label>
+          </div>
+        </RadioGroup>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">cards · checked and unchecked</span>
+        <RadioGroup defaultValue="doom" className="flex-row flex-wrap">
+          <RadioGroupCard value="doom" className="flex w-40 flex-col gap-1">
+            <span className="text-sm text-doom-hi">doom</span>
+            <span className="text-2xs text-doom-dim">the default theme</span>
+          </RadioGroupCard>
+          <RadioGroupCard value="mono" className="flex w-40 flex-col gap-1">
+            <span className="text-sm text-doom-hi">mono</span>
+            <span className="text-2xs text-doom-dim">no accents</span>
+          </RadioGroupCard>
+        </RadioGroup>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/ScrollArea.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/ScrollArea.stories.tsx
@@ -1,0 +1,59 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ *
+ * Radix only paints the bar once it has measured an overflow, so each frame
+ * gets an explicit height and more rows than fit. `type` is set away from the
+ * default `hover`, which would leave the bar invisible in a screenshot.
+ */
+import { ScrollArea } from './ScrollArea.tsx';
+
+const meta = {
+  title: 'Components/ScrollArea',
+  component: ScrollArea,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+const ROWS = Array.from({ length: 18 }, (_, index) => `run ${String(index + 1).padStart(3, '0')} completed`);
+
+function Rows() {
+  return (
+    <div className="flex flex-col">
+      {ROWS.map((row) => (
+        <span key={row} className="border-b border-doom-border-soft px-3 py-1.5 text-sm text-doom-dim last:border-b-0">
+          {row}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-wrap items-start gap-6">
+        <div className="flex flex-col gap-2">
+          <span className="text-2xs text-doom-dim uppercase tracking-widest">type always</span>
+          <ScrollArea type="always" className="h-64 w-80 rounded-md border border-doom-border bg-doom-panel">
+            <Rows />
+          </ScrollArea>
+        </div>
+        <div className="flex flex-col gap-2">
+          <span className="text-2xs text-doom-dim uppercase tracking-widest">type auto</span>
+          <ScrollArea type="auto" className="h-64 w-80 rounded-md border border-doom-border bg-doom-panel">
+            <Rows />
+          </ScrollArea>
+        </div>
+        <div className="flex flex-col gap-2">
+          <span className="text-2xs text-doom-dim uppercase tracking-widest">no overflow</span>
+          <ScrollArea type="always" className="h-64 w-80 rounded-md border border-doom-border bg-doom-panel">
+            <span className="block px-3 py-1.5 text-sm text-doom-dim">Content that fits leaves no bar behind.</span>
+          </ScrollArea>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/SectionLabel.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/SectionLabel.stories.tsx
@@ -1,0 +1,38 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { SectionLabel } from './SectionLabel.tsx';
+
+const HEADINGS = ['sessions', 'activity', 'minor modes'] as const;
+
+const meta = {
+  title: 'Components/SectionLabel',
+  component: SectionLabel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">default</span>
+        <div className="flex flex-wrap items-center gap-6">
+          {HEADINGS.map((heading) => (
+            <SectionLabel key={heading}>{heading}</SectionLabel>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">heading a section</span>
+        <div className="flex flex-col gap-1.5">
+          <SectionLabel>sessions</SectionLabel>
+          <span className="text-xs text-doom-faint">3 running, 1 idle</span>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/SectionLabel.tsx
+++ b/packages/core/doompi-web-components/src/components/SectionLabel.tsx
@@ -6,7 +6,7 @@ export function SectionLabel({ className, ...props }: ComponentProps<'span'>) {
   return (
     <span
       data-slot="section-label"
-      className={cn('font-mono text-[9px] font-bold tracking-[0.18em] text-doom-faint uppercase', className)}
+      className={cn('font-mono text-2xs font-bold tracking-widest text-doom-faint uppercase', className)}
       {...props}
     />
   );

--- a/packages/core/doompi-web-components/src/components/Select.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Select.stories.tsx
@@ -1,0 +1,76 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. One Select is held `open` so the popover paints without a click;
+ * the rest stay closed to show what the trigger alone looks like.
+ */
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from './Select.tsx';
+
+const meta = {
+  title: 'Components/Select',
+  component: Select,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex min-h-96 flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">closed · placeholder and disabled</span>
+        <div className="flex flex-wrap items-center gap-3">
+          <Select>
+            <SelectTrigger className="w-48">
+              <SelectValue placeholder="choose a model" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="sonnet">claude sonnet</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select disabled defaultValue="sonnet">
+            <SelectTrigger className="w-48">
+              <SelectValue placeholder="choose a model" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="sonnet">claude sonnet</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Last, because the open popover paints over whatever follows it. */}
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">open · value selected</span>
+        <Select open defaultValue="sonnet">
+          <SelectTrigger className="w-48">
+            <SelectValue placeholder="model" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectLabel>anthropic</SelectLabel>
+              <SelectItem value="sonnet">claude sonnet</SelectItem>
+              <SelectItem value="opus">claude opus</SelectItem>
+            </SelectGroup>
+            <SelectSeparator />
+            <SelectGroup>
+              <SelectLabel>local</SelectLabel>
+              <SelectItem value="qwen">qwen3 coder</SelectItem>
+              <SelectItem value="offline" disabled>
+                offline model
+              </SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Select.tsx
+++ b/packages/core/doompi-web-components/src/components/Select.tsx
@@ -25,7 +25,7 @@ export function SelectTrigger({ className, children, ...props }: ComponentProps<
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       className={cn(
-        'flex h-7 cursor-pointer items-center justify-between gap-2 rounded border border-doom-border bg-doom-deep px-2.5 font-mono text-[11px] text-doom-hi outline-none transition-colors hover:border-doom-blue/50 focus-visible:ring-2 focus-visible:ring-doom-blue/50 disabled:pointer-events-none disabled:opacity-40 data-[placeholder]:text-doom-faint',
+        'flex h-7 cursor-pointer items-center justify-between gap-2 rounded border border-doom-border bg-doom-deep px-2.5 font-mono text-sm text-doom-hi outline-none transition-colors hover:border-doom-blue/50 focus-visible:ring-2 focus-visible:ring-doom-blue/50 disabled:pointer-events-none disabled:opacity-40 data-[placeholder]:text-doom-faint',
         className,
       )}
       {...props}
@@ -67,7 +67,7 @@ export function SelectLabel({ className, ...props }: ComponentProps<typeof Selec
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn('px-2 py-1 text-[8px] font-bold tracking-[0.14em] text-doom-faint uppercase', className)}
+      className={cn('px-2 py-1 text-2xs font-bold tracking-wider text-doom-faint uppercase', className)}
       {...props}
     />
   );
@@ -78,7 +78,7 @@ export function SelectItem({ className, children, ...props }: ComponentProps<typ
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        'relative flex cursor-pointer items-center gap-2 rounded-[3px] py-1.5 pr-2 pl-7 text-[11px] text-doom-hi outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-40 data-[highlighted]:bg-doom-deep',
+        'relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-7 text-sm text-doom-hi outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-40 data-[highlighted]:bg-doom-deep',
         className,
       )}
       {...props}

--- a/packages/core/doompi-web-components/src/components/Separator.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Separator.stories.tsx
@@ -1,0 +1,47 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Separator } from './Separator.tsx';
+
+const meta = {
+  title: 'Components/Separator',
+  component: Separator,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">horizontal</span>
+        <div className="flex w-64 flex-col gap-2 text-xs">
+          <span>above</span>
+          <Separator />
+          <span>below</span>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">vertical</span>
+        <div className="flex h-5 items-center gap-3 text-xs">
+          <span>left</span>
+          <Separator orientation="vertical" />
+          <span>middle</span>
+          <Separator orientation="vertical" />
+          <span>right</span>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">semantic</span>
+        <div className="flex w-64 flex-col gap-2 text-xs">
+          <span>keeps its separator role</span>
+          <Separator decorative={false} />
+          <span>instead of being hidden</span>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Sheet.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Sheet.stories.tsx
@@ -1,0 +1,64 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ *
+ * Both roots are `open`. A sheet is pinned to an edge and portalled to
+ * document.body, so the two sides paint at once without overlapping; the
+ * wrapper keeps a min-height so the screenshot has room behind them.
+ */
+import { Button } from './Button.tsx';
+import { Sheet, SheetBody, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from './Sheet.tsx';
+
+const meta = {
+  title: 'Components/Sheet',
+  component: Sheet,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+const LABEL = 'text-2xs text-doom-dim uppercase tracking-widest';
+
+export const Playground = {
+  render: () => (
+    <div className="flex min-h-96 flex-col gap-6 bg-doom-bg p-6">
+      <span className={LABEL}>sheets render over this surface</span>
+
+      <Sheet open>
+        <SheetContent side="left" width="sm">
+          <SheetHeader dismissible={false}>
+            <SheetTitle>filters</SheetTitle>
+          </SheetHeader>
+          <SheetBody>
+            <span className={LABEL}>side left / width sm / header plain</span>
+            <SheetDescription>
+              The narrow preset with the close control turned off, for a sheet whose header already owns its right edge.
+            </SheetDescription>
+          </SheetBody>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open>
+        <SheetContent side="right" width="lg">
+          <SheetHeader>
+            <SheetTitle>run detail</SheetTitle>
+          </SheetHeader>
+          <SheetBody>
+            <span className={LABEL}>side right / width lg / header dismissible</span>
+            <SheetDescription>
+              The wide preset with the default close control. Between these two sits `width=&quot;md&quot;`, the
+              default.
+            </SheetDescription>
+          </SheetBody>
+          <SheetFooter>
+            <span className="text-2xs text-doom-faint">esc to close</span>
+            <Button variant="primary" size="sm">
+              rerun
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Sheet.tsx
+++ b/packages/core/doompi-web-components/src/components/Sheet.tsx
@@ -105,7 +105,7 @@ export function SheetTitle({ className, ...props }: ComponentProps<typeof SheetP
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn('truncate text-[13px] font-bold text-doom-hi', className)}
+      className={cn('truncate text-base font-bold text-doom-hi', className)}
       {...props}
     />
   );
@@ -115,7 +115,7 @@ export function SheetDescription({ className, ...props }: ComponentProps<typeof 
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn('text-[11px] leading-relaxed text-doom-dim', className)}
+      className={cn('text-sm leading-relaxed text-doom-dim', className)}
       {...props}
     />
   );

--- a/packages/core/doompi-web-components/src/components/Skeleton.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Skeleton.stories.tsx
@@ -1,0 +1,37 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Skeleton } from './Skeleton.tsx';
+
+const meta = {
+  title: 'Components/Skeleton',
+  component: Skeleton,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">text lines</span>
+        <div className="flex flex-col gap-1.5">
+          <Skeleton className="h-3 w-64" />
+          <Skeleton className="h-3 w-48" />
+          <Skeleton className="h-3 w-32" />
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">block</span>
+        <Skeleton className="h-16 w-64" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">avatar</span>
+        <Skeleton className="h-6 w-6 rounded-full" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Spinner.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Spinner.stories.tsx
@@ -1,0 +1,43 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Spinner } from './Spinner.tsx';
+
+/** Spinner declares no variants; it turns in the current text colour at whatever size it is given. */
+const SIZES = [
+  ['sm', 'h-3 w-3'],
+  ['md', 'h-4 w-4'],
+  ['lg', 'h-5 w-5'],
+] as const;
+
+const meta = {
+  title: 'Components/Spinner',
+  component: Spinner,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">size</span>
+        <div className="flex flex-wrap items-center gap-4">
+          {SIZES.map(([name, size]) => (
+            <Spinner key={name} className={size} />
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">announced</span>
+        <div className="flex flex-wrap items-center gap-1.5 text-xs">
+          <Spinner label="Loading providers" />
+          <span>loading providers</span>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/StatusBadge.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/StatusBadge.stories.tsx
@@ -1,0 +1,36 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { StatusBadge } from './StatusBadge.tsx';
+import { STATUS_TONES } from '../types/tone.ts';
+
+const SIZES = ['xs', 'sm', 'md', 'lg'] as const;
+
+const meta = {
+  title: 'Components/StatusBadge',
+  component: StatusBadge,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      {SIZES.map((size) => (
+        <div key={size} className="flex flex-col gap-2">
+          <span className="text-2xs text-doom-dim uppercase tracking-widest">size {size}</span>
+          <div className="flex flex-wrap items-center gap-2">
+            {STATUS_TONES.map((tone) => (
+              <StatusBadge key={tone} tone={tone} size={size}>
+                {tone}
+              </StatusBadge>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/StatusBadge.tsx
+++ b/packages/core/doompi-web-components/src/components/StatusBadge.tsx
@@ -5,7 +5,7 @@ import { cn } from '../lib/cn.ts';
 import type { StatusTone as Tone } from '../types/tone.ts';
 
 export const statusBadgeVariants = cva(
-  'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-[3px] font-mono font-bold uppercase',
+  'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-sm font-mono font-bold uppercase',
   {
     variants: {
       tone: {
@@ -17,10 +17,10 @@ export const statusBadgeVariants = cva(
         accent: 'bg-doom-tint-magenta text-doom-magenta',
       } satisfies Record<Tone, string>,
       size: {
-        xs: 'px-1.5 py-0.5 text-[8px]',
-        sm: 'px-[7px] py-[3px] text-[9px]',
-        md: 'h-[21px] px-2 text-[10px] normal-case',
-        lg: 'h-6 px-2.5 text-[11px] normal-case',
+        xs: 'px-1.5 py-0.5 text-2xs',
+        sm: 'px-[7px] py-[3px] text-xs',
+        md: 'h-[21px] px-2 text-sm normal-case',
+        lg: 'h-6 px-2.5 text-base normal-case',
       },
     },
     defaultVariants: { tone: 'neutral', size: 'sm' },

--- a/packages/core/doompi-web-components/src/components/StreamCursor.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/StreamCursor.stories.tsx
@@ -1,0 +1,39 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { StreamCursor } from './StreamCursor.tsx';
+
+const meta = {
+  title: 'Components/StreamCursor',
+  component: StreamCursor,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">default</span>
+        <StreamCursor />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">trailing a line of text</span>
+        <span className="font-mono text-sm text-doom-text">
+          reading the file
+          <StreamCursor />
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">on a larger ramp</span>
+        <span className="font-mono text-base text-doom-hi">
+          still thinking
+          <StreamCursor />
+        </span>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Switch.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Switch.stories.tsx
@@ -1,0 +1,45 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Switch } from './Switch.tsx';
+
+const meta = {
+  title: 'Components/Switch',
+  component: Switch,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state off</span>
+        <Switch aria-label="off" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state on</span>
+        <Switch aria-label="on" defaultChecked />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state disabled off</span>
+        <Switch aria-label="disabled off" disabled />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state disabled on</span>
+        <Switch aria-label="disabled on" defaultChecked disabled />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">beside a label</span>
+        {/* Radix renders a button, not a form control, so the caption is a span with the name on the switch. */}
+        <span className="flex items-center gap-2 font-mono text-sm text-doom-dim">
+          <Switch aria-label="stream tool output" defaultChecked />
+          stream tool output
+        </span>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/SyntaxText.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/SyntaxText.stories.tsx
@@ -1,0 +1,50 @@
+import { SyntaxLine, SyntaxText } from './SyntaxText.tsx';
+
+const TYPESCRIPT = [
+  'export function label(session: Session): string {',
+  '  // the id is the fallback name',
+  '  return session.title ?? session.id;',
+  '}',
+].join('\n');
+
+const SPANS = [
+  { text: 'const ', token: 'keyword' },
+  { text: 'ready', token: 'variable' },
+  { text: ' = ', token: 'operator' },
+  { text: 'true', token: 'constant' },
+  { text: ';', token: 'punctuation' },
+] as const;
+
+const meta = {
+  title: 'Components/SyntaxText',
+  component: SyntaxText,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">grammar given</span>
+        <SyntaxText text={TYPESCRIPT} grammar="typescript" className="text-sm text-doom-text" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">grammar from the path</span>
+        <SyntaxText text={TYPESCRIPT} path="src/label.ts" className="text-sm text-doom-text" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">no grammar, plain</span>
+        <SyntaxText text={TYPESCRIPT} className="text-sm text-doom-text" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">SyntaxLine</span>
+        <div className="flex flex-col font-mono text-sm text-doom-text">
+          <SyntaxLine spans={SPANS} text="" />
+          <SyntaxLine text="const ready = true; // no spans yet, so plain" />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Tabs.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Tabs.stories.tsx
@@ -1,0 +1,60 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. The Radix tabs carry a `defaultValue` so a panel is visible
+ * without a click.
+ */
+import { NavTab, NavTabBadge, Tabs, TabsContent, TabsList, TabsTrigger } from './Tabs.tsx';
+
+const meta = {
+  title: 'Components/Tabs',
+  component: Tabs,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">tabs · panel swapped in place</span>
+        <Tabs defaultValue="output" className="flex flex-col gap-2">
+          <TabsList>
+            <TabsTrigger value="output">output</TabsTrigger>
+            <TabsTrigger value="diff">diff</TabsTrigger>
+            <TabsTrigger value="logs" disabled>
+              logs
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="output" className="rounded-md bg-doom-panel p-3 text-sm text-doom-dim">
+            3 files changed, 0 failures.
+          </TabsContent>
+          <TabsContent value="diff" className="rounded-md bg-doom-panel p-3 text-sm text-doom-dim">
+            src/components/Tabs.tsx
+          </TabsContent>
+        </Tabs>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">nav tab · active</span>
+        <div className="flex items-center gap-1">
+          <NavTab href="#runs" active>
+            runs
+            <NavTabBadge active>3</NavTabBadge>
+          </NavTab>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">nav tab · inactive</span>
+        <div className="flex items-center gap-1">
+          <NavTab href="#queue">
+            queue
+            <NavTabBadge>12</NavTabBadge>
+          </NavTab>
+          <NavTab href="#settings">settings</NavTab>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Tabs.tsx
+++ b/packages/core/doompi-web-components/src/components/Tabs.tsx
@@ -10,7 +10,7 @@ import { cn } from '../lib/cn.ts';
  * panels, and a link that looks like a tab must not be a second implementation.
  */
 export const tabVariants = cva(
-  'flex cursor-pointer items-center gap-1.5 rounded px-2 py-1 text-[10px] transition-colors outline-none',
+  'flex cursor-pointer items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors outline-none',
   {
     variants: {
       active: {
@@ -24,7 +24,7 @@ export const tabVariants = cva(
 
 /** The count a tab carries; it inverts on the active tab so it stays readable on the tint. */
 export const tabBadgeVariants = cva(
-  'flex h-[15px] min-w-[15px] items-center justify-center rounded-full px-1 text-[8px] font-bold',
+  'flex h-[15px] min-w-[15px] items-center justify-center rounded-full px-1 text-2xs font-bold',
   {
     variants: {
       active: { true: 'bg-doom-blue text-doom-rail', false: 'bg-doom-panel text-doom-dim' },

--- a/packages/core/doompi-web-components/src/components/TerminalView.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/TerminalView.stories.tsx
@@ -1,0 +1,28 @@
+import { TerminalView } from './TerminalView.tsx';
+
+const meta = {
+  title: 'Components/TerminalView',
+  component: TerminalView,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">default font size</span>
+        <div className="h-40 bg-doom-deep">
+          <TerminalView />
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-faint uppercase tracking-widest">font size 14</span>
+        <div className="h-40 bg-doom-deep">
+          <TerminalView fontSize={14} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Textarea.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Textarea.stories.tsx
@@ -1,0 +1,53 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { Textarea } from './Textarea.tsx';
+
+const VARIANTS = ['default', 'bare'] as const;
+const SIZES = ['xs', 'sm', 'md', 'lg'] as const;
+
+const meta = {
+  title: 'Components/Textarea',
+  component: Textarea,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      {VARIANTS.map((variant) => (
+        <div key={variant} className="flex flex-col gap-3">
+          <span className="text-2xs text-doom-dim uppercase tracking-widest">variant {variant}</span>
+          {SIZES.map((size) => (
+            <div key={size} className="flex flex-col gap-1">
+              <span className="text-2xs text-doom-dim uppercase tracking-widest">size {size}</span>
+              <Textarea
+                variant={variant}
+                size={size}
+                rows={2}
+                defaultValue={`${variant} ${size}\nsecond line`}
+                className="w-64"
+              />
+            </div>
+          ))}
+        </div>
+      ))}
+      <div className="flex flex-col gap-1">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state placeholder</span>
+        <Textarea rows={2} placeholder="ask for something" className="w-64" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state invalid</span>
+        <Textarea aria-invalid rows={2} defaultValue="the prompt is empty" className="w-64" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">state disabled</span>
+        <Textarea disabled rows={2} defaultValue="locked while the run is live" className="w-64" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Toast.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Toast.stories.tsx
@@ -1,0 +1,40 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ *
+ * The tone table is drawn straight from `toastVariants` rather than from the
+ * `Toast` root. Radix's root portals into the viewport during render, and a
+ * viewport mounted in the same commit is still null at that point, so a toast
+ * declared open beside its own viewport throws before it can paint. Everything
+ * inside the surface is the real part: only the <li> wrapper is stood in for.
+ */
+import { STATUS_TONES } from '../types/tone.ts';
+import { Toast, ToastClose, ToastDescription, ToastTitle, toastVariants } from './Toast.tsx';
+
+const meta = {
+  title: 'Components/Toast',
+  component: Toast,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      {STATUS_TONES.map((tone) => (
+        <div key={tone} className="flex flex-col gap-2">
+          <span className="text-2xs text-doom-dim uppercase tracking-widest">tone {tone}</span>
+          <div className={`${toastVariants({ tone })} w-full max-w-sm`}>
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <ToastTitle>build finished</ToastTitle>
+              <ToastDescription>42 files changed in 3.1s.</ToastDescription>
+            </div>
+            <ToastClose />
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Toast.tsx
+++ b/packages/core/doompi-web-components/src/components/Toast.tsx
@@ -52,7 +52,7 @@ export function ToastTitle({ className, ...props }: ComponentProps<typeof ToastP
   return (
     <ToastPrimitive.Title
       data-slot="toast-title"
-      className={cn('text-[11px] font-bold text-doom-hi', className)}
+      className={cn('text-sm font-bold text-doom-hi', className)}
       {...props}
     />
   );
@@ -62,7 +62,7 @@ export function ToastDescription({ className, ...props }: ComponentProps<typeof 
   return (
     <ToastPrimitive.Description
       data-slot="toast-description"
-      className={cn('text-[11px] leading-relaxed text-doom-dim', className)}
+      className={cn('text-sm leading-relaxed text-doom-dim', className)}
       {...props}
     />
   );

--- a/packages/core/doompi-web-components/src/components/ToolPathLink.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/ToolPathLink.stories.tsx
@@ -1,0 +1,51 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ */
+import { ToolPathLink } from './ToolPathLink.tsx';
+
+const PATH = 'packages/core/doompi-web-components/src/components/ToolPathLink.tsx';
+
+/** Stories never click; the link only needs a handler to render as a button. */
+const noop = () => {};
+
+const meta = {
+  title: 'Components/ToolPathLink',
+  component: ToolPathLink,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no onOpen, plain text</span>
+        <span className="font-mono text-sm">
+          <ToolPathLink path={PATH} />
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">with onOpen, a link</span>
+        <span className="font-mono text-sm">
+          <ToolPathLink path={PATH} onOpen={noop} />
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">in a tool call header</span>
+        <div className="flex items-center gap-2 rounded-md border border-doom-border bg-doom-deep px-2 py-1 font-mono text-sm">
+          <span className="shrink-0 text-doom-dim uppercase tracking-wide">read</span>
+          <ToolPathLink path={PATH} onOpen={noop} />
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">truncated by a narrow container</span>
+        <div className="flex w-48 rounded-md border border-doom-border bg-doom-deep px-2 py-1 font-mono text-sm">
+          <ToolPathLink path={PATH} onOpen={noop} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Tooltip.stories.tsx
+++ b/packages/core/doompi-web-components/src/components/Tooltip.stories.tsx
@@ -1,0 +1,45 @@
+/*
+ * Plain CSF objects; see Badge.stories.tsx for why Storybook's types are not
+ * imported. `Playground` is the story the DoomPi style-system extension renders
+ * by default.
+ *
+ * TooltipProvider wraps the grid and every root is `open`, so all four sides
+ * paint without a hover. The wrapper keeps padding on every edge so a tooltip
+ * is not pushed back onto its trigger by collision avoidance.
+ */
+import { Button } from './Button.tsx';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './Tooltip.tsx';
+
+const meta = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+const SIDES = ['top', 'right', 'bottom', 'left'] as const;
+
+export const Playground = {
+  render: () => (
+    <div className="flex min-h-96 flex-col gap-6 bg-doom-bg p-6">
+      <TooltipProvider>
+        <div className="grid grid-cols-4 items-center justify-items-center gap-6 py-24">
+          {SIDES.map((side) => (
+            <div key={side} className="flex flex-col items-center gap-2">
+              <Tooltip open>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="sm">
+                    {side}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side={side}>copies the run id</TooltipContent>
+              </Tooltip>
+              <span className="text-2xs text-doom-dim uppercase tracking-widest">side {side}</span>
+            </div>
+          ))}
+        </div>
+      </TooltipProvider>
+    </div>
+  ),
+};

--- a/packages/core/doompi-web-components/src/components/Tooltip.tsx
+++ b/packages/core/doompi-web-components/src/components/Tooltip.tsx
@@ -27,7 +27,7 @@ export function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          'z-50 rounded border border-doom-border bg-doom-deep px-2 py-1 font-mono text-[10px] text-doom-text shadow-lg data-[state=delayed-open]:animate-doom-fade',
+          'z-50 rounded border border-doom-border bg-doom-deep px-2 py-1 font-mono text-xs text-doom-text shadow-lg data-[state=delayed-open]:animate-doom-fade',
           className,
         )}
         {...props}

--- a/packages/core/doompi-web-components/style-system.config.yaml
+++ b/packages/core/doompi-web-components/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-components

--- a/packages/core/doompi-web-components/styles/preview.css
+++ b/packages/core/doompi-web-components/styles/preview.css
@@ -1,0 +1,17 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * This file exists because `styles/tokens.css` is the *consumer-facing* export:
+ * it deliberately does not pull in Tailwind, leaving that to whoever imports it.
+ * The screenshot renderer only injects `@import 'tailwindcss'` when a project
+ * configures no `cssFiles` at all, so a project that names one has to bring
+ * Tailwind itself.
+ *
+ * `@source` for the component sources is appended by the renderer, which scans
+ * `<appPath>/src`. That matters here because tokens.css scans `../dist`, which
+ * holds built output rather than the sources a story renders from.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-components`).
+ */
+@import 'tailwindcss';
+@import './tokens.css';

--- a/packages/core/doompi-web-components/styles/tokens.css
+++ b/packages/core/doompi-web-components/styles/tokens.css
@@ -122,6 +122,56 @@
 
   --font-mono: var(--doom-font-mono);
 
+  /*
+   * Type scale.
+   *
+   * Normalised from the nine ad-hoc sizes that had accumulated as `text-[Npx]`
+   * utilities. Tailwind's stock steps (12/14/16/18px) are too large for this
+   * 13px-base terminal UI, which is why they were routinely bypassed; these
+   * values deliberately override them so there is a single scale.
+   *
+   * Line heights are restated for every step. Overriding `--text-*` alone would
+   * leave Tailwind's default `--text-*--line-height` in place, pairing a stale
+   * leading with the new size.
+   */
+  --text-2xs: 9px;
+  --text-2xs--line-height: 1.45;
+  --text-xs: 10px;
+  --text-xs--line-height: 1.45;
+  --text-sm: 12px;
+  --text-sm--line-height: 1.45;
+  --text-base: 13px;
+  --text-base--line-height: 1.5;
+  --text-lg: 15px;
+  --text-lg--line-height: 1.4;
+
+  /* Tailwind's default spacing base, stated explicitly so the value is
+   * discoverable as a token rather than an implicit framework default. */
+  --spacing: 0.25rem;
+
+  /*
+   * Corner radii, tightened to the values this UI actually draws. Tailwind's
+   * stock steps (4/6/8px) sat just wide of the 2/3/5/10px the components were
+   * hand-rolling as `rounded-[Npx]`.
+   *
+   * Only `rounded-xs|sm|md|lg` read these. Bare `rounded`, `rounded-t|b`,
+   * `rounded-full` and `rounded-none` compile to hardcoded values and are not
+   * retunable, so the 4px of a bare `rounded` sits between sm and md by design.
+   */
+  --radius-xs: 2px;
+  --radius-sm: 3px;
+  --radius-md: 5px;
+  --radius-lg: 10px;
+
+  /*
+   * Letter spacing for the uppercase micro-labels this UI leans on. Tailwind's
+   * widest step is 0.1em, which is narrower than every tracking value in the
+   * codebase, so the whole ramp shifts wider rather than adding parallel names.
+   */
+  --tracking-wide: 0.08em;
+  --tracking-wider: 0.14em;
+  --tracking-widest: 0.18em;
+
   --animate-doom-fade: doom-fade 140ms ease-out;
   --animate-doom-pop: doom-pop 160ms cubic-bezier(0.16, 1, 0.3, 1);
   --animate-doom-rise: doom-rise 160ms cubic-bezier(0.16, 1, 0.3, 1);

--- a/packages/core/doompi-web-components/tests/components/render.test.tsx
+++ b/packages/core/doompi-web-components/tests/components/render.test.tsx
@@ -115,7 +115,7 @@ describe('primitives', () => {
     expect(html(<Input placeholder="p" />)).toContain('placeholder="p"');
     expect(html(<Textarea variant="bare" />)).toContain('bg-transparent');
     expect(html(<Kbd>SPC</Kbd>)).toContain('<kbd');
-    expect(html(<SectionLabel>sessions</SectionLabel>)).toContain('tracking-[0.18em]');
+    expect(html(<SectionLabel>sessions</SectionLabel>)).toContain('tracking-widest');
     expect(html(<Separator orientation="vertical" />)).toContain('data-orientation="vertical"');
     expect(html(<Spinner />)).toContain('animate-spin');
     expect(html(<StreamCursor />)).toContain('animate-doom-blink');

--- a/packages/core/doompi-web-components/vibe-lint.config.yaml
+++ b/packages/core/doompi-web-components/vibe-lint.config.yaml
@@ -15,6 +15,16 @@ ignore:
   - "dist/**"
   - "coverage/**"
 
+# Story files are read by the style-system renderer, which resolves the default
+# export by looking for a bare `const meta` declaration. Naming the export at
+# the point of definition breaks the render, so the export-shape rules are off
+# here. Every other rule, theming included, still applies to stories.
+overrides:
+  - files:
+      - "src/components/*.stories.tsx"
+    rules:
+      no-default-export: "off"
+      direct-export-only: "off"
 boundaries:
   - name: types
     pattern: src/types/**

--- a/packages/core/doompi-web-components/vitest.config.ts
+++ b/packages/core/doompi-web-components/vitest.config.ts
@@ -18,6 +18,10 @@ export const vitestConfig = defineConfig({
         'src/exports/',
         '**/*.d.ts',
         '**/*.config.*',
+        // Story files are render fixtures for the style-system screenshot
+        // pipeline, not shipped logic. They are never imported by the package
+        // entries and hold no behaviour a unit test could assert.
+        '**/*.stories.tsx',
         '**/coverage/**',
         // CodeMirror and xterm mount onto a real element and measure it, so
         // neither editor can be reached by server rendering. The modules under

--- a/packages/core/doompi/tests/fixtures/packageCompatibility.json
+++ b/packages/core/doompi/tests/fixtures/packageCompatibility.json
@@ -47,7 +47,8 @@
       "llms.txt",
       "README.md",
       "LICENSE",
-      "package.json"
+      "package.json",
+      "!src/web/**/*.stories.tsx"
     ],
     "os": [],
     "cpu": []
@@ -96,7 +97,8 @@
       "llms.txt",
       "README.md",
       "LICENSE",
-      "package.json"
+      "package.json",
+      "!src/web/**/*.stories.tsx"
     ],
     "os": [],
     "cpu": []
@@ -434,7 +436,7 @@
       "extensions": ["./dist/extensions/pi.mjs"]
     },
     "assets": [],
-    "files": ["dist", "src/web", "src/exports/webClient.ts"],
+    "files": ["dist", "src/web", "src/exports/webClient.ts", "!src/web/**/*.stories.tsx"],
     "os": [],
     "cpu": []
   },
@@ -741,7 +743,8 @@
       "src/types/domain.ts",
       "src/types/webFiles.ts",
       "src/types/fileEditsApi.ts",
-      "LICENSE"
+      "LICENSE",
+      "!src/web/**/*.stories.tsx"
     ],
     "os": [],
     "cpu": []
@@ -783,7 +786,8 @@
       "src/types/goal.ts",
       "README.md",
       "LICENSE",
-      "package.json"
+      "package.json",
+      "!src/web/**/*.stories.tsx"
     ],
     "os": [],
     "cpu": []
@@ -815,7 +819,7 @@
       "extensions": ["./dist/extensions/pi.mjs"]
     },
     "assets": [],
-    "files": ["dist", "src/web", "src/exports/webClient.ts"],
+    "files": ["dist", "src/web", "src/exports/webClient.ts", "!src/web/**/*.stories.tsx"],
     "os": [],
     "cpu": []
   },
@@ -970,7 +974,14 @@
       "extensions": ["./dist/extensions/pi.mjs"]
     },
     "assets": [],
-    "files": ["dist", "src/web", "src/exports/webClient.ts", "src/types/webMetrics.ts", "src/types/issueGrouping.ts"],
+    "files": [
+      "dist",
+      "src/web",
+      "src/exports/webClient.ts",
+      "src/types/webMetrics.ts",
+      "src/types/issueGrouping.ts",
+      "!src/web/**/*.stories.tsx"
+    ],
     "os": [],
     "cpu": []
   },
@@ -1010,7 +1021,8 @@
       "src/types/loopView.ts",
       "README.md",
       "LICENSE",
-      "package.json"
+      "package.json",
+      "!src/web/**/*.stories.tsx"
     ],
     "os": [],
     "cpu": []
@@ -1093,7 +1105,8 @@
       "src/prompts",
       "README.md",
       "LICENSE",
-      "package.json"
+      "package.json",
+      "!src/web/**/*.stories.tsx"
     ],
     "os": [],
     "cpu": []
@@ -1208,7 +1221,8 @@
       "src/types/planSettings.ts",
       "README.md",
       "LICENSE",
-      "package.json"
+      "package.json",
+      "!src/web/**/*.stories.tsx"
     ],
     "os": [],
     "cpu": []
@@ -1442,7 +1456,8 @@
       "llms.txt",
       "README.md",
       "LICENSE",
-      "package.json"
+      "package.json",
+      "!src/web/**/*.stories.tsx"
     ],
     "os": [],
     "cpu": []
@@ -1474,7 +1489,7 @@
       "extensions": ["./dist/extensions/pi.mjs"]
     },
     "assets": [],
-    "files": ["dist", "src/web", "src/exports/webClient.ts"],
+    "files": ["dist", "src/web", "src/exports/webClient.ts", "!src/web/**/*.stories.tsx"],
     "os": [],
     "cpu": []
   },
@@ -1829,7 +1844,8 @@
       "src/types/webRunnerLog.ts",
       "README.md",
       "LICENSE",
-      "package.json"
+      "package.json",
+      "!src/web/**/*.stories.tsx"
     ],
     "os": [],
     "cpu": []
@@ -2035,7 +2051,14 @@
       "extensions": ["./dist/extensions/pi.mjs"]
     },
     "assets": [],
-    "files": ["dist", "src/web", "src/exports/webClient.ts", "src/types/webTasks.ts", "package.json"],
+    "files": [
+      "dist",
+      "src/web",
+      "src/exports/webClient.ts",
+      "src/types/webTasks.ts",
+      "package.json",
+      "!src/web/**/*.stories.tsx"
+    ],
     "os": [],
     "cpu": []
   },
@@ -2072,7 +2095,7 @@
       "extensions": ["./dist/extensions/pi.mjs"]
     },
     "assets": [],
-    "files": ["dist", "src/web", "src/exports/webClient.ts", "src/types/webSubagents.ts"],
+    "files": ["dist", "src/web", "src/exports/webClient.ts", "src/types/webSubagents.ts", "!src/web/**/*.stories.tsx"],
     "os": [],
     "cpu": []
   },
@@ -2140,7 +2163,8 @@
       "src/types/questionnaire.ts",
       "README.md",
       "LICENSE",
-      "package.json"
+      "package.json",
+      "!src/web/**/*.stories.tsx"
     ],
     "os": [],
     "cpu": []
@@ -2312,7 +2336,7 @@
       "extensions": ["./dist/extensions/pi.mjs"]
     },
     "assets": ["./themes/doom-pi-dark.json"],
-    "files": ["dist", "src/web", "src/exports/webClient.ts", "themes"],
+    "files": ["dist", "src/web", "src/exports/webClient.ts", "themes", "!src/web/**/*.stories.tsx"],
     "os": [],
     "cpu": []
   },
@@ -2367,7 +2391,8 @@
       "src/types/manualTranscription.ts",
       "README.md",
       "LICENSE",
-      "package.json"
+      "package.json",
+      "!src/web/**/*.stories.tsx"
     ],
     "os": [],
     "cpu": []
@@ -2457,7 +2482,8 @@
       "src/web",
       "src/exports/webClient.ts",
       "src/types/webWorkflows.ts",
-      "src/types/webWorkflowTerminal.ts"
+      "src/types/webWorkflowTerminal.ts",
+      "!src/web/**/*.stories.tsx"
     ],
     "os": [],
     "cpu": []

--- a/packages/default/doompi-edit/package.json
+++ b/packages/default/doompi-edit/package.json
@@ -26,7 +26,8 @@
   "files": [
     "dist",
     "src/web",
-    "src/exports/webClient.ts"
+    "src/exports/webClient.ts",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -73,6 +74,7 @@
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "5.0.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsdown": "0.23.0",
     "typescript": "7.0.2",
     "vitest": "5.0.0"

--- a/packages/default/doompi-edit/src/web/components/EditToolMessage.stories.tsx
+++ b/packages/default/doompi-edit/src/web/components/EditToolMessage.stories.tsx
@@ -1,0 +1,76 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { EditToolMessage } from './EditToolMessage.tsx';
+
+// Pi's display diff: `+12 text`, `-12 text`, ` 12 text`, and an unnumbered
+// elision between hunks.
+const DIFF = [
+  ' 1 import { clsx, type ClassValue } from "clsx";',
+  ' 2 import { twMerge } from "tailwind-merge";',
+  ' ... ',
+  ' 5 export function cn(...inputs: ClassValue[]) {',
+  '-6   return twMerge(clsx(inputs));',
+  '+6   return twMerge(clsx(inputs), { cache: true });',
+  ' 7 }',
+].join('\n');
+
+const LONG_DIFF = Array.from({ length: 30 }, (_, index) => `+${String(index + 1)} const row = ${String(index)};`).join(
+  '\n',
+);
+
+const args = { path: 'src/lib/cn.ts', edits: [{ from: '5#usq', to: '6#eky' }] };
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'edit', ...overrides }).props;
+
+const meta = {
+  title: 'Edit/EditToolMessage',
+  component: EditToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <EditToolMessage {...props({ args, running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · banded diff rows</span>
+        <EditToolMessage {...props({ args, result: { content: [], details: { diff: DIFF } } })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · collapsed past 24 rows</span>
+        <EditToolMessage
+          {...props({
+            args: { path: 'src/lib/rows.ts', edits: [{ from: '1#aaa', to: '30#zzz' }] },
+            result: { content: [], details: { diff: LONG_DIFF } },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <EditToolMessage
+          {...props({
+            args: { path: 'src/lib/cn.ts', edits: [{ from: '5#usq', to: '6#eky' }] },
+            result: { content: [{ type: 'text', text: 'anchor 5#usq no longer matches the file' }], details: null },
+            output: 'anchor 5#usq no longer matches the file',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-edit/style-system.config.yaml
+++ b/packages/default/doompi-edit/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/default/doompi-edit/styles/preview.css
+++ b/packages/default/doompi-edit/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/default/doompi-edit/tests/packageContract.test.ts
+++ b/packages/default/doompi-edit/tests/packageContract.test.ts
@@ -86,7 +86,7 @@ describe('doompi-edit package contract', () => {
     const manifest = await readManifest();
     const exportsMap = manifest.exports ?? {};
     expect(exportsMap['./package.json']).toBeDefined();
-    expect(manifest.files).toEqual(['dist', 'src/web', 'src/exports/webClient.ts']);
+    expect(manifest.files).toEqual(['dist', 'src/web', 'src/exports/webClient.ts', '!src/web/**/*.stories.tsx']);
     expect(manifest.files).not.toContain('src');
     expect(manifest.files).not.toContain('tests');
     await expect(access(path.join(packageDirectory, 'dist'))).resolves.toBeUndefined();

--- a/packages/default/doompi-edit/vibe-lint.config.yaml
+++ b/packages/default/doompi-edit/vibe-lint.config.yaml
@@ -17,3 +17,14 @@ rules:
   no-raw-theme-color: error
   boundary-import-allowlist: error
   file-naming-convention: error
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/packages/default/doompi-file-edit/package.json
+++ b/packages/default/doompi-file-edit/package.json
@@ -32,7 +32,8 @@
     "src/types/domain.ts",
     "src/types/webFiles.ts",
     "src/types/fileEditsApi.ts",
-    "LICENSE"
+    "LICENSE",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/default/doompi-file-edit/src/web/components/CommentDraft.stories.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/CommentDraft.stories.tsx
@@ -1,0 +1,59 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ */
+import { CommentDraft } from './CommentDraft.tsx';
+
+const SNIPPET = [
+  'export function cn(...inputs: ClassValue[]) {',
+  '  const merged = twMerge(clsx(inputs));',
+  '  return merged;',
+  '}',
+].join('\n');
+
+const LONG_SNIPPET = Array.from({ length: 14 }, (_, index) => `  line ${index + 1} of a selection past the trim`).join(
+  '\n',
+);
+
+const noop = (): void => {};
+
+const meta = {
+  title: 'Files/CommentDraft',
+  component: CommentDraft,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">a line range</span>
+        <CommentDraft snippet={SNIPPET} startLine={12} endLine={15} onSubmit={noop} onCancel={noop} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">a single line</span>
+        <CommentDraft snippet="  return merged;" startLine={14} onSubmit={noop} onCancel={noop} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          no anchor · selected in the rendered preview
+        </span>
+        <CommentDraft
+          snippet="The cockpit serves any file under a session's working directory."
+          onSubmit={noop}
+          onCancel={noop}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">long selection · trimmed and scrolled</span>
+        <CommentDraft snippet={LONG_SNIPPET} startLine={40} endLine={53} onSubmit={noop} onCancel={noop} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-file-edit/src/web/components/CommentDraft.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/CommentDraft.tsx
@@ -29,8 +29,8 @@ export function CommentDraft({ snippet, startLine, endLine, onSubmit, onCancel }
 
   return (
     <div data-testid="files-comment-draft" className="flex flex-col gap-1.5 border-t border-doom-border p-2">
-      <p className="text-[9px] text-doom-faint">{range}</p>
-      <pre className="max-h-24 overflow-y-auto whitespace-pre-wrap break-words rounded border border-doom-border-soft bg-doom-deep p-1.5 font-mono text-[10px] text-doom-dim">
+      <p className="text-2xs text-doom-faint">{range}</p>
+      <pre className="max-h-24 overflow-y-auto whitespace-pre-wrap break-words rounded border border-doom-border-soft bg-doom-deep p-1.5 font-mono text-xs text-doom-dim">
         {trimSnippet(snippet, 8, 600)}
       </pre>
       <Textarea
@@ -46,7 +46,7 @@ export function CommentDraft({ snippet, startLine, endLine, onSubmit, onCancel }
           event.preventDefault();
           if (body.trim() !== '') onSubmit(body);
         }}
-        className="text-[11px]"
+        className="text-sm"
       />
       <div className="flex items-center gap-1.5">
         <Button
@@ -55,14 +55,14 @@ export function CommentDraft({ snippet, startLine, endLine, onSubmit, onCancel }
           data-testid="files-comment-add"
           disabled={body.trim() === ''}
           onClick={() => onSubmit(body)}
-          className="text-[9px]"
+          className="text-2xs"
         >
           add comment
         </Button>
-        <Button variant="ghost" size="xs" data-testid="files-comment-cancel" onClick={onCancel} className="text-[9px]">
+        <Button variant="ghost" size="xs" data-testid="files-comment-cancel" onClick={onCancel} className="text-2xs">
           cancel
         </Button>
-        <span className="text-[9px] text-doom-faint">⌘⏎ to add</span>
+        <span className="text-2xs text-doom-faint">⌘⏎ to add</span>
       </div>
     </div>
   );

--- a/packages/default/doompi-file-edit/src/web/components/DeleteFileDialog.stories.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/DeleteFileDialog.stories.tsx
@@ -1,0 +1,30 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * The dialog portals to the body, so only the open one is worth a variant: the
+ * closed dialog renders nothing at all.
+ */
+import { DeleteFileDialog } from './DeleteFileDialog.tsx';
+
+const noop = (): void => {};
+
+const meta = {
+  title: 'Files/DeleteFileDialog',
+  component: DeleteFileDialog,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">open · confirming a delete</span>
+        <DeleteFileDialog relPath="src/web/lib/fileView.ts" open onConfirm={noop} onCancel={noop} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-file-edit/src/web/components/DiffView.stories.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/DiffView.stories.tsx
@@ -1,0 +1,59 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ */
+import type { FileEditsDiffHunk } from '../../types/fileEditsApi.ts';
+import { DiffView } from './DiffView.tsx';
+
+const NEAR: FileEditsDiffHunk = {
+  start: 12,
+  rows: [
+    { marker: ' ', line: 12, content: 'export function cn(...inputs: ClassValue[]) {' },
+    { marker: '-', line: 13, content: '  return twMerge(clsx(inputs));' },
+    { marker: '+', line: 13, content: '  const merged = twMerge(clsx(inputs));' },
+    { marker: '+', line: 14, content: '  return merged;' },
+    { marker: ' ', line: 15, content: '}' },
+  ],
+};
+
+const FAR: FileEditsDiffHunk = {
+  start: 98,
+  rows: [
+    { marker: ' ', line: 98, content: 'const empty = { items: [], detail: {} };' },
+    { marker: '-', line: 99, content: 'export const files = defineStore(empty);' },
+    { marker: '+', line: 99, content: 'export const files = defineSessionStore(empty);' },
+    { marker: ' ', line: 100, content: '' },
+  ],
+};
+
+const meta = {
+  title: 'Files/DiffView',
+  component: DiffView,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          two hunks · the gap between them is a rule
+        </span>
+        <DiffView hunks={[NEAR, FAR]} testId="story-diff" />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">one hunk · three-digit gutter</span>
+        <DiffView hunks={[FAR]} testId="story-diff-single" />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">nothing changed</span>
+        <DiffView hunks={[]} testId="story-diff-empty" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-file-edit/src/web/components/DiffView.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/DiffView.tsx
@@ -49,7 +49,7 @@ export function DiffView({ hunks, testId, onSelect }: DiffViewProps) {
 
   if (hunks.length === 0) {
     return (
-      <p data-testid={`${testId}-empty`} className="px-2 py-1 text-[10px] text-doom-faint">
+      <p data-testid={`${testId}-empty`} className="px-2 py-1 text-xs text-doom-faint">
         no lines changed
       </p>
     );
@@ -60,12 +60,12 @@ export function DiffView({ hunks, testId, onSelect }: DiffViewProps) {
       data-testid={testId}
       data-diff-surface={testId}
       onMouseUp={handleSelect}
-      className="overflow-x-auto font-mono text-[11px] leading-[1.5]"
+      className="overflow-x-auto font-mono text-sm leading-normal"
     >
       {hunks.map((hunk, position) => (
         <div key={`${hunk.start}-${position}`}>
           {position > 0 ? (
-            <div className="flex items-center gap-2 px-2 py-0.5 text-[9px] text-doom-faint">
+            <div className="flex items-center gap-2 px-2 py-0.5 text-2xs text-doom-faint">
               <span className="h-px flex-1 bg-doom-border-soft" />
               <span>⋯</span>
               <span className="h-px flex-1 bg-doom-border-soft" />

--- a/packages/default/doompi-file-edit/src/web/components/FilePanel.stories.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/FilePanel.stories.tsx
@@ -1,0 +1,125 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * The panel fetches its own history on mount, so the story answers the detail
+ * route instead of pre-seeding the store: that is the state the panel actually
+ * reaches, error line and all, rather than one assembled behind its back. The
+ * diff and edit views are entered by clicking, which a static render cannot do,
+ * so what is covered here is the preview the tab opens on.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { FileEditsDetailView } from '../../types/fileEditsApi.ts';
+import { FilePanel } from './FilePanel.tsx';
+
+const AT = Date.parse('2024-05-04T10:00:00Z');
+
+const CODE = [
+  "import { clsx, type ClassValue } from 'clsx';",
+  "import { twMerge } from 'tailwind-merge';",
+  '',
+  'export function cn(...inputs: ClassValue[]) {',
+  '  const merged = twMerge(clsx(inputs));',
+  '  return merged;',
+  '}',
+].join('\n');
+
+const MARKDOWN = [
+  '# doompi-file-edit',
+  '',
+  'Every file this session changed, with its history and a way to fix a line.',
+  '',
+  '- `detail` answers one file in a single round trip',
+  '- `content` takes the manual save back',
+  '- `preview` reads a file the session never changed',
+].join('\n');
+
+function detailOf(relPath: string, overrides: Partial<FileEditsDetailView> = {}): FileEditsDetailView {
+  return {
+    path: `/Users/dev/project/${relPath}`,
+    relPath,
+    versions: [
+      { index: 1, tool: 'write', at: AT, origin: 'tool', additions: 7, removals: 0 },
+      { index: 2, tool: 'edit', at: AT + 60_000, origin: 'tool', additions: 2, removals: 1 },
+    ],
+    cumulative: { additions: 9, removals: 1 },
+    working: { content: CODE, hash: 'a1b2c3d4', unavailable: false },
+    ...overrides,
+  };
+}
+
+const DETAILS: Record<string, FileEditsDetailView | undefined> = {
+  '/Users/dev/project/src/web/lib/cn.ts': detailOf('src/web/lib/cn.ts'),
+  '/Users/dev/project/README.md': detailOf('README.md', {
+    working: { content: MARKDOWN, hash: 'e5f6a7b8', unavailable: false },
+  }),
+  '/Users/dev/project/src/data/index.bin': detailOf('src/data/index.bin', {
+    cumulative: { additions: 0, removals: 0, note: 'no baseline was captured for this file' },
+    working: {
+      content: '',
+      hash: '',
+      unavailable: true,
+      reason: 'this file is binary, so its text was not captured',
+    },
+  }),
+};
+
+/**
+ * The session API, answered in the page. `sealedTransport.fetch` is a
+ * pass-through off a tunnel, so replacing the global is the one seam that
+ * covers every route the panel reaches; anything unrecognised falls through to
+ * the real one so the renderer's own requests still work.
+ */
+const realFetch = globalThis.fetch.bind(globalThis);
+globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = String(input instanceof Request ? input.url : input);
+  const filePath = new URL(url, globalThis.location.origin).searchParams.get('path') ?? '';
+  const detail = DETAILS[filePath];
+  if (url.includes('/api/plugin/file-edits/detail') && detail !== undefined) {
+    return Promise.resolve(new Response(JSON.stringify(detail), { status: 200 }));
+  }
+  if (url.includes('/api/sessions/')) {
+    return Promise.resolve(new Response(new Blob(['\u0000\u0001binary'], { type: 'application/octet-stream' })));
+  }
+  return realFetch(input, init);
+};
+
+const slot = slotPropsFixture({ sessionId: 's1' }).props;
+
+const meta = {
+  title: 'Files/FilePanel',
+  component: FilePanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">code · preview holds the editor open</span>
+        <div className="flex h-96 flex-col border border-doom-border-soft">
+          <FilePanel {...slot} filePath="/Users/dev/project/src/web/lib/cn.ts" relPath="src/web/lib/cn.ts" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">markdown · rendered, not diffed</span>
+        <div className="flex h-96 flex-col border border-doom-border-soft">
+          <FilePanel {...slot} filePath="/Users/dev/project/README.md" relPath="README.md" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          binary · the reason is said and the bytes are offered anyway
+        </span>
+        <div className="flex h-96 flex-col border border-doom-border-soft">
+          <FilePanel {...slot} filePath="/Users/dev/project/src/data/index.bin" relPath="src/data/index.bin" />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-file-edit/src/web/components/FilePanel.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/FilePanel.tsx
@@ -193,12 +193,12 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
         {/* Edit is not one of the header's two toggles, so with neither lit the
             mode needs saying; picking either toggle leaves it. */}
         {view === 'edit' ? (
-          <Badge tone="neutral" data-testid="files-editing" className="shrink-0 text-[8px]">
+          <Badge tone="neutral" data-testid="files-editing" className="shrink-0 text-2xs">
             editing
           </Badge>
         ) : null}
         {detail === undefined ? null : (
-          <span className="shrink-0 text-[9px] text-doom-faint">
+          <span className="shrink-0 text-2xs text-doom-faint">
             +{detail.cumulative.additions} -{detail.cumulative.removals}
           </span>
         )}
@@ -213,7 +213,7 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
               size="xs"
               data-testid={`files-view-${entry}`}
               onClick={() => setView(entry)}
-              className="text-[9px]"
+              className="text-2xs"
             >
               {entry}
             </Button>
@@ -262,12 +262,12 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
       />
 
       {loading && detail === undefined ? (
-        <p data-testid="files-loading" className="px-4 py-3 text-[11px] text-doom-faint">
+        <p data-testid="files-loading" className="px-4 py-3 text-sm text-doom-faint">
           reading this file's history…
         </p>
       ) : null}
       {error === undefined ? null : (
-        <p data-testid="files-error" className="px-4 py-3 text-[11px] text-doom-red">
+        <p data-testid="files-error" className="px-4 py-3 text-sm text-doom-red">
           {error}
         </p>
       )}
@@ -276,7 +276,7 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
         {detail === undefined ? null : view === 'diff' ? (
           <div className="flex flex-col">
             {detail.cumulative.note === undefined ? null : (
-              <p data-testid="files-cumulative-note" className="px-4 py-2 text-[10px] text-doom-yellow">
+              <p data-testid="files-cumulative-note" className="px-4 py-2 text-xs text-doom-yellow">
                 {detail.cumulative.note}
               </p>
             )}
@@ -288,7 +288,7 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
               />
             )}
             <section className="mt-2 border-t border-doom-border">
-              <h2 className="px-4 py-2 text-[10px] font-bold tracking-wide text-doom-faint uppercase">
+              <h2 className="px-4 py-2 text-xs font-bold tracking-wide text-doom-faint uppercase">
                 {detail.versions.length} {detail.versions.length === 1 ? 'change' : 'changes'} this session
               </h2>
               {detail.versions.map((version) => (
@@ -301,22 +301,22 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
                     className="w-full gap-2 rounded-none px-4 py-1.5 hover:bg-doom-panel"
                   >
                     <span className="flex w-full min-w-0 items-center gap-2">
-                      <span className="shrink-0 text-[9px] text-doom-faint">#{version.index}</span>
-                      <span className="min-w-0 flex-1 truncate text-left text-[10px] text-doom-text">
+                      <span className="shrink-0 text-2xs text-doom-faint">#{version.index}</span>
+                      <span className="min-w-0 flex-1 truncate text-left text-xs text-doom-text">
                         {versionSummary(version)}
                       </span>
                       {version.origin === 'scan' ? (
-                        <Badge tone="neutral" className="shrink-0 text-[8px]">
+                        <Badge tone="neutral" className="shrink-0 text-2xs">
                           no baseline
                         </Badge>
                       ) : null}
-                      <span className="shrink-0 text-[9px] text-doom-faint">
+                      <span className="shrink-0 text-2xs text-doom-faint">
                         {expanded === version.index ? '▾' : '▸'}
                       </span>
                     </span>
                   </Button>
                   {expanded !== version.index ? null : version.hunks === undefined ? (
-                    <p className="px-4 py-1.5 text-[10px] text-doom-faint">{version.note ?? 'nothing to show'}</p>
+                    <p className="px-4 py-1.5 text-xs text-doom-faint">{version.note ?? 'nothing to show'}</p>
                   ) : (
                     <DiffView
                       hunks={version.hunks}
@@ -331,7 +331,7 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
         ) : view === 'edit' ? (
           <div className="flex h-full flex-col gap-2 p-3">
             {working?.unavailable === true ? (
-              <p data-testid="files-source-unavailable" className="text-[11px] text-doom-faint">
+              <p data-testid="files-source-unavailable" className="text-sm text-doom-faint">
                 {working.reason ?? 'this file cannot be shown'}
               </p>
             ) : (
@@ -365,7 +365,7 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
                     loading={saving}
                     disabled={source === undefined || saving}
                     onClick={() => void save()}
-                    className="text-[9px]"
+                    className="text-2xs"
                   >
                     save to disk
                   </Button>
@@ -375,7 +375,7 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
                       size="xs"
                       data-testid="files-revert"
                       onClick={() => setSource(undefined)}
-                      className="text-[9px]"
+                      className="text-2xs"
                     >
                       discard edits
                     </Button>
@@ -383,7 +383,7 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
                   {saveNote === undefined ? null : (
                     <span
                       data-testid="files-save-note"
-                      className={saveNote === 'saved' ? 'text-[9px] text-doom-green' : 'text-[9px] text-doom-red'}
+                      className={saveNote === 'saved' ? 'text-2xs text-doom-green' : 'text-2xs text-doom-red'}
                     >
                       {saveNote}
                     </span>
@@ -398,8 +398,8 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
             data-mode={previewMode}
             className={
               previewMode === 'code'
-                ? 'flex h-full flex-col gap-2 p-4 text-[12px] text-doom-text'
-                : 'flex flex-col gap-2 p-4 text-[12px] text-doom-text'
+                ? 'flex h-full flex-col gap-2 p-4 text-sm text-doom-text'
+                : 'flex flex-col gap-2 p-4 text-sm text-doom-text'
             }
             onMouseUp={() => {
               // Highlighted source knows which lines were picked, so a note on
@@ -417,7 +417,7 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
             {/* A file the editor cannot hold is still a file the reader came
                 to see, so the reason is said and the bytes are shown anyway. */}
             {previewMode === 'unavailable' ? (
-              <p data-testid="files-preview-unavailable" className="text-[11px] text-doom-faint">
+              <p data-testid="files-preview-unavailable" className="text-sm text-doom-faint">
                 {working?.reason ?? 'this file cannot be shown'}
               </p>
             ) : null}
@@ -453,7 +453,7 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
               // reading view rather than an empty pane.
               <pre
                 data-testid="files-preview-text"
-                className="whitespace-pre-wrap break-words font-mono text-[11px] leading-[1.5] text-doom-text"
+                className="whitespace-pre-wrap break-words font-mono text-sm leading-normal text-doom-text"
               >
                 {content}
               </pre>
@@ -475,7 +475,7 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
       {comments.length === 0 ? null : (
         <footer data-testid="files-review" className="shrink-0 border-t border-doom-border px-3 py-2">
           <div className="flex items-center gap-2 pb-1">
-            <span className="flex-1 text-[10px] font-bold text-doom-hi">
+            <span className="flex-1 text-xs font-bold text-doom-hi">
               {comments.length} {comments.length === 1 ? 'comment' : 'comments'}
             </span>
             <Button
@@ -483,15 +483,15 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
               size="xs"
               data-testid="files-send-review"
               onClick={sendReview}
-              className="text-[9px]"
+              className="text-2xs"
             >
               send review
             </Button>
           </div>
           {comments.map((comment) => (
             <div key={comment.id} data-testid="files-review-comment" className="flex items-start gap-2 py-0.5">
-              <span className="shrink-0 text-[9px] text-doom-faint">{commentAnchor(comment)}</span>
-              <span className="min-w-0 flex-1 truncate text-[10px] text-doom-text">{comment.body}</span>
+              <span className="shrink-0 text-2xs text-doom-faint">{commentAnchor(comment)}</span>
+              <span className="min-w-0 flex-1 truncate text-xs text-doom-text">{comment.body}</span>
               <Button
                 variant="ghost"
                 size="xs"
@@ -499,7 +499,7 @@ export function FilePanel({ filePath, relPath, sessionId, sendSessionFrame, clos
                 onClick={() => {
                   if (sessionId !== null) removeComment(sessionId, comment.id);
                 }}
-                className="shrink-0 text-[9px]"
+                className="shrink-0 text-2xs"
               >
                 remove
               </Button>

--- a/packages/default/doompi-file-edit/src/web/components/FilePreviewPanel.stories.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/FilePreviewPanel.stories.tsx
@@ -1,0 +1,104 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * The panel has no store: everything it shows comes from one fetch, so the
+ * story answers the preview route and each variant is a different file.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { FileEditsPreviewView } from '../../types/fileEditsApi.ts';
+import { FilePreviewPanel } from './FilePreviewPanel.tsx';
+
+const CODE = [
+  "export const filesChannelType = 'file_edits';",
+  '',
+  '/** Footer status key whose presence shows the activity group. */',
+  "export const filesStatusKey = 'doom-file-edit-files';",
+].join('\n');
+
+const MARKDOWN = [
+  '## reading a file the session never changed',
+  '',
+  'One view, the file as it stands, and nothing else.',
+].join('\n');
+
+function previewOf(relPath: string, content: string): FileEditsPreviewView {
+  return {
+    path: `/Users/dev/project/${relPath}`,
+    relPath,
+    working: { content, hash: 'c0ffee', unavailable: false },
+  };
+}
+
+const PREVIEWS: Record<string, FileEditsPreviewView | undefined> = {
+  '/Users/dev/project/src/types/webFiles.ts': previewOf('src/types/webFiles.ts', CODE),
+  '/Users/dev/project/NOTES.md': previewOf('NOTES.md', MARKDOWN),
+};
+
+/** Never settles, so the panel stays on its loading line for the shot. */
+const PENDING_PATH = '/Users/dev/project/src/slow.ts';
+
+/**
+ * The session API, answered in the page. `sealedTransport.fetch` is a
+ * pass-through off a tunnel, so replacing the global covers the route the panel
+ * reaches; anything unrecognised falls through to the real one.
+ */
+const realFetch = globalThis.fetch.bind(globalThis);
+globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = String(input instanceof Request ? input.url : input);
+  if (!url.includes('/api/plugin/file-edits/preview')) return realFetch(input, init);
+  const filePath = new URL(url, globalThis.location.origin).searchParams.get('path') ?? '';
+  if (filePath === PENDING_PATH) return new Promise<Response>(() => {});
+  const preview = PREVIEWS[filePath];
+  if (preview === undefined) {
+    return Promise.resolve(
+      new Response(JSON.stringify({ error: 'that path is outside the session working directory' }), { status: 403 }),
+    );
+  }
+  return Promise.resolve(new Response(JSON.stringify(preview), { status: 200 }));
+};
+
+const slot = slotPropsFixture({ sessionId: 's1' }).props;
+
+const meta = {
+  title: 'Files/FilePreviewPanel',
+  component: FilePreviewPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">code · read-only, marked unchanged</span>
+        <div className="flex h-96 flex-col border border-doom-border-soft">
+          <FilePreviewPanel {...slot} filePath="/Users/dev/project/src/types/webFiles.ts" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">markdown · rendered</span>
+        <div className="flex h-64 flex-col border border-doom-border-soft">
+          <FilePreviewPanel {...slot} filePath="/Users/dev/project/NOTES.md" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">still reading</span>
+        <div className="flex flex-col border border-doom-border-soft">
+          <FilePreviewPanel {...slot} filePath={PENDING_PATH} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">the route refused</span>
+        <div className="flex flex-col border border-doom-border-soft">
+          <FilePreviewPanel {...slot} filePath="/etc/passwd" />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-file-edit/src/web/components/FilePreviewPanel.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/FilePreviewPanel.tsx
@@ -62,25 +62,25 @@ export function FilePreviewPanel({ filePath, sessionId, closeTransientTab }: Fil
     <div data-testid="files-preview-panel" className="flex min-h-0 flex-1 flex-col">
       <header className="flex shrink-0 items-center gap-2 border-b border-doom-border px-4 py-2">
         <Breadcrumb path={relPath} data-testid="files-preview-breadcrumb" className="min-w-0 flex-1" />
-        <span className="shrink-0 text-[9px] text-doom-faint">unchanged</span>
+        <span className="shrink-0 text-2xs text-doom-faint">unchanged</span>
         <Button
           variant="ghost"
           size="xs"
           data-testid="files-preview-close"
           onClick={() => closeTransientTab(filePreviewTabId(filePath))}
-          className="shrink-0 text-[9px]"
+          className="shrink-0 text-2xs"
         >
           close
         </Button>
       </header>
 
       {error === undefined ? null : (
-        <p data-testid="files-preview-error" className="px-4 py-3 text-[11px] text-doom-red">
+        <p data-testid="files-preview-error" className="px-4 py-3 text-sm text-doom-red">
           {error}
         </p>
       )}
       {preview === undefined && error === undefined ? (
-        <p data-testid="files-preview-loading" className="px-4 py-3 text-[11px] text-doom-faint">
+        <p data-testid="files-preview-loading" className="px-4 py-3 text-sm text-doom-faint">
           reading this file…
         </p>
       ) : null}
@@ -90,10 +90,10 @@ export function FilePreviewPanel({ filePath, sessionId, closeTransientTab }: Fil
           <div
             data-testid="files-preview"
             data-mode={previewMode}
-            className="flex h-full flex-col gap-2 p-4 text-[12px] text-doom-text"
+            className="flex h-full flex-col gap-2 p-4 text-sm text-doom-text"
           >
             {previewMode === 'unavailable' ? (
-              <p data-testid="files-preview-unavailable" className="text-[11px] text-doom-faint">
+              <p data-testid="files-preview-unavailable" className="text-sm text-doom-faint">
                 {working?.reason ?? 'this file cannot be shown'}
               </p>
             ) : null}
@@ -120,7 +120,7 @@ export function FilePreviewPanel({ filePath, sessionId, closeTransientTab }: Fil
             ) : (
               <pre
                 data-testid="files-preview-text"
-                className="whitespace-pre-wrap break-words font-mono text-[11px] leading-[1.5] text-doom-text"
+                className="whitespace-pre-wrap break-words font-mono text-sm leading-normal text-doom-text"
               >
                 {content}
               </pre>

--- a/packages/default/doompi-file-edit/src/web/components/FilesActivitySection.stories.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/FilesActivitySection.stories.tsx
@@ -1,0 +1,76 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * The section reads the session store rather than props, so each variant is a
+ * different session id seeded before the render runs.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { FilesItemView } from '../../types/webFiles.ts';
+import { FilesActivitySection } from './FilesActivitySection.tsx';
+import { files } from '../stores/filesStore.ts';
+
+const NOW = Date.parse('2024-05-04T10:00:00Z');
+
+function item(relPath: string, overrides: Partial<FilesItemView> = {}): FilesItemView {
+  return {
+    path: `/Users/dev/project/${relPath}`,
+    relPath,
+    tool: 'edit',
+    at: NOW,
+    count: 1,
+    diffable: true,
+    ...overrides,
+  };
+}
+
+const FEW: FilesItemView[] = [
+  item('src/web/components/FilePanel.tsx', { count: 4 }),
+  item('src/web/lib/fileView.ts', { tool: 'write' }),
+  item('dist/index.js', { tool: 'bash', diffable: false }),
+];
+
+const MANY: FilesItemView[] = [
+  ...FEW,
+  item('src/types/fileEditsApi.ts'),
+  item('src/web/api/filesApi.ts', { count: 2 }),
+  item('tests/unit/fileView.test.ts', { tool: 'user' }),
+  item('README.md'),
+];
+
+files.update('files-few', (current) => ({ ...current, items: FEW }));
+files.update('files-many', (current) => ({ ...current, items: MANY }));
+
+const slot = (sessionId: string) => slotPropsFixture({ sessionId }).props;
+
+const meta = {
+  title: 'Files/FilesActivitySection',
+  component: FilesActivitySection,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex max-w-md flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">nothing changed yet</span>
+        <FilesActivitySection {...slot('files-empty')} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">three files · one changed by a command</span>
+        <FilesActivitySection {...slot('files-few')} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          more than fits · five rows and the show-all link
+        </span>
+        <FilesActivitySection {...slot('files-many')} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-file-edit/src/web/components/FilesActivitySection.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/FilesActivitySection.tsx
@@ -30,7 +30,7 @@ export function FilesActivitySection({ sessionId, openTransientTab }: WebPluginS
   };
   if (items.length === 0) {
     return (
-      <p data-testid="activity-summary-files" className="px-1 text-[10px] text-doom-faint">
+      <p data-testid="activity-summary-files" className="px-1 text-xs text-doom-faint">
         nothing changed yet
       </p>
     );
@@ -49,7 +49,7 @@ export function FilesActivitySection({ sessionId, openTransientTab }: WebPluginS
           size="xs"
           data-testid="activity-files-show-all"
           aria-label={`show all ${items.length} changed files`}
-          className="self-start px-1 pt-0.5 text-[9px] text-doom-faint"
+          className="self-start px-1 pt-0.5 text-2xs text-doom-faint"
           onClick={() => setBrowserOpen(true)}
         >
           show all {items.length} files

--- a/packages/default/doompi-file-edit/src/web/components/FilesBrowser.stories.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/FilesBrowser.stories.tsx
@@ -1,0 +1,67 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ */
+import type { FilesItemView } from '../../types/webFiles.ts';
+import { FileActivityRow, FilesBrowser } from './FilesBrowser.tsx';
+
+const NOW = Date.parse('2024-05-04T10:00:00Z');
+
+function item(relPath: string, overrides: Partial<FilesItemView> = {}): FilesItemView {
+  return {
+    path: `/Users/dev/project/${relPath}`,
+    relPath,
+    tool: 'edit',
+    at: NOW,
+    count: 1,
+    diffable: true,
+    ...overrides,
+  };
+}
+
+/** A file found by comparing the tree around a bash call: openable, but never diffable. */
+const SCANNED = item('dist/index.js', { tool: 'bash', diffable: false });
+
+/** Several directories, a repeat, and the scan-found file, newest change first. */
+const ITEMS: FilesItemView[] = [
+  item('src/web/components/FilePanel.tsx', { count: 4 }),
+  item('src/web/components/DiffView.tsx', { tool: 'write' }),
+  item('src/web/lib/fileView.ts', { count: 2 }),
+  item('src/types/fileEditsApi.ts'),
+  item('tests/unit/fileView.test.ts', { tool: 'user' }),
+  SCANNED,
+  item('README.md'),
+];
+
+const noop = (): void => {};
+
+const meta = {
+  title: 'Files/FilesBrowser',
+  component: FilesBrowser,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex min-h-screen flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex max-w-md flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">activity rows · the dock's own list</span>
+        <div className="flex flex-col gap-0.5">
+          {ITEMS.slice(0, 4).map((entry) => (
+            <FileActivityRow key={entry.path} item={entry} onOpen={noop} />
+          ))}
+          <FileActivityRow item={SCANNED} onOpen={noop} />
+        </div>
+      </div>
+
+      <span className="max-w-md text-2xs text-doom-dim uppercase tracking-widest">
+        drawer · grouped by path, newest change marked, pinned to the right edge
+      </span>
+
+      <FilesBrowser items={ITEMS} onClose={noop} onOpen={noop} />
+    </div>
+  ),
+};

--- a/packages/default/doompi-file-edit/src/web/components/FilesBrowser.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/FilesBrowser.tsx
@@ -9,16 +9,14 @@ function FileMetadata({ item, label, recent = false }: { item: FilesItemView; la
     <span className="flex min-w-0 w-full items-center gap-1.5">
       {/* The dock passes no label and keeps the whole path; the drawer's tree
           passes what its group header has not already said. */}
-      <span className="min-w-0 flex-1 truncate text-left text-[10px] font-bold text-doom-hi">
-        {label ?? item.relPath}
-      </span>
+      <span className="min-w-0 flex-1 truncate text-left text-xs font-bold text-doom-hi">{label ?? item.relPath}</span>
       {recent ? (
-        <span data-recent="true" title="most recent change" className="shrink-0 text-[9px] text-doom-blue">
+        <span data-recent="true" title="most recent change" className="shrink-0 text-2xs text-doom-blue">
           ●
         </span>
       ) : null}
-      {item.count > 1 ? <span className="shrink-0 text-[9px] text-doom-faint">{item.count}×</span> : null}
-      <span className={`shrink-0 text-[9px] ${item.diffable ? 'text-doom-faint' : 'text-doom-yellow'}`}>
+      {item.count > 1 ? <span className="shrink-0 text-2xs text-doom-faint">{item.count}×</span> : null}
+      <span className={`shrink-0 text-2xs ${item.diffable ? 'text-doom-faint' : 'text-doom-yellow'}`}>
         {TOOL_LABEL[item.tool] ?? item.tool}
       </span>
     </span>
@@ -34,7 +32,7 @@ export function FileActivityRow({ item, onOpen }: { item: FilesItemView; onOpen:
       data-file-diffable={item.diffable}
       title={item.diffable ? item.path : `${item.path} (changed by a command, so no diff was captured)`}
       onClick={onOpen}
-      className="min-w-0 gap-0.5 rounded-[5px] px-1 py-1 hover:bg-doom-panel"
+      className="min-w-0 gap-0.5 rounded-md px-1 py-1 hover:bg-doom-panel"
     >
       <FileMetadata item={item} />
     </Button>
@@ -52,7 +50,7 @@ function FileGroupHeader({ prefix }: { prefix: string }) {
   return (
     <div
       data-testid={`files-browser-group-${prefix}`}
-      className="truncate px-4 pt-2 pb-1 text-[9px] font-bold tracking-wide text-doom-faint"
+      className="truncate px-4 pt-2 pb-1 text-2xs font-bold tracking-wide text-doom-faint"
     >
       {prefix}
     </div>
@@ -170,8 +168,8 @@ export function FilesBrowser({
       className="fixed inset-y-0 right-0 z-50 flex w-[min(440px,calc(100vw-24px))] flex-col overflow-hidden border-l border-doom-border bg-doom-rail outline-none"
     >
       <div className="flex h-11 shrink-0 items-center gap-2.5 border-b border-doom-border px-4">
-        <span className="text-[13px] font-bold text-doom-hi"># files</span>
-        <span data-testid="files-browser-total" className="text-[9px] text-doom-faint">
+        <span className="text-base font-bold text-doom-hi"># files</span>
+        <span data-testid="files-browser-total" className="text-2xs text-doom-faint">
           {items.length} changed
         </span>
         <span className="min-w-0 flex-1" />
@@ -215,7 +213,7 @@ export function FilesBrowser({
           </Button>
         ) : null}
       </div>
-      <p data-testid="files-browser-matches" className="shrink-0 px-4 pb-2 text-[9px] text-doom-faint">
+      <p data-testid="files-browser-matches" className="shrink-0 px-4 pb-2 text-2xs text-doom-faint">
         {shown.length} matches · {grouped === undefined ? 'newest change first' : 'by path'}
       </p>
       <div
@@ -224,7 +222,7 @@ export function FilesBrowser({
         aria-label="changed files"
         className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-2"
       >
-        {shown.length === 0 ? <p className="px-4 py-3 text-[10px] text-doom-faint">nothing matches the path</p> : null}
+        {shown.length === 0 ? <p className="px-4 py-3 text-xs text-doom-faint">nothing matches the path</p> : null}
         {grouped === undefined
           ? shown.map((item) => (
               <BrowserFileRow
@@ -256,7 +254,7 @@ export function FilesBrowser({
             ))}
       </div>
       <div className="flex h-8 shrink-0 items-center border-t border-doom-border-soft bg-doom-deep px-4">
-        <span className="text-[9px] text-doom-faint">↑↓ choose · enter open · esc close</span>
+        <span className="text-2xs text-doom-faint">↑↓ choose · enter open · esc close</span>
       </div>
     </aside>
   );

--- a/packages/default/doompi-file-edit/src/web/components/SessionMediaPreview.stories.tsx
+++ b/packages/default/doompi-file-edit/src/web/components/SessionMediaPreview.stories.tsx
@@ -1,0 +1,79 @@
+/*
+ * Plain CSF objects; the style-system renderer parses these files statically
+ * and mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * The component exists because a media element cannot issue the encrypted fetch
+ * a remote session file needs, so the story answers that fetch and shows the
+ * three states it settles into.
+ */
+import { SessionMediaPreview } from './SessionMediaPreview.tsx';
+
+const SVG = [
+  '<svg xmlns="http://www.w3.org/2000/svg" width="240" height="120" viewBox="0 0 240 120">',
+  '<rect width="240" height="120" fill="#1c2027"/>',
+  '<circle cx="72" cy="60" r="34" fill="#7fd1c1"/>',
+  '<rect x="128" y="38" width="84" height="44" rx="6" fill="#c8a2ff"/>',
+  '</svg>',
+].join('');
+
+const IMAGE_SRC = '/api/sessions/s1/file?path=assets/logo.svg';
+const DOWNLOAD_SRC = '/api/sessions/s1/file?path=assets/bundle.zip';
+
+/**
+ * `sealedTransport.fetch` is a pass-through off a tunnel, so replacing the
+ * global is the seam that stands in for the session's bytes route; anything
+ * unrecognised falls through to the real one.
+ */
+const realFetch = globalThis.fetch.bind(globalThis);
+globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = String(input instanceof Request ? input.url : input);
+  if (url === IMAGE_SRC) {
+    return Promise.resolve(new Response(new Blob([SVG], { type: 'image/svg+xml' })));
+  }
+  if (url === DOWNLOAD_SRC) {
+    return Promise.resolve(new Response(new Blob(['PK\u0003\u0004'], { type: 'application/zip' })));
+  }
+  if (url.startsWith('/api/sessions/')) return Promise.resolve(new Response('not found', { status: 404 }));
+  return realFetch(input, init);
+};
+
+const meta = {
+  title: 'Files/SessionMediaPreview',
+  component: SessionMediaPreview,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6 text-sm text-doom-text">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">an image the browser can show</span>
+        <SessionMediaPreview src={IMAGE_SRC} path="assets/logo.svg" data-testid="story-media-image" />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          a format it cannot · the honest download
+        </span>
+        <SessionMediaPreview src={DOWNLOAD_SRC} path="assets/bundle.zip" data-testid="story-media-download" />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">the route refused</span>
+        <SessionMediaPreview
+          src="/api/sessions/s1/file?path=assets/missing.png"
+          path="assets/missing.png"
+          data-testid="story-media-error"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no source yet</span>
+        <SessionMediaPreview src="" path="assets/logo.svg" data-testid="story-media-loading" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-file-edit/style-system.config.yaml
+++ b/packages/default/doompi-file-edit/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/default/doompi-file-edit/styles/preview.css
+++ b/packages/default/doompi-file-edit/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/default/doompi-file-edit/vibe-lint.config.yaml
+++ b/packages/default/doompi-file-edit/vibe-lint.config.yaml
@@ -17,3 +17,14 @@ rules:
   no-raw-theme-color: error
   boundary-import-allowlist: error
   file-naming-convention: error
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/packages/default/doompi-grep/package.json
+++ b/packages/default/doompi-grep/package.json
@@ -27,7 +27,8 @@
   "files": [
     "dist",
     "src/web",
-    "src/exports/webClient.ts"
+    "src/exports/webClient.ts",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -75,6 +76,7 @@
     "@vitest/coverage-v8": "5.0.0",
     "@vscode/ripgrep": "1.18.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsdown": "0.23.0",
     "typescript": "7.0.2",
     "vitest": "5.0.0"

--- a/packages/default/doompi-grep/src/web/components/GrepToolMessage.stories.tsx
+++ b/packages/default/doompi-grep/src/web/components/GrepToolMessage.stories.tsx
@@ -1,0 +1,86 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { GrepToolMessage } from './GrepToolMessage.tsx';
+
+const MATCHES = [
+  '@file src/lib/cn.ts#a1b2c3d4',
+  '   3#rew|',
+  '>> 4#nsj|export function cn(...inputs: ClassValue[]) {',
+  '   5#usq|  return twMerge(clsx(inputs));',
+  '@file src/lib/theme.ts#9f8e7d6c',
+  '>> 12#pqr|export function cnTheme(name: string) {',
+  '[2 matches in 2 files]',
+].join('\n');
+
+const text = (value: string) => ({ content: [{ type: 'text', text: value }], details: null });
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'grep', ...overrides }).props;
+
+/*
+ * The card is collapsed until someone clicks it and the renderer only takes a
+ * screenshot, so every result body here would be invisible. Opening the card
+ * from a mount ref is what puts the body in the shot; the collapsed header is
+ * shown once on its own so both states are reviewable.
+ */
+const openCard = (node: HTMLDivElement | null) =>
+  node?.querySelector<HTMLButtonElement>('[data-testid="tool-expand"]')?.click();
+
+const meta = {
+  title: 'Grep/GrepToolMessage',
+  component: GrepToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">collapsed · the default</span>
+        <GrepToolMessage
+          {...props({ args: { pattern: 'export function cn', path: 'src/lib' }, result: text(MATCHES) })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2" ref={openCard}>
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <GrepToolMessage {...props({ args: { pattern: 'export function cn' }, running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2" ref={openCard}>
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">expanded · matches and context</span>
+        <GrepToolMessage
+          {...props({
+            args: { pattern: 'export function cn', path: 'src/lib', glob: '*.ts', ignoreCase: true, limit: 20 },
+            result: text(MATCHES),
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2" ref={openCard}>
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">expanded · nothing found</span>
+        <GrepToolMessage {...props({ args: { pattern: 'zzzz', path: 'src' }, result: text('[no matches]') })} />
+      </div>
+
+      <div className="flex flex-col gap-2" ref={openCard}>
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <GrepToolMessage
+          {...props({
+            args: { pattern: '(unclosed' },
+            result: text('regex parse error: unclosed group'),
+            output: 'regex parse error: unclosed group',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-grep/style-system.config.yaml
+++ b/packages/default/doompi-grep/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/default/doompi-grep/styles/preview.css
+++ b/packages/default/doompi-grep/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/default/doompi-grep/tests/packageContract.test.ts
+++ b/packages/default/doompi-grep/tests/packageContract.test.ts
@@ -93,7 +93,7 @@ describe('doompi-grep package contract', () => {
     const manifest = await readManifest();
     const exportsMap = manifest.exports ?? {};
     expect(exportsMap['./package.json']).toBeDefined();
-    expect(manifest.files).toEqual(['dist', 'src/web', 'src/exports/webClient.ts']);
+    expect(manifest.files).toEqual(['dist', 'src/web', 'src/exports/webClient.ts', '!src/web/**/*.stories.tsx']);
     expect(manifest.files).not.toContain('src');
     expect(manifest.files).not.toContain('tests');
     await expect(access(path.join(packageDirectory, 'dist'))).resolves.toBeUndefined();

--- a/packages/default/doompi-grep/vibe-lint.config.yaml
+++ b/packages/default/doompi-grep/vibe-lint.config.yaml
@@ -17,3 +17,14 @@ rules:
   no-raw-theme-color: error
   boundary-import-allowlist: error
   file-naming-convention: error
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/packages/default/doompi-log/package.json
+++ b/packages/default/doompi-log/package.json
@@ -31,7 +31,8 @@
     "src/web",
     "src/exports/webClient.ts",
     "src/types/webMetrics.ts",
-    "src/types/issueGrouping.ts"
+    "src/types/issueGrouping.ts",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -101,6 +102,7 @@
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "5.0.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsdown": "0.23.0",
     "typescript": "7.0.2",
     "vitest": "5.0.0"

--- a/packages/default/doompi-log/src/web/components/IssuesDetail.stories.tsx
+++ b/packages/default/doompi-log/src/web/components/IssuesDetail.stories.tsx
@@ -1,0 +1,129 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ *
+ * The samples are typed as IssuesView so the grouping this component runs over
+ * them is exercised against the real wire shape rather than a loose literal.
+ */
+import type { IssuesView, MetricsTool } from '../../types/webMetrics.ts';
+import { IssuesDetail } from './IssuesDetail.tsx';
+
+const tools: readonly MetricsTool[] = [
+  { name: 'bash', calls: 742, p90TotalTokens: 411_200 },
+  { name: 'spawn_subagent', calls: 46, p90TotalTokens: 902_100 },
+  { name: 'read', calls: 1006, p90TotalTokens: 325_900 },
+];
+
+const view: IssuesView = {
+  totalIssues: 69,
+  uniqueIncidents: 5,
+  byCategory: { tool_failure: 44, provider_error: 21, hook_failure: 4 },
+  byTool: { bash: 20, spawn_subagent: 21, hook: 3 },
+  byErrorType: { overloaded_error: 21, ENOENT: 12 },
+  samples: [
+    {
+      fingerprint: 'tool_failure|pi|bash||pi.tool_result',
+      occurrenceCount: 12,
+      category: 'tool_failure',
+      timestamp: '2025-06-04 08:41',
+      level: 'error',
+      message: 'pi.tool_result',
+      detail: 'pnpm exec nx run doompi-log:test -- --reporter=dot: exited 1',
+      tool: 'bash',
+      errorType: null,
+      agentName: 'ponytail',
+      model: 'claude-sonnet-4-5',
+      statusCode: null,
+    },
+    {
+      fingerprint: 'tool_failure|pi|bash||pi.tool_result|2',
+      occurrenceCount: 8,
+      category: 'tool_failure',
+      timestamp: '2025-06-04 09:02',
+      level: 'error',
+      message: 'pi.tool_result',
+      detail: 'pnpm exec nx run doompi-log:test -- --reporter=dot: exited 1',
+      tool: 'bash',
+      errorType: null,
+      agentName: 'ponytail',
+      model: 'claude-sonnet-4-5',
+      statusCode: null,
+    },
+    {
+      fingerprint: 'provider_error|overloaded_error|529',
+      occurrenceCount: 21,
+      category: 'provider_error',
+      timestamp: '2025-06-04 07:55',
+      level: 'error',
+      message: 'pi.provider_error',
+      detail: 'the upstream provider is overloaded; the turn was retried three times',
+      tool: null,
+      errorType: 'overloaded_error',
+      agentName: null,
+      model: 'claude-sonnet-4-5',
+      statusCode: '529',
+    },
+    {
+      fingerprint: 'tool_failure|pi|spawn_subagent||ENOENT',
+      occurrenceCount: 21,
+      category: 'tool_failure',
+      timestamp: '2025-06-03 22:14',
+      level: 'error',
+      message: 'pi.tool_result',
+      detail: 'ENOENT: bin/runnerHost.mjs could not be found by walking up from dist/src/schemas',
+      tool: 'spawn_subagent',
+      errorType: 'ENOENT',
+      agentName: 'main',
+      model: null,
+      statusCode: null,
+    },
+    {
+      fingerprint: 'hook_failure|pi|hook||vibe-lint',
+      occurrenceCount: 3,
+      category: 'hook_failure',
+      timestamp: '2025-06-02 11:30',
+      level: 'warn',
+      message: 'pi.hook_result',
+      detail: 'vibe-lint post-edit diagnostics timed out after 30s',
+      tool: 'hook',
+      errorType: null,
+      agentName: null,
+      model: null,
+      statusCode: null,
+    },
+  ],
+};
+
+/** The sink answered, and nothing went wrong in the window. */
+const empty: IssuesView = {
+  totalIssues: 0,
+  uniqueIncidents: 0,
+  byCategory: {},
+  byTool: {},
+  byErrorType: {},
+  samples: [],
+};
+
+const meta = {
+  title: 'Log/IssuesDetail',
+  component: IssuesDetail,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">ranked incidents, worst first</span>
+        <IssuesDetail view={view} tools={tools} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">nothing went wrong</span>
+        <IssuesDetail view={empty} tools={tools} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-log/src/web/components/IssuesDetail.tsx
+++ b/packages/default/doompi-log/src/web/components/IssuesDetail.tsx
@@ -40,13 +40,13 @@ function IssueRow({ group, max, tools }: IssueRowProps) {
   return (
     <li className="flex flex-col">
       <div className="relative">
-        <span aria-hidden="true" className="absolute inset-y-0 left-0 rounded-[2px] bg-doom-red/20" style={{ width }} />
+        <span aria-hidden="true" className="absolute inset-y-0 left-0 rounded-xs bg-doom-red/20" style={{ width }} />
         <button
           type="button"
           onClick={() => setOpen(!open)}
           aria-expanded={open}
           data-testid={`metrics-issue-${group.key}`}
-          className="relative flex w-full items-center gap-2 rounded-[2px] px-1 py-[3px] text-left text-[10px] hover:bg-doom-tint focus-visible:outline focus-visible:outline-1 focus-visible:outline-doom-blue"
+          className="relative flex w-full items-center gap-2 rounded-xs px-1 py-[3px] text-left text-xs hover:bg-doom-tint focus-visible:outline focus-visible:outline-1 focus-visible:outline-doom-blue"
         >
           <span className="w-8 shrink-0 text-right font-bold text-doom-red">{group.occurrences}</span>
           <span className="w-24 shrink-0 truncate text-doom-hi">{titleOf(group)}</span>
@@ -56,8 +56,8 @@ function IssueRow({ group, max, tools }: IssueRowProps) {
       </div>
 
       {open ? (
-        <div className="flex flex-col gap-1 px-2 py-2 text-[10px]" data-testid={`metrics-issue-body-${group.key}`}>
-          <div className="flex flex-wrap gap-x-3 gap-y-1 text-[9px] text-doom-faint">
+        <div className="flex flex-col gap-1 px-2 py-2 text-xs" data-testid={`metrics-issue-body-${group.key}`}>
+          <div className="flex flex-wrap gap-x-3 gap-y-1 text-2xs text-doom-faint">
             <span>category {group.category}</span>
             {group.tool === null ? null : <span>tool {group.tool}</span>}
             {group.errorType === null ? null : <span>error {group.errorType}</span>}
@@ -67,7 +67,7 @@ function IssueRow({ group, max, tools }: IssueRowProps) {
             <span>last seen {group.lastSeen}</span>
           </div>
           <span className="break-words text-doom-dim">{group.detail}</span>
-          <ul className="flex flex-col gap-[1px] text-[9px] text-doom-faint">
+          <ul className="flex flex-col gap-[1px] text-2xs text-doom-faint">
             {group.members.map((member, index) => (
               <li key={`${member.timestamp}-${String(index)}`} className="flex flex-wrap gap-x-2">
                 <span>{member.timestamp}</span>
@@ -99,7 +99,7 @@ export function IssuesDetail({ view, tools }: IssuesDetailProps) {
 
   return (
     <div className="flex flex-col gap-3">
-      <span className="text-[10px] text-doom-dim">
+      <span className="text-xs text-doom-dim">
         <span className="text-doom-hi">{view.totalIssues}</span> occurrences of{' '}
         <span className="text-doom-hi">{groups.length}</span> distinct problems, worst first
       </span>
@@ -113,8 +113,8 @@ export function IssuesDetail({ view, tools }: IssuesDetailProps) {
       )}
 
       <div className="flex flex-col gap-1">
-        <span className="text-[9px] font-bold text-doom-faint">failures by tool</span>
-        <table className="w-full text-[10px]" data-testid="metrics-issues-tools">
+        <span className="text-2xs font-bold text-doom-faint">failures by tool</span>
+        <table className="w-full text-xs" data-testid="metrics-issues-tools">
           <tbody>
             {countRows(view.byTool).map(([name, failures]) => {
               const calls = callsByTool.get(name);
@@ -134,8 +134,8 @@ export function IssuesDetail({ view, tools }: IssuesDetailProps) {
         </table>
       </div>
 
-      <div className="flex flex-wrap gap-x-4 gap-y-1 text-[10px] text-doom-dim">
-        <span className="text-[9px] font-bold text-doom-faint">by category</span>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-doom-dim">
+        <span className="text-2xs font-bold text-doom-faint">by category</span>
         {countRows(view.byCategory).map(([name, count]) => (
           <span key={name}>
             {name} <span className="text-doom-hi">{count}</span>

--- a/packages/default/doompi-log/src/web/components/IssuesSection.stories.tsx
+++ b/packages/default/doompi-log/src/web/components/IssuesSection.stories.tsx
@@ -1,0 +1,39 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ *
+ * The section is collapsed until a reader clicks, and the click reads from the
+ * hub. What renders without a hub is exactly the state this story shows: the
+ * opener and the line explaining why the detail costs something.
+ */
+import type { MetricsTool } from '../../types/webMetrics.ts';
+import { IssuesSection } from './IssuesSection.tsx';
+
+const tools: readonly MetricsTool[] = [
+  { name: 'bash', calls: 742, p90TotalTokens: 411_200 },
+  { name: 'read', calls: 1006, p90TotalTokens: 325_900 },
+];
+
+const meta = {
+  title: 'Log/IssuesSection',
+  component: IssuesSection,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">collapsed, the whole-window view</span>
+        <IssuesSection tools={tools} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">collapsed, narrowed to one session</span>
+        <IssuesSection tools={tools} focus="9f2c41ae" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-log/src/web/components/IssuesSection.tsx
+++ b/packages/default/doompi-log/src/web/components/IssuesSection.tsx
@@ -50,14 +50,14 @@ export function IssuesSection({ tools, focus }: IssuesSectionProps) {
   return (
     <section className="flex flex-col gap-1" data-testid="metrics-issues">
       <div className="flex items-center gap-2">
-        <span className="text-[9px] font-bold text-doom-faint">issues</span>
+        <span className="text-2xs font-bold text-doom-faint">issues</span>
         {open ? null : (
-          <Button variant="ghost" size="xs" className="text-[9px]" onClick={load} data-testid="metrics-issues-open">
+          <Button variant="ghost" size="xs" className="text-2xs" onClick={load} data-testid="metrics-issues-open">
             show detail
           </Button>
         )}
         {open && !loading ? (
-          <Button variant="ghost" size="xs" className="text-[9px]" onClick={load} data-testid="metrics-issues-reload">
+          <Button variant="ghost" size="xs" className="text-2xs" onClick={load} data-testid="metrics-issues-reload">
             reload
           </Button>
         ) : null}
@@ -66,13 +66,13 @@ export function IssuesSection({ tools, focus }: IssuesSectionProps) {
       {/* Reading this scans the whole window in a subprocess, so the reader is
           told why it is behind a click rather than left wondering. */}
       {open ? null : (
-        <span className="text-[9px] text-doom-faint/70">
+        <span className="text-2xs text-doom-faint/70">
           the log sink has no issues endpoint, so this is read separately and takes a moment
         </span>
       )}
 
       {message === '' ? null : (
-        <span className="text-[10px] text-doom-yellow" data-testid="metrics-issues-message">
+        <span className="text-xs text-doom-yellow" data-testid="metrics-issues-message">
           {message}
         </span>
       )}

--- a/packages/default/doompi-log/src/web/components/MetricsNotice.stories.tsx
+++ b/packages/default/doompi-log/src/web/components/MetricsNotice.stories.tsx
@@ -1,0 +1,72 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ *
+ * This module has no single `MetricsNotice` component: it exports the two
+ * things the page says instead of, or above, a report. `component` names the
+ * one with variants worth comparing; both are drawn below.
+ */
+import { EmptyForReason, FocusNotice } from './MetricsNotice.tsx';
+
+const meta = {
+  title: 'Log/MetricsNotice',
+  component: FocusNotice,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">empty · no sink installed</span>
+        <EmptyForReason
+          response={{
+            unavailable: 'no-sink',
+            detail: 'No log sink is installed on this machine, so nothing is recorded.',
+          }}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">empty · sink with nothing in it</span>
+        <EmptyForReason
+          response={{ unavailable: 'no-data', detail: 'The log sink is installed but has not recorded a turn yet.' }}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">empty · package api not mounted</span>
+        <EmptyForReason
+          response={{
+            unavailable: 'no-api',
+            detail: 'This cockpit is running a bundle without the log package API, so there are no metrics to read.',
+          }}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">focus · applied</span>
+        <FocusNotice
+          requested="claude-sonnet-4-5"
+          applied="claude-sonnet-4-5"
+          dimension="model"
+          onClear={() => undefined}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">focus · refused by an older sink</span>
+        <FocusNotice requested="claude-sonnet-4-5" applied={undefined} dimension="model" onClear={() => undefined} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          focus · nothing requested, renders null
+        </span>
+        <FocusNotice requested="" applied={undefined} dimension="session" onClear={() => undefined} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-log/src/web/components/MetricsNotice.tsx
+++ b/packages/default/doompi-log/src/web/components/MetricsNotice.tsx
@@ -39,19 +39,19 @@ export function FocusNotice({ requested, applied, dimension, onClear }: FocusNot
     // whole numbers. Saying "showing model X" over them would be a lie, so the
     // drill-down is reported as refused instead.
     return (
-      <span className="text-[10px] text-doom-yellow" data-testid="metrics-focus-refused">
+      <span className="text-xs text-doom-yellow" data-testid="metrics-focus-refused">
         this log sink does not support narrowing by {DIMENSION_LABELS[dimension]}, so the numbers below are still
         everything
-        <Button variant="ghost" size="xs" className="ml-2 text-[9px]" onClick={onClear}>
+        <Button variant="ghost" size="xs" className="ml-2 text-2xs" onClick={onClear}>
           clear
         </Button>
       </span>
     );
   }
   return (
-    <span className="text-[10px] text-doom-dim" data-testid="metrics-focus">
+    <span className="text-xs text-doom-dim" data-testid="metrics-focus">
       narrowed to <span className="text-doom-hi">{applied}</span>
-      <Button variant="ghost" size="xs" className="ml-2 text-[9px]" onClick={onClear}>
+      <Button variant="ghost" size="xs" className="ml-2 text-2xs" onClick={onClear}>
         clear
       </Button>
     </span>

--- a/packages/default/doompi-log/src/web/components/MetricsPanel.stories.tsx
+++ b/packages/default/doompi-log/src/web/components/MetricsPanel.stories.tsx
@@ -1,0 +1,103 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ *
+ * The panel fetches its own report through the shared sealed transport, which
+ * is a plain `fetch` until a tunnel handshake completes. There is no hub behind
+ * the renderer, so this file answers the one route the panel reads and lets
+ * everything else through; without it the story would only ever show
+ * "The cockpit hub is unreachable."
+ *
+ * ponytail: the stub matches on the path segment rather than parsing the query,
+ * so every dimension and period draws the same report. Widen it only if a story
+ * needs to compare two selections side by side.
+ */
+import { LOG_API_BASE_PATH, type MetricsReport } from '../../types/webMetrics.ts';
+import { MetricsPanel } from './MetricsPanel.tsx';
+
+const report: MetricsReport = {
+  generatedAt: '2025-06-04 09:12',
+  dimension: 'model',
+  period: 'week',
+  bucketUnit: 'day',
+  transport: 'http',
+  totals: {
+    totalTokens: 48_240_000,
+    inputTokens: 312_400,
+    outputTokens: 96_800,
+    cachedTokens: 47_610_000,
+    reasoningTokens: 12_800,
+    groupCount: 3,
+    failedGroups: 1,
+    issueCount: 23,
+  },
+  timeline: [
+    { label: '2025-05-30', totalTokens: 9_480_000, inputTokens: 62_800, outputTokens: 18_900 },
+    { label: '2025-05-31', totalTokens: 1_240_000, inputTokens: 11_200, outputTokens: 3_400 },
+    { label: '2025-06-01', totalTokens: 780_000, inputTokens: 7_900, outputTokens: 2_100 },
+    { label: '2025-06-02', totalTokens: 12_900_000, inputTokens: 88_300, outputTokens: 27_600 },
+    { label: '2025-06-03', totalTokens: 11_460_000, inputTokens: 71_500, outputTokens: 21_300 },
+    { label: '2025-06-04', totalTokens: 12_380_000, inputTokens: 70_700, outputTokens: 23_500 },
+  ],
+  groups: [
+    {
+      key: 'claude-sonnet-4-5',
+      totalTokens: 31_900_000,
+      inputTokens: 198_400,
+      outputTokens: 61_200,
+      issueCount: 14,
+      failed: false,
+    },
+    {
+      key: 'gpt-5-codex',
+      totalTokens: 12_140_000,
+      inputTokens: 79_600,
+      outputTokens: 24_800,
+      issueCount: 9,
+      failed: true,
+    },
+    {
+      key: 'claude-haiku-4-5',
+      totalTokens: 4_200_000,
+      inputTokens: 34_400,
+      outputTokens: 10_800,
+      issueCount: 0,
+      failed: false,
+    },
+  ],
+  tools: [
+    { name: 'read', calls: 1006, p90TotalTokens: 325_900 },
+    { name: 'bash', calls: 742, p90TotalTokens: 411_200 },
+    { name: 'edit', calls: 388, p90TotalTokens: 298_700 },
+  ],
+};
+
+const liveFetch = globalThis.fetch.bind(globalThis);
+globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+  if (!url.includes(`/api/plugin/${LOG_API_BASE_PATH}/metrics`)) return liveFetch(input, init);
+  return Promise.resolve(
+    new Response(JSON.stringify(report), { status: 200, headers: { 'content-type': 'application/json' } }),
+  );
+};
+
+const request = (input: string, init?: RequestInit): Promise<Response> => liveFetch(input, init);
+
+const meta = {
+  title: 'Log/MetricsPanel',
+  component: MetricsPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">a report, with its selects</span>
+        <MetricsPanel request={request} requestWithStepUp={request} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-log/src/web/components/MetricsPanel.tsx
+++ b/packages/default/doompi-log/src/web/components/MetricsPanel.tsx
@@ -73,7 +73,7 @@ export function MetricsPanel(_props: SettingsPanelProps) {
             setDimension(next as MetricsDimension);
           }}
         >
-          <SelectTrigger data-testid="metrics-dimension" className="w-[140px] text-[10px]">
+          <SelectTrigger data-testid="metrics-dimension" className="w-[140px] text-xs">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -85,7 +85,7 @@ export function MetricsPanel(_props: SettingsPanelProps) {
           </SelectContent>
         </Select>
         <Select value={period} onValueChange={(next) => setPeriod(next as MetricsPeriod)}>
-          <SelectTrigger data-testid="metrics-period" className="w-[110px] text-[10px]">
+          <SelectTrigger data-testid="metrics-period" className="w-[110px] text-xs">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -100,7 +100,7 @@ export function MetricsPanel(_props: SettingsPanelProps) {
         <Button
           variant="ghost"
           size="xs"
-          className="ml-auto text-[9px]"
+          className="ml-auto text-2xs"
           onClick={() => setPeriod((current) => current)}
           disabled={loading}
         >
@@ -109,7 +109,7 @@ export function MetricsPanel(_props: SettingsPanelProps) {
       </div>
 
       {error === '' ? null : (
-        <span className="text-[10px] text-doom-red" data-testid="metrics-error">
+        <span className="text-xs text-doom-red" data-testid="metrics-error">
           {error}
         </span>
       )}

--- a/packages/default/doompi-log/src/web/components/MetricsReportView.stories.tsx
+++ b/packages/default/doompi-log/src/web/components/MetricsReportView.stories.tsx
@@ -1,0 +1,129 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ *
+ * The report is typed as MetricsReport rather than left inferred, so a change
+ * to the wire contract breaks this story instead of drawing stale fields.
+ */
+import type { MetricsReport } from '../../types/webMetrics.ts';
+import { MetricsReportView } from './MetricsReportView.tsx';
+
+const report: MetricsReport = {
+  generatedAt: '2025-06-04 09:12',
+  dimension: 'model',
+  period: 'week',
+  bucketUnit: 'day',
+  transport: 'http',
+  totals: {
+    totalTokens: 48_240_000,
+    inputTokens: 312_400,
+    outputTokens: 96_800,
+    cachedTokens: 47_610_000,
+    reasoningTokens: 12_800,
+    groupCount: 4,
+    failedGroups: 1,
+    issueCount: 23,
+  },
+  timeline: [
+    { label: '2025-05-29', totalTokens: 4_120_000, inputTokens: 41_000, outputTokens: 12_400 },
+    { label: '2025-05-30', totalTokens: 9_480_000, inputTokens: 62_800, outputTokens: 18_900 },
+    { label: '2025-05-31', totalTokens: 1_240_000, inputTokens: 11_200, outputTokens: 3_400 },
+    { label: '2025-06-01', totalTokens: 780_000, inputTokens: 7_900, outputTokens: 2_100 },
+    { label: '2025-06-02', totalTokens: 12_900_000, inputTokens: 88_300, outputTokens: 27_600 },
+    { label: '2025-06-03', totalTokens: 11_460_000, inputTokens: 71_500, outputTokens: 21_300 },
+    { label: '2025-06-04', totalTokens: 8_260_000, inputTokens: 29_700, outputTokens: 11_100 },
+  ],
+  groups: [
+    {
+      key: 'claude-sonnet-4-5',
+      totalTokens: 31_900_000,
+      inputTokens: 198_400,
+      outputTokens: 61_200,
+      issueCount: 14,
+      failed: false,
+    },
+    {
+      key: 'gpt-5-codex',
+      totalTokens: 12_140_000,
+      inputTokens: 79_600,
+      outputTokens: 24_800,
+      issueCount: 9,
+      failed: true,
+    },
+    {
+      key: 'claude-haiku-4-5',
+      totalTokens: 3_820_000,
+      inputTokens: 28_100,
+      outputTokens: 9_400,
+      issueCount: 0,
+      failed: false,
+    },
+    {
+      key: 'gemini-2-5-pro',
+      totalTokens: 380_000,
+      inputTokens: 6_300,
+      outputTokens: 1_400,
+      issueCount: 0,
+      failed: false,
+    },
+  ],
+  tools: [
+    { name: 'read', calls: 1006, p90TotalTokens: 325_900 },
+    { name: 'bash', calls: 742, p90TotalTokens: 411_200 },
+    { name: 'edit', calls: 388, p90TotalTokens: 298_700 },
+    { name: 'grep', calls: 214, p90TotalTokens: 187_400 },
+    { name: 'spawn_subagent', calls: 46, p90TotalTokens: 902_100 },
+    { name: 'write', calls: 31, p90TotalTokens: 96_800 },
+  ],
+};
+
+/** The degenerate shape the sink answers with on a short history: one bucket, one group. */
+const singleBucket: MetricsReport = {
+  ...report,
+  dimension: 'session',
+  period: 'day',
+  bucketUnit: 'hour',
+  focus: '9f2c41ae',
+  transport: 'cli',
+  totals: {
+    totalTokens: 214_000,
+    inputTokens: 3_100,
+    outputTokens: 940,
+    cachedTokens: 209_800,
+    reasoningTokens: 0,
+    groupCount: 1,
+    failedGroups: 0,
+    issueCount: 0,
+  },
+  timeline: [{ label: '2025-06-04 09:00', totalTokens: 214_000, inputTokens: 3_100, outputTokens: 940 }],
+  groups: [
+    { key: '9f2c41ae', totalTokens: 214_000, inputTokens: 3_100, outputTokens: 940, issueCount: 0, failed: false },
+  ],
+  tools: [{ name: 'read', calls: 12, p90TotalTokens: 41_200 }],
+};
+
+const meta = {
+  title: 'Log/MetricsReportView',
+  component: MetricsReportView,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">a week by model, with issues</span>
+        <MetricsReportView report={report} onFocus={() => undefined} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          one bucket · session dimension · narrowed
+        </span>
+        <MetricsReportView report={singleBucket} onFocus={() => undefined} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-log/src/web/components/MetricsReportView.tsx
+++ b/packages/default/doompi-log/src/web/components/MetricsReportView.tsx
@@ -39,7 +39,7 @@ export function MetricsReportView({ report, onFocus }: MetricsReportViewProps) {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-1">
-        <div className="flex flex-wrap items-center gap-3 text-[10px] text-doom-dim">
+        <div className="flex flex-wrap items-center gap-3 text-xs text-doom-dim">
           <span>
             <span className="text-doom-hi">{formatTokens(report.totals.totalTokens)}</span> total
           </span>
@@ -70,41 +70,41 @@ export function MetricsReportView({ report, onFocus }: MetricsReportViewProps) {
             beside it without this line reads as a breakdown that does not
             add up, which is worse than not showing them.
           */}
-        <span className="text-[9px] text-doom-faint/70">
+        <span className="text-2xs text-doom-faint/70">
           total is what the providers reported and is dominated by cache traffic; the parts beside it are counted
           separately and do not sum to it
         </span>
       </div>
 
       <section className="flex flex-col gap-1">
-        <span className="text-[9px] font-bold text-doom-faint">tokens over time</span>
+        <span className="text-2xs font-bold text-doom-faint">tokens over time</span>
         <TimelineChart buckets={report.timeline} bucketUnit={report.bucketUnit} />
       </section>
 
       <section className="flex flex-col gap-1">
-        <span className="text-[9px] font-bold text-doom-faint">tokens by {DIMENSION_LABELS[report.dimension]}</span>
+        <span className="text-2xs font-bold text-doom-faint">tokens by {DIMENSION_LABELS[report.dimension]}</span>
         {DIMENSION_NOTES[report.dimension] === undefined ? null : (
-          <span className="text-[9px] text-doom-faint/70">{DIMENSION_NOTES[report.dimension]}</span>
+          <span className="text-2xs text-doom-faint/70">{DIMENSION_NOTES[report.dimension]}</span>
         )}
         <GroupBars groups={report.groups} focus={report.focus} onFocus={onFocus} />
       </section>
 
       <section className="flex flex-col gap-1">
-        <span className="text-[9px] font-bold text-doom-faint">tool calls</span>
+        <span className="text-2xs font-bold text-doom-faint">tool calls</span>
         {/*
             The token column is a ranking hint, not a measurement. The sink
             attributes a turn's whole total to every tool that ran in that
             turn, so saying otherwise here would be a lie the chart repeats.
           */}
-        <span className="text-[9px] text-doom-faint/70">
+        <span className="text-2xs text-doom-faint/70">
           call counts are exact; the token column ranks tools by the turns they ran in, and is not each tool&apos;s own
           consumption
         </span>
-        <table className="w-full text-[10px]" data-testid="metrics-tools">
+        <table className="w-full text-xs" data-testid="metrics-tools">
           {/* Without heads the two right columns are just numbers; "1006" and
               "325.9k" do not say which is a call count and which is tokens. */}
           <thead>
-            <tr className="text-[9px] text-doom-faint/70">
+            <tr className="text-2xs text-doom-faint/70">
               <th className="py-1 text-left font-normal">tool</th>
               <th className="w-20 py-1 text-right font-normal">calls</th>
               <th className="w-20 py-1 text-right font-normal">tokens</th>
@@ -124,7 +124,7 @@ export function MetricsReportView({ report, onFocus }: MetricsReportViewProps) {
 
       <IssuesSection tools={report.tools} focus={report.dimension === 'session' ? report.focus : undefined} />
 
-      <span className="text-[9px] text-doom-faint/70" data-testid="metrics-provenance">
+      <span className="text-2xs text-doom-faint/70" data-testid="metrics-provenance">
         read over {report.transport ?? 'an unreported transport'} · generated {report.generatedAt}
       </span>
     </div>

--- a/packages/default/doompi-log/src/web/components/charts/GroupBars.tsx
+++ b/packages/default/doompi-log/src/web/components/charts/GroupBars.tsx
@@ -28,7 +28,7 @@ export function GroupBars({ groups, focus, onFocus }: GroupBarsProps) {
       {/* The two right-hand columns were bare numbers. A row reading "11.0M  12"
           gave no way to know the second figure counted issues. Same widths and
           padding as a row, so the heads sit over their own columns. */}
-      <div aria-hidden className="flex items-center gap-2 px-1 text-[9px] text-doom-faint/70">
+      <div aria-hidden className="flex items-center gap-2 px-1 text-2xs text-doom-faint/70">
         <span className="min-w-0 flex-1" />
         <span className="w-14 shrink-0 text-right">tokens</span>
         <span className="w-10 shrink-0 text-right">issues</span>
@@ -58,18 +58,18 @@ export function GroupBars({ groups, focus, onFocus }: GroupBarsProps) {
                 track for horizontal space. */}
               <span
                 aria-hidden="true"
-                className={`absolute inset-y-0 left-0 rounded-[2px] ${selected ? 'bg-doom-blue/30' : 'bg-doom-blue/15'}`}
+                className={`absolute inset-y-0 left-0 rounded-xs ${selected ? 'bg-doom-blue/30' : 'bg-doom-blue/15'}`}
                 style={{ width }}
               />
               {onFocus === undefined ? (
-                <span className="relative flex items-center gap-2 px-1 py-[3px] text-[10px]">{row}</span>
+                <span className="relative flex items-center gap-2 px-1 py-[3px] text-xs">{row}</span>
               ) : (
                 <button
                   type="button"
                   onClick={() => onFocus(selected ? '' : group.key)}
                   aria-pressed={selected}
                   data-testid={`metrics-group-${group.key}`}
-                  className="relative flex w-full items-center gap-2 rounded-[2px] px-1 py-[3px] text-[10px] hover:bg-doom-tint focus-visible:outline focus-visible:outline-1 focus-visible:outline-doom-blue"
+                  className="relative flex w-full items-center gap-2 rounded-xs px-1 py-[3px] text-xs hover:bg-doom-tint focus-visible:outline focus-visible:outline-1 focus-visible:outline-doom-blue"
                 >
                   {row}
                 </button>

--- a/packages/default/doompi-log/src/web/components/charts/TimelineChart.tsx
+++ b/packages/default/doompi-log/src/web/components/charts/TimelineChart.tsx
@@ -62,7 +62,7 @@ export function TimelineChart({ buckets, bucketUnit }: TimelineChartProps) {
           );
         })}
       </svg>
-      <div className="flex flex-wrap justify-between gap-x-3 text-[9px] text-doom-faint">
+      <div className="flex flex-wrap justify-between gap-x-3 text-2xs text-doom-faint">
         <span>{buckets[0]?.label ?? ''}</span>
         {buckets.length > 1 ? <span>peak {formatTokens(max)}</span> : null}
         <span>

--- a/packages/default/doompi-log/style-system.config.yaml
+++ b/packages/default/doompi-log/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/default/doompi-log/styles/preview.css
+++ b/packages/default/doompi-log/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/default/doompi-log/vibe-lint.config.yaml
+++ b/packages/default/doompi-log/vibe-lint.config.yaml
@@ -11,6 +11,15 @@ rules:
   file-naming-convention: error
 
 overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off
   # Reads time, randomness or process state ambiently instead of taking it as a
   # dependency. Each needs a clock, id factory or env threaded through its
   # caller; until then the rule stays on for every other module here.

--- a/packages/default/doompi-mcp/package.json
+++ b/packages/default/doompi-mcp/package.json
@@ -34,7 +34,8 @@
     "src/prompts",
     "README.md",
     "LICENSE",
-    "package.json"
+    "package.json",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -91,6 +92,7 @@
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "5.0.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsdown": "0.23.0",
     "typescript": "7.0.2",
     "vitest": "5.0.0"

--- a/packages/default/doompi-mcp/src/web/components/McpRepositorySettingsPanel.stories.tsx
+++ b/packages/default/doompi-mcp/src/web/components/McpRepositorySettingsPanel.stories.tsx
@@ -1,0 +1,75 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ *
+ * The panel reads its catalog through the `request` prop, so this story answers
+ * that one route instead of stubbing anything global. The catalog is typed as
+ * McpRepositoryCatalog, so a change to the wire shape breaks the story.
+ *
+ * Only one panel is given a repository: the settings store is a module
+ * singleton keyed by repository id, so two loaded panels would fight over it.
+ */
+import type { RepositorySettingsPanelProps } from '@agimon-ai/doompi-web-contracts';
+import type { McpRepositoryCatalog } from '../../types/webMcp.ts';
+import { McpRepositorySettingsPanel } from './McpRepositorySettingsPanel.tsx';
+
+const catalog: McpRepositoryCatalog = {
+  repositoryId: 'repo-1',
+  sync: { fresh: true, reasons: [] },
+  servers: [
+    {
+      name: 'linear',
+      state: 'connected',
+      source: 'cached',
+      credentialPresent: true,
+      tools: [
+        { name: 'list_issues', piName: 'linear_list_issues', description: 'List issues for a team' },
+        { name: 'create_issue', piName: 'linear_create_issue', description: 'Open a new issue' },
+      ],
+    },
+    {
+      name: 'github',
+      state: 'needs-auth',
+      source: 'live',
+      credentialPresent: false,
+      tools: [],
+      error: 'The saved credential expired on 2025-06-01.',
+    },
+    { name: 'sentry', state: 'not-connected', source: 'configured', credentialPresent: false, tools: [] },
+  ],
+  droppedServers: ['internal-shell'],
+  diagnostics: ['stdio server "internal-shell" is not on the install allowlist'],
+};
+
+const request: RepositorySettingsPanelProps['request'] = (input) =>
+  Promise.resolve(
+    input.includes('/api/plugin/mcp/repository')
+      ? new Response(JSON.stringify(catalog), { status: 200, headers: { 'content-type': 'application/json' } })
+      : new Response('{}', { status: 404, headers: { 'content-type': 'application/json' } }),
+  );
+
+const repository = { id: 'repo-1', name: 'doompi', path: '/Users/dev/workspace/doompi', active: true };
+
+const meta = {
+  title: 'Mcp/McpRepositorySettingsPanel',
+  component: McpRepositorySettingsPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">a synced catalog</span>
+        <McpRepositorySettingsPanel repository={repository} request={request} requestWithStepUp={request} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no repository selected</span>
+        <McpRepositorySettingsPanel repository={null} request={request} requestWithStepUp={request} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-mcp/src/web/components/McpRepositorySettingsPanel.tsx
+++ b/packages/default/doompi-mcp/src/web/components/McpRepositorySettingsPanel.tsx
@@ -52,7 +52,7 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
   }, [authorizationId, authorizationStatus, repositoryId, request]);
 
   if (!repository) {
-    return <p className="py-3 text-[10px] text-doom-faint">Select a repository to inspect its synced MCP catalog.</p>;
+    return <p className="py-3 text-xs text-doom-faint">Select a repository to inspect its synced MCP catalog.</p>;
   }
 
   const catalog = state.repositoryId === repository.id ? state.catalog : undefined;
@@ -63,7 +63,7 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
     <div className="flex flex-col gap-3" data-testid="mcp-repository-settings">
       <div className="flex flex-col items-stretch gap-2 rounded border border-doom-border bg-doom-panel px-3 py-2 min-[560px]:flex-row min-[560px]:items-center">
         <Badge>{catalog?.sync.fresh ? 'synced' : 'sync required'}</Badge>
-        <span className="min-w-0 text-[10px] leading-relaxed text-doom-muted min-[560px]:flex-1">
+        <span className="min-w-0 text-xs leading-relaxed text-doom-muted min-[560px]:flex-1">
           {catalog?.sync.fresh
             ? 'Cached inspection is local. Discovery contacts the configured servers.'
             : catalog
@@ -76,7 +76,7 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
           loading={busy === 'loading'}
           disabled={busy !== undefined}
           onClick={() => void loadMcpSettings(request, repository.id)}
-          className="w-full text-[10px] min-[560px]:w-auto"
+          className="w-full text-xs min-[560px]:w-auto"
         >
           refresh cache
         </Button>
@@ -86,7 +86,7 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
           loading={busy === 'discovering'}
           disabled={busy !== undefined || !catalog?.sync.fresh}
           onClick={() => setConfirmDiscovery(true)}
-          className="w-full text-[10px] min-[560px]:w-auto"
+          className="w-full text-xs min-[560px]:w-auto"
         >
           discover live
         </Button>
@@ -94,7 +94,7 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
 
       {!confirmDiscovery ? null : (
         <div className="flex flex-col items-stretch gap-2 rounded border border-doom-accent/50 bg-doom-accent/5 px-3 py-2 min-[560px]:flex-row min-[560px]:items-center">
-          <span className="min-w-0 text-[10px] leading-relaxed text-doom-hi min-[560px]:flex-1">
+          <span className="min-w-0 text-xs leading-relaxed text-doom-hi min-[560px]:flex-1">
             Discovery starts configured processes and contacts remote MCP servers. Continue?
           </span>
           <Button
@@ -104,7 +104,7 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
               setConfirmDiscovery(false);
               void discoverMcpSettings(requestWithStepUp, repository.id);
             }}
-            className="w-full text-[10px] min-[560px]:w-auto"
+            className="w-full text-xs min-[560px]:w-auto"
           >
             confirm discovery
           </Button>
@@ -112,23 +112,23 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
             variant="ghost"
             size="xs"
             onClick={() => setConfirmDiscovery(false)}
-            className="w-full text-[10px] min-[560px]:w-auto"
+            className="w-full text-xs min-[560px]:w-auto"
           >
             cancel
           </Button>
         </div>
       )}
 
-      {!error ? null : <p className="rounded border border-doom-red/40 px-3 py-2 text-[10px] text-doom-red">{error}</p>}
+      {!error ? null : <p className="rounded border border-doom-red/40 px-3 py-2 text-xs text-doom-red">{error}</p>}
 
       {authorization ? (
         <div className="flex flex-col gap-2 rounded border border-doom-border bg-doom-panel px-3 py-2">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="min-w-0 basis-full text-[10px] font-bold text-doom-hi min-[560px]:basis-auto">
+            <span className="min-w-0 basis-full text-xs font-bold text-doom-hi min-[560px]:basis-auto">
               {authorization.serverName}
             </span>
             <Badge>{authorization.status}</Badge>
-            <span className="min-w-0 flex-1 text-[9px] text-doom-faint">authorization flow</span>
+            <span className="min-w-0 flex-1 text-2xs text-doom-faint">authorization flow</span>
             {TERMINAL_AUTHORIZATION.has(authorization.status) ? null : (
               <Button
                 variant="ghost"
@@ -136,7 +136,7 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
                 loading={busy === 'cancelling'}
                 disabled={busy !== undefined}
                 onClick={() => void cancelMcpFlow(requestWithStepUp, repository.id, authorization.id)}
-                className="w-full text-[10px] min-[560px]:w-auto"
+                className="w-full text-xs min-[560px]:w-auto"
               >
                 cancel
               </Button>
@@ -147,17 +147,17 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
               href={authorization.authorizationUrl}
               target="_blank"
               rel="noreferrer noopener"
-              className="w-fit text-[10px] text-doom-accent underline underline-offset-2"
+              className="w-fit text-xs text-doom-accent underline underline-offset-2"
             >
               open authorization page
             </a>
           )}
-          {!authorization.error ? null : <p className="text-[9px] text-doom-red">{authorization.error}</p>}
+          {!authorization.error ? null : <p className="text-2xs text-doom-red">{authorization.error}</p>}
         </div>
       ) : null}
 
       {!catalog || catalog.servers.length === 0 ? (
-        <p className="rounded border border-dashed border-doom-border px-3 py-4 text-[10px] text-doom-faint">
+        <p className="rounded border border-dashed border-doom-border px-3 py-4 text-xs text-doom-faint">
           {busy === 'loading' ? 'Reading the cached catalog.' : 'No MCP servers are enabled in the synced selection.'}
         </p>
       ) : (
@@ -168,7 +168,7 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
               className="flex flex-col gap-2 rounded border border-doom-border bg-doom-panel px-3 py-2"
             >
               <div className="flex flex-wrap items-center gap-2">
-                <span className="min-w-0 basis-full truncate text-[11px] font-bold text-doom-hi min-[560px]:basis-auto min-[560px]:flex-1">
+                <span className="min-w-0 basis-full truncate text-sm font-bold text-doom-hi min-[560px]:basis-auto min-[560px]:flex-1">
                   {server.name}
                 </span>
                 <Badge>{server.state}</Badge>
@@ -179,14 +179,14 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
                   size="xs"
                   disabled={busy !== undefined || !catalog.sync.fresh}
                   onClick={() => setConfirmAuthorization(server.name)}
-                  className="w-full text-[10px] min-[560px]:w-auto"
+                  className="w-full text-xs min-[560px]:w-auto"
                 >
                   authorize
                 </Button>
               </div>
               {confirmAuthorization !== server.name ? null : (
                 <div className="flex flex-col items-stretch gap-2 border-t border-doom-border pt-2 min-[560px]:flex-row min-[560px]:items-center">
-                  <span className="min-w-0 text-[9px] leading-relaxed text-doom-muted min-[560px]:flex-1">
+                  <span className="min-w-0 text-2xs leading-relaxed text-doom-muted min-[560px]:flex-1">
                     Start a bounded OAuth attempt for this server? A passkey may be required.
                   </span>
                   <Button
@@ -196,7 +196,7 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
                       setConfirmAuthorization(undefined);
                       void authorizeMcpServer(requestWithStepUp, repository.id, server.name);
                     }}
-                    className="w-full text-[10px] min-[560px]:w-auto"
+                    className="w-full text-xs min-[560px]:w-auto"
                   >
                     continue
                   </Button>
@@ -204,22 +204,22 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
                     variant="ghost"
                     size="xs"
                     onClick={() => setConfirmAuthorization(undefined)}
-                    className="w-full text-[10px] min-[560px]:w-auto"
+                    className="w-full text-xs min-[560px]:w-auto"
                   >
                     cancel
                   </Button>
                 </div>
               )}
               <details>
-                <summary className="cursor-pointer text-[9px] text-doom-muted">
+                <summary className="cursor-pointer text-2xs text-doom-muted">
                   {String(server.tools.length)} cached {server.tools.length === 1 ? 'tool' : 'tools'}
                 </summary>
                 <div className="mt-2 flex flex-col gap-1 border-t border-doom-border pt-2">
                   {server.tools.length === 0 ? (
-                    <span className="text-[9px] text-doom-faint">Run discovery to populate capabilities.</span>
+                    <span className="text-2xs text-doom-faint">Run discovery to populate capabilities.</span>
                   ) : (
                     server.tools.map((tool) => (
-                      <div key={tool.piName} className="flex min-w-0 gap-2 text-[9px]">
+                      <div key={tool.piName} className="flex min-w-0 gap-2 text-2xs">
                         <code className="shrink-0 text-doom-hi">{tool.name}</code>
                         <span className="truncate text-doom-faint">{tool.description ?? tool.piName}</span>
                       </div>
@@ -227,19 +227,19 @@ export function McpRepositorySettingsPanel({ repository, request, requestWithSte
                   )}
                 </div>
               </details>
-              {!server.error ? null : <p className="text-[9px] text-doom-red">{server.error}</p>}
+              {!server.error ? null : <p className="text-2xs text-doom-red">{server.error}</p>}
             </div>
           ))}
         </div>
       )}
 
       {catalog?.droppedServers.length ? (
-        <p className="text-[9px] text-doom-faint">
+        <p className="text-2xs text-doom-faint">
           Policy omitted {String(catalog.droppedServers.length)} configured servers.
         </p>
       ) : null}
       {catalog?.diagnostics.map((diagnostic) => (
-        <p key={diagnostic} className="text-[9px] text-doom-red">
+        <p key={diagnostic} className="text-2xs text-doom-red">
           {diagnostic}
         </p>
       ))}

--- a/packages/default/doompi-mcp/src/web/components/McpSessionAuthSection.stories.tsx
+++ b/packages/default/doompi-mcp/src/web/components/McpSessionAuthSection.stories.tsx
@@ -1,0 +1,64 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ *
+ * The servers arrive as the session status string this package publishes, and
+ * are built with `formatMcpSessionAuthStatus` rather than a hand-written JSON
+ * literal, so a story cannot show a shape the parser would reject.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { formatMcpSessionAuthStatus, MCP_SESSION_AUTH_STATUS_KEY } from '../../types/webMcp.ts';
+import { McpSessionAuthSection } from './McpSessionAuthSection.tsx';
+
+const status = formatMcpSessionAuthStatus([
+  { name: 'linear', state: 'connected' },
+  { name: 'github', state: 'needs-auth', authorizationUrl: 'https://github.com/login/oauth/authorize?client_id=x' },
+  { name: 'sentry', state: 'connecting' },
+  { name: 'notion', state: 'failed' },
+  { name: 'slack', state: 'disabled' },
+]);
+
+const slot = slotPropsFixture({
+  sessionId: 's1',
+  statuses: { [MCP_SESSION_AUTH_STATUS_KEY]: status ?? '' },
+  contextInventory: [
+    { name: 'list_issues', itemKind: 'tool', source: 'mcp', owner: 'linear', tokens: 1420, active: true },
+    { name: 'create_issue', itemKind: 'tool', source: 'mcp', owner: 'linear', tokens: 980, active: true },
+    { name: 'search_docs', itemKind: 'tool', source: 'mcp', owner: 'linear', tokens: 610, active: false },
+    { name: 'list_repos', itemKind: 'tool', source: 'mcp', owner: 'github', tokens: null, active: false },
+  ],
+}).props;
+
+/** No session focused: every button is disabled, which is the read-only shape. */
+const noSession = slotPropsFixture({
+  sessionId: null,
+  statuses: { [MCP_SESSION_AUTH_STATUS_KEY]: status ?? '' },
+}).props;
+
+const meta = {
+  title: 'Mcp/McpSessionAuthSection',
+  component: McpSessionAuthSection,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          five states, with the tools each server contributes
+        </span>
+        <McpSessionAuthSection {...slot} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          no session focused · nothing actionable
+        </span>
+        <McpSessionAuthSection {...noSession} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-mcp/src/web/components/McpSessionAuthSection.tsx
+++ b/packages/default/doompi-mcp/src/web/components/McpSessionAuthSection.tsx
@@ -102,8 +102,8 @@ export function McpSessionAuthSection({
       {servers.length === 0 ? null : (
         <section data-testid="context-mcp-auth" className="flex flex-col gap-2 border-b border-doom-border px-3 py-3">
           <div className="flex flex-col gap-0.5">
-            <p className="text-[9px] font-bold uppercase tracking-wide text-doom-faint">MCP servers</p>
-            <p className="text-[9px] leading-relaxed text-doom-muted">
+            <p className="text-2xs font-bold uppercase tracking-wide text-doom-faint">MCP servers</p>
+            <p className="text-2xs leading-relaxed text-doom-muted">
               Open sign-in in a new tab, or copy the link from the authorization dialog.
             </p>
           </div>
@@ -115,8 +115,8 @@ export function McpSessionAuthSection({
               return (
                 <li key={item.name} className="flex min-w-0 flex-col gap-1 px-1 py-0.5">
                   <div className="flex min-w-0 items-center gap-2">
-                    <span className="min-w-0 flex-1 truncate text-[10px] text-doom-hi">{item.name}</span>
-                    <span className="text-[9px] text-doom-muted">{item.state.replace(/-/g, ' ')}</span>
+                    <span className="min-w-0 flex-1 truncate text-xs text-doom-hi">{item.name}</span>
+                    <span className="text-2xs text-doom-muted">{item.state.replace(/-/g, ' ')}</span>
                     <Button
                       variant="subtle"
                       size="xs"
@@ -133,23 +133,23 @@ export function McpSessionAuthSection({
                           setTarget({ sessionId, name: item.name });
                         }
                       }}
-                      className="shrink-0 text-[8px] font-bold"
+                      className="shrink-0 text-2xs font-bold"
                     >
                       {item.state === 'connected' ? 'manage' : 'authorize'}
                     </Button>
                   </div>
                   {tools.length === 0 ? (
-                    <p className="pl-3 text-[9px] text-doom-faint">no tools reported</p>
+                    <p className="pl-3 text-2xs text-doom-faint">no tools reported</p>
                   ) : (
                     <ul aria-label={`${item.name} tools`} className="flex flex-col">
                       {tools.map((tool) => (
                         <li key={tool.name} className="flex min-w-0 items-center gap-2 py-px pl-3">
                           <span
-                            className={`min-w-0 flex-1 truncate text-[9px] ${tool.active ? 'text-doom-muted' : 'text-doom-faint'}`}
+                            className={`min-w-0 flex-1 truncate text-2xs ${tool.active ? 'text-doom-muted' : 'text-doom-faint'}`}
                           >
                             {tool.name}
                           </span>
-                          <span className="w-14 shrink-0 text-right text-[9px] text-doom-faint">
+                          <span className="w-14 shrink-0 text-right text-2xs text-doom-faint">
                             {tool.active ? tokenEstimate(tool.tokens) : `(${tokenEstimate(tool.tokens)})`}
                           </span>
                         </li>
@@ -174,7 +174,7 @@ export function McpSessionAuthSection({
         <DialogContent data-testid="mcp-authorization-dialog">
           <DialogHeader className="items-start px-4 py-4 sm:px-5">
             <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-              <DialogTitle className="break-words text-[14px] leading-snug">
+              <DialogTitle className="break-words text-base leading-snug">
                 {server?.state === 'connected' ? 'Manage' : 'Authorize'} {selected?.name}
               </DialogTitle>
               <DialogDescription className="max-w-2xl">
@@ -185,7 +185,7 @@ export function McpSessionAuthSection({
             </div>
           </DialogHeader>
           <DialogBody className="px-4 py-4 sm:px-5 sm:py-5">
-            <p role="status" className="text-[11px] text-doom-muted">
+            <p role="status" className="text-sm text-doom-muted">
               {server?.state === 'connected'
                 ? 'Authorization complete. This server is connected.'
                 : server?.state === 'closed'
@@ -199,7 +199,7 @@ export function McpSessionAuthSection({
                         : 'This server is no longer available in the session.'}
             </p>
             {popupBlocked ? (
-              <p className="text-[10px] text-doom-muted">
+              <p className="text-xs text-doom-muted">
                 The browser blocked the new tab. Open the link below when it is ready.
               </p>
             ) : null}
@@ -215,7 +215,7 @@ export function McpSessionAuthSection({
                   href={authorizationUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-[11px] text-doom-accent underline underline-offset-2"
+                  className="text-sm text-doom-accent underline underline-offset-2"
                 >
                   open authorization page
                 </a>
@@ -225,7 +225,7 @@ export function McpSessionAuthSection({
               </div>
             ) : null}
             {copyFeedback ? (
-              <p role="status" className="text-[10px] text-doom-muted">
+              <p role="status" className="text-xs text-doom-muted">
                 {copyFeedback}
               </p>
             ) : null}

--- a/packages/default/doompi-mcp/src/web/components/McpToolMessage.stories.tsx
+++ b/packages/default/doompi-mcp/src/web/components/McpToolMessage.stories.tsx
@@ -1,0 +1,124 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ * The props come from the contracts package's own testing fixture rather than
+ * a hand-rolled stub, so a change to the render contract breaks this story at
+ * the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { McpToolDetails } from '../../types/webMcp.ts';
+import { McpToolMessage } from './McpToolMessage.tsx';
+import { MCP_STATUS_KEY } from '../lib/mcpToolMatch.ts';
+
+/** The server names the session publishes, which is how a call is recognised without details. */
+const statuses = { [MCP_STATUS_KEY]: 'linear,github' };
+
+const SHORT = ['LIN-4821 Cockpit metrics panel', 'LIN-4822 Prompt library dialog'].join('\n');
+
+const LONG = Array.from(
+  { length: 18 },
+  (_, index) => `LIN-${String(4821 + index)} issue title ${String(index + 1)}`,
+).join('\n');
+
+const details: McpToolDetails = {
+  server: 'linear',
+  tool: 'list_issues',
+  blocks: [
+    {
+      type: 'resource_link',
+      uri: 'https://linear.app/doompi/issue/LIN-4821',
+      name: 'LIN-4821',
+      title: 'Cockpit metrics panel',
+      description: 'Draw the log sink report in settings',
+    },
+    { type: 'structured', value: { total: 2, cursor: null, hasMore: false } },
+    {
+      type: 'resource',
+      uri: 'linear://doompi/query.graphql',
+      mimeType: 'application/graphql',
+      text: '{ issues { id } }',
+    },
+    { type: 'audio', data: 'AAAA', mimeType: 'audio/wav' },
+  ],
+};
+
+const props = (overrides: Parameters<typeof toolMessagePropsFixture>[0]) =>
+  toolMessagePropsFixture({ statuses, ...overrides }).props;
+
+const meta = {
+  title: 'Mcp/McpToolMessage',
+  component: McpToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          running · server from the session status
+        </span>
+        <McpToolMessage
+          {...props({ toolName: 'linear_list_issues', args: { team: 'doompi', limit: 25 }, running: true })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · text only</span>
+        <McpToolMessage
+          {...props({
+            toolName: 'linear_list_issues',
+            args: { team: 'doompi', limit: 25 },
+            result: { content: [{ type: 'text', text: SHORT }], details: null },
+            output: SHORT,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          complete · identity and blocks from the details
+        </span>
+        <McpToolMessage
+          {...props({
+            toolName: 'linear_list_issues',
+            args: { team: 'doompi', state: 'open', limit: 25, cursor: null },
+            result: { content: [{ type: 'text', text: SHORT }], details },
+            output: SHORT,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          complete · collapsed to twelve lines, expandable
+        </span>
+        <McpToolMessage
+          {...props({
+            toolName: 'linear_list_issues',
+            args: { team: 'doompi' },
+            result: { content: [{ type: 'text', text: LONG }], details: null },
+            output: LONG,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          failed · server the session never named
+        </span>
+        <McpToolMessage
+          {...props({
+            toolName: 'notion_search',
+            args: { query: 'release checklist' },
+            result: { content: [{ type: 'text', text: 'MCP error -32001: request timed out' }], details: null },
+            output: 'MCP error -32001: request timed out',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-mcp/style-system.config.yaml
+++ b/packages/default/doompi-mcp/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/default/doompi-mcp/styles/preview.css
+++ b/packages/default/doompi-mcp/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/default/doompi-mcp/vibe-lint.config.yaml
+++ b/packages/default/doompi-mcp/vibe-lint.config.yaml
@@ -17,3 +17,14 @@ rules:
   no-raw-theme-color: error
   boundary-import-allowlist: error
   file-naming-convention: error
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/packages/default/doompi-prompt/package.json
+++ b/packages/default/doompi-prompt/package.json
@@ -33,7 +33,8 @@
     "llms.txt",
     "README.md",
     "LICENSE",
-    "package.json"
+    "package.json",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/default/doompi-prompt/src/web/components/PromptEditor.stories.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptEditor.stories.tsx
@@ -1,0 +1,77 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ *
+ * The drafts are typed as DraftState, so the save button's enabled state here
+ * is the component's own rule rather than a claim this file makes.
+ */
+import type { DraftState } from '../lib/promptsActions.ts';
+import { PromptEditor } from './PromptEditor.tsx';
+
+const empty: DraftState = { name: '', text: '', original: '' };
+
+const filled: DraftState = {
+  name: 'ship-it',
+  text: 'Run the affected Nx lint, typecheck, build and test targets, then report what changed.',
+  original: '',
+};
+
+const editing: DraftState = { ...filled, original: 'ship-it' };
+
+const meta = {
+  title: 'Prompt/PromptEditor',
+  component: PromptEditor,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">new · empty, save disabled</span>
+        <PromptEditor
+          draft={empty}
+          busy={false}
+          onChange={() => undefined}
+          onSave={() => undefined}
+          onCancel={() => undefined}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">new · complete, save enabled</span>
+        <PromptEditor
+          draft={filled}
+          busy={false}
+          onChange={() => undefined}
+          onSave={() => undefined}
+          onCancel={() => undefined}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">editing an existing prompt</span>
+        <PromptEditor
+          draft={editing}
+          busy={false}
+          onChange={() => undefined}
+          onSave={() => undefined}
+          onCancel={() => undefined}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">saving</span>
+        <PromptEditor
+          draft={editing}
+          busy
+          onChange={() => undefined}
+          onSave={() => undefined}
+          onCancel={() => undefined}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-prompt/src/web/components/PromptEditor.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptEditor.tsx
@@ -27,7 +27,7 @@ export function PromptEditor({ draft, busy, onChange, onSave, onCancel }: Prompt
   return (
     <div data-testid="prompts-editor" className="flex flex-col gap-4">
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="prompts-name" className="text-[10px] font-bold text-doom-dim">
+        <label htmlFor="prompts-name" className="text-xs font-bold text-doom-dim">
           prompt name
         </label>
         <Input
@@ -41,7 +41,7 @@ export function PromptEditor({ draft, busy, onChange, onSave, onCancel }: Prompt
         />
       </div>
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="prompts-text" className="text-[10px] font-bold text-doom-dim">
+        <label htmlFor="prompts-text" className="text-xs font-bold text-doom-dim">
           prompt text
         </label>
         <Textarea

--- a/packages/default/doompi-prompt/src/web/components/PromptPickerList.stories.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptPickerList.stories.tsx
@@ -1,0 +1,85 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ */
+import type { SavedPromptView } from '../../types/webPrompts.ts';
+import { PromptPickerList } from './PromptPickerList.tsx';
+
+const prompts: readonly SavedPromptView[] = [
+  {
+    name: 'ship-it',
+    description: 'run the affected targets, then report what changed',
+    text: 'Run the affected Nx lint, typecheck, build and test targets, then report what changed.',
+  },
+  {
+    name: 'review-diff',
+    description: 'review the working tree for concrete defects',
+    text: 'Review the working tree for defects, regressions and missing tests. Name files and lines.',
+  },
+  {
+    name: 'explain-this-flow',
+    description: 'trace one flow end to end before touching it',
+    text: 'Trace this flow from entry point to persistence and list every side effect on the way.',
+  },
+];
+
+const noop = () => undefined;
+
+const handlers = {
+  onFilterChange: noop,
+  onSend: noop,
+  onEdit: noop,
+  onDelete: noop,
+  onRetry: noop,
+};
+
+const meta = {
+  title: 'Prompt/PromptPickerList',
+  component: PromptPickerList,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">a loaded library</span>
+        <PromptPickerList prompts={prompts} filter="" loading={false} busy={false} error="" {...handlers} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">filtered to one</span>
+        <PromptPickerList prompts={prompts} filter="review" loading={false} busy={false} error="" {...handlers} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">filter matches nothing</span>
+        <PromptPickerList prompts={prompts} filter="deploy" loading={false} busy={false} error="" {...handlers} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">nothing saved yet</span>
+        <PromptPickerList prompts={[]} filter="" loading={false} busy={false} error="" {...handlers} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">loading</span>
+        <PromptPickerList prompts={[]} filter="" loading busy={false} error="" {...handlers} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">the hub refused</span>
+        <PromptPickerList
+          prompts={[]}
+          filter=""
+          loading={false}
+          busy={false}
+          error="The hub did not answer."
+          {...handlers}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-prompt/src/web/components/PromptPickerList.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptPickerList.tsx
@@ -40,12 +40,12 @@ export function PromptPickerList(props: PromptPickerListProps) {
       />
 
       {props.loading ? (
-        <p data-testid="prompts-loading" className="py-4 text-center text-[11px] text-doom-faint">
+        <p data-testid="prompts-loading" className="py-4 text-center text-sm text-doom-faint">
           loading prompts…
         </p>
       ) : props.error !== '' ? (
-        <div className="flex items-center justify-between gap-3 rounded-[5px] border border-doom-red/40 p-3">
-          <span className="text-[11px] text-doom-red" data-testid="prompts-error">
+        <div className="flex items-center justify-between gap-3 rounded-md border border-doom-red/40 p-3">
+          <span className="text-sm text-doom-red" data-testid="prompts-error">
             {props.error}
           </span>
           <Button variant="outline" size="sm" data-testid="prompts-retry" onClick={props.onRetry}>
@@ -53,7 +53,7 @@ export function PromptPickerList(props: PromptPickerListProps) {
           </Button>
         </div>
       ) : visible.length === 0 ? (
-        <p data-testid="prompts-empty" className="py-4 text-center text-[11px] text-doom-faint">
+        <p data-testid="prompts-empty" className="py-4 text-center text-sm text-doom-faint">
           {props.prompts.length === 0 ? 'no saved prompts yet. create one below.' : 'nothing matches that filter'}
         </p>
       ) : null}
@@ -64,7 +64,7 @@ export function PromptPickerList(props: PromptPickerListProps) {
             <div
               key={prompt.name}
               data-testid={`prompts-item-${prompt.name}`}
-              className="flex min-h-11 items-center gap-1 rounded-[5px] border border-doom-border-soft px-2 py-1.5 text-doom-text hover:bg-doom-deep"
+              className="flex min-h-11 items-center gap-1 rounded-md border border-doom-border-soft px-2 py-1.5 text-doom-text hover:bg-doom-deep"
             >
               <Button
                 variant="ghost"
@@ -74,8 +74,8 @@ export function PromptPickerList(props: PromptPickerListProps) {
                 title="send this prompt to the focused session"
                 onClick={() => props.onSend(prompt)}
               >
-                <span className="w-full truncate text-[11px] font-bold">/{prompt.name}</span>
-                <span className="w-full truncate text-[10px] font-normal text-doom-faint">{prompt.description}</span>
+                <span className="w-full truncate text-sm font-bold">/{prompt.name}</span>
+                <span className="w-full truncate text-xs font-normal text-doom-faint">{prompt.description}</span>
               </Button>
               <Button
                 variant="ghost"

--- a/packages/default/doompi-prompt/src/web/components/PromptsComposerMenuItem.stories.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptsComposerMenuItem.stories.tsx
@@ -1,0 +1,33 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ *
+ * The row is sized by the composer menu that owns it, so it is drawn inside a
+ * panel of that width rather than stretched across the viewport.
+ */
+import { PromptsComposerMenuItem } from './PromptsComposerMenuItem.tsx';
+
+const meta = {
+  title: 'Prompt/PromptsComposerMenuItem',
+  component: PromptsComposerMenuItem,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">in a composer menu</span>
+        <div
+          role="menu"
+          className="w-64 rounded-md border border-doom-border-soft bg-doom-panel p-1"
+          aria-label="composer actions"
+        >
+          <PromptsComposerMenuItem />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-prompt/src/web/components/PromptsComposerMenuItem.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptsComposerMenuItem.tsx
@@ -20,7 +20,7 @@ export function PromptsComposerMenuItem() {
       role="menuitem"
       density="compact"
       data-testid="composer-menu-prompts"
-      className="w-full text-[12px] text-doom-text hover:bg-doom-tint-blue"
+      className="w-full text-sm text-doom-text hover:bg-doom-tint-blue"
       onClick={requestPromptDialogOpen}
     >
       <BookmarkPlusIcon className="h-3 w-3 shrink-0" />

--- a/packages/default/doompi-prompt/src/web/components/PromptsDialog.stories.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptsDialog.stories.tsx
@@ -1,0 +1,59 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ *
+ * One open dialog only: this portals to the document body over a modal
+ * overlay, so a second open instance would stack on top of the first rather
+ * than sit beside it. The states behind the picker (editor, confirmations) are
+ * reached by interaction, and their bodies have their own stories.
+ */
+import type { SavedPromptView } from '../../types/webPrompts.ts';
+import { PromptsDialog } from './PromptsDialog.tsx';
+
+const prompts: readonly SavedPromptView[] = [
+  {
+    name: 'ship-it',
+    description: 'run the affected targets, then report what changed',
+    text: 'Run the affected Nx lint, typecheck, build and test targets, then report what changed.',
+  },
+  {
+    name: 'review-diff',
+    description: 'review the working tree for concrete defects',
+    text: 'Review the working tree for defects, regressions and missing tests. Name files and lines.',
+  },
+  {
+    name: 'explain-this-flow',
+    description: 'trace one flow end to end before touching it',
+    text: 'Trace this flow from entry point to persistence and list every side effect on the way.',
+  },
+];
+
+const meta = {
+  title: 'Prompt/PromptsDialog',
+  component: PromptsDialog,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          open · the picker over a loaded library
+        </span>
+        <PromptsDialog
+          open
+          prompts={prompts}
+          loading={false}
+          loadError=""
+          sessionId="s1"
+          onOpenChange={() => undefined}
+          onReload={() => Promise.resolve()}
+          onSend={() => undefined}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-prompt/src/web/components/PromptsDialog.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptsDialog.tsx
@@ -150,14 +150,14 @@ export function PromptsDialog({
 
         <DialogBody>
           {error === '' ? null : draft || confirmation ? (
-            <span className="text-[11px] text-doom-red" data-testid="prompts-error">
+            <span className="text-sm text-doom-red" data-testid="prompts-error">
               {error}
             </span>
           ) : null}
 
           {confirmation?.kind === 'remove' ? (
             <div className="flex flex-col gap-4" data-testid="prompts-remove-confirmation">
-              <p className="text-[11px] leading-relaxed text-doom-dim">
+              <p className="text-sm leading-relaxed text-doom-dim">
                 Remove <strong className="text-doom-hi">/{confirmation.prompt.name}</strong>? This cannot be undone.
               </p>
               <div className="flex justify-end gap-2">
@@ -177,7 +177,7 @@ export function PromptsDialog({
             </div>
           ) : confirmation?.kind === 'replace' && draft ? (
             <div className="flex flex-col gap-4" data-testid="prompts-replace-confirmation">
-              <p className="text-[11px] leading-relaxed text-doom-dim">
+              <p className="text-sm leading-relaxed text-doom-dim">
                 <strong className="text-doom-hi">/{confirmation.name}</strong> already exists. Replace its text with
                 this draft?
               </p>
@@ -229,7 +229,7 @@ export function PromptsDialog({
 
         {draft || confirmation ? null : (
           <DialogFooter variant="bar">
-            <span className="text-[10px] text-doom-faint">
+            <span className="text-xs text-doom-faint">
               {prompts.length === 0 ? 'build your reusable library' : `${String(prompts.length)} saved`}
             </span>
             <Button

--- a/packages/default/doompi-prompt/src/web/components/PromptsDialogHost.stories.tsx
+++ b/packages/default/doompi-prompt/src/web/components/PromptsDialogHost.stories.tsx
@@ -1,0 +1,67 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * finding a bare `const meta`, so it is not named at the point of definition.
+ *
+ * The host renders nothing until something asks for the library, and it loads
+ * that library over the sealed transport, which is a plain `fetch` until a
+ * tunnel handshake completes. So this file does the two things the cockpit
+ * would: it answers the collection route, and it publishes one open request.
+ * The request survives until the host subscribes, because
+ * `subscribePromptDialogRequest` delivers the pending one on subscribe.
+ *
+ * ponytail: the stub answers reads only. Nothing here exercises save or
+ * delete; add matching branches if a story needs the mutation states.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { API_BASE_PATH, PROMPTS_PATH, type SavedPromptListResponse } from '../../types/webPrompts.ts';
+import { PromptsDialogHost } from './PromptsDialogHost.tsx';
+import { requestPromptDialogOpen } from '../lib/messagePromptDraft.ts';
+
+const body: SavedPromptListResponse = {
+  prompts: [
+    {
+      name: 'ship-it',
+      description: 'run the affected targets, then report what changed',
+      text: 'Run the affected Nx lint, typecheck, build and test targets, then report what changed.',
+    },
+    {
+      name: 'review-diff',
+      description: 'review the working tree for concrete defects',
+      text: 'Review the working tree for defects, regressions and missing tests. Name files and lines.',
+    },
+  ],
+};
+
+const liveFetch = globalThis.fetch.bind(globalThis);
+globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+  if (!url.includes(`/api/plugin/${API_BASE_PATH}${PROMPTS_PATH}`)) return liveFetch(input, init);
+  return Promise.resolve(
+    new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } }),
+  );
+};
+
+const slot = slotPropsFixture({ sessionId: 's1' }).props;
+
+requestPromptDialogOpen();
+
+const meta = {
+  title: 'Prompt/PromptsDialogHost',
+  component: PromptsDialogHost,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          opened by a composer menu request, library loaded
+        </span>
+        <PromptsDialogHost {...slot} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-prompt/style-system.config.yaml
+++ b/packages/default/doompi-prompt/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/default/doompi-prompt/styles/preview.css
+++ b/packages/default/doompi-prompt/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/default/doompi-prompt/vibe-lint.config.yaml
+++ b/packages/default/doompi-prompt/vibe-lint.config.yaml
@@ -14,3 +14,14 @@ rules:
   public-export-boundary: error
   no-internal-public-import: error
   doom-layer-boundary: error
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/packages/default/doompi-read/package.json
+++ b/packages/default/doompi-read/package.json
@@ -27,7 +27,8 @@
   "files": [
     "dist",
     "src/web",
-    "src/exports/webClient.ts"
+    "src/exports/webClient.ts",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -75,6 +76,7 @@
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "5.0.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsdown": "0.23.0",
     "typescript": "7.0.2",
     "vitest": "5.0.0"

--- a/packages/default/doompi-read/src/web/components/ReadToolMessage.stories.tsx
+++ b/packages/default/doompi-read/src/web/components/ReadToolMessage.stories.tsx
@@ -1,0 +1,67 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { ReadToolMessage } from './ReadToolMessage.tsx';
+
+const OUTPUT = [
+  '@file src/lib/cn.ts#a1b2c3d4',
+  "1#axh|import { clsx, type ClassValue } from 'clsx';",
+  "2#zyb|import { twMerge } from 'tailwind-merge';",
+  '3#rew|',
+  '4#nsj|export function cn(...inputs: ClassValue[]) {',
+  '5#usq|  return twMerge(clsx(inputs));',
+  '6#eky|}',
+].join('\n');
+
+const result = { content: [{ type: 'text', text: OUTPUT }], details: null };
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'read', ...overrides }).props;
+
+const meta = {
+  title: 'Read/ReadToolMessage',
+  component: ReadToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <ReadToolMessage {...props({ args: { path: 'src/lib/cn.ts' }, running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete</span>
+        <ReadToolMessage {...props({ args: { path: 'src/lib/cn.ts' }, result, output: OUTPUT })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          complete · offset and limit in the heading
+        </span>
+        <ReadToolMessage {...props({ args: { path: 'src/lib/cn.ts', offset: 1, limit: 6 }, result, output: OUTPUT })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <ReadToolMessage
+          {...props({
+            args: { path: 'src/lib/missing.ts' },
+            result: { content: [{ type: 'text', text: 'ENOENT: no such file or directory' }], details: null },
+            output: 'ENOENT: no such file or directory',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-read/style-system.config.yaml
+++ b/packages/default/doompi-read/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/default/doompi-read/styles/preview.css
+++ b/packages/default/doompi-read/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/default/doompi-read/tests/packageContract.test.ts
+++ b/packages/default/doompi-read/tests/packageContract.test.ts
@@ -94,7 +94,7 @@ describe('doompi-read package contract', () => {
     const manifest = await readManifest();
     const exportsMap = manifest.exports ?? {};
     expect(exportsMap['./package.json']).toBeDefined();
-    expect(manifest.files).toEqual(['dist', 'src/web', 'src/exports/webClient.ts']);
+    expect(manifest.files).toEqual(['dist', 'src/web', 'src/exports/webClient.ts', '!src/web/**/*.stories.tsx']);
     expect(manifest.files).not.toContain('src');
     expect(manifest.files).not.toContain('tests');
     await expect(access(path.join(packageDirectory, 'dist'))).resolves.toBeUndefined();

--- a/packages/default/doompi-read/vibe-lint.config.yaml
+++ b/packages/default/doompi-read/vibe-lint.config.yaml
@@ -17,3 +17,14 @@ rules:
   no-raw-theme-color: error
   boundary-import-allowlist: error
   file-naming-convention: error
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/packages/default/doompi-runner/package.json
+++ b/packages/default/doompi-runner/package.json
@@ -39,7 +39,8 @@
     "src/types/webRunnerLog.ts",
     "README.md",
     "LICENSE",
-    "package.json"
+    "package.json",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -347,6 +348,7 @@
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "5.0.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsdown": "0.23.0",
     "typescript": "7.0.2",
     "vitest": "5.0.0"

--- a/packages/default/doompi-runner/src/web/components/BashToolMessage.stories.tsx
+++ b/packages/default/doompi-runner/src/web/components/BashToolMessage.stories.tsx
@@ -1,0 +1,146 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { RunnerRunView } from '../../types/webRunners.ts';
+import { runners } from '../stores/runnersStore.ts';
+import { BashToolMessage } from './BashToolMessage.tsx';
+
+const SESSION_ID = 's1';
+
+const run = (overrides: Partial<RunnerRunView> & Pick<RunnerRunView, 'id'>): RunnerRunView => ({
+  name: overrides.id,
+  pid: 4242,
+  command: 'pnpm test',
+  cwd: '/Users/doom/workspace/doompi',
+  interactive: false,
+  backend: 'rmux',
+  state: 'running',
+  promoted: false,
+  startedAt: '2025-01-14T09:12:00.000Z',
+  logPath: `/tmp/doom/runners/${overrides.id}.log`,
+  ...overrides,
+});
+
+// The header's log and stop controls only appear for a run the runners channel
+// has reported, so the story seeds the same store that channel writes into.
+runners.update(SESSION_ID, () => ({
+  runs: [
+    run({
+      id: 'run-1',
+      state: 'completed',
+      exit: { reason: 'completed', code: 0, signal: null, finishedAt: '2025-01-14T09:12:31.000Z' },
+    }),
+    run({ id: 'bg-2', name: 'vitest watch', promoted: true, command: 'pnpm vitest --watch' }),
+    run({ id: 'bg-3', name: 'dev server', promoted: true, command: 'pnpm dev' }),
+  ],
+  stopRequested: ['bg-3'],
+}));
+
+const TAIL = [
+  '$ pnpm test',
+  '',
+  ' ✓ src/lib/cn.test.ts (4 tests) 12ms',
+  ' ✓ src/lib/theme.test.ts (9 tests) 31ms',
+  '',
+  ' Test Files  2 passed (2)',
+  '      Tests  13 passed (13)',
+].join('\n');
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'bash', ...overrides }).props;
+
+/*
+ * The card is collapsed until someone clicks it and the renderer only takes a
+ * screenshot, so every result body here would be invisible. Opening the card
+ * from a mount ref is what puts the body in the shot; the collapsed header is
+ * shown once on its own so both states are reviewable.
+ */
+const openCard = (node: HTMLDivElement | null) =>
+  node?.querySelector<HTMLButtonElement>('[data-testid="tool-expand"]')?.click();
+
+const meta = {
+  title: 'Runner/BashToolMessage',
+  component: BashToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">collapsed · the default</span>
+        <BashToolMessage
+          {...props({
+            args: { command: 'pnpm test', timeout: 120 },
+            result: { content: [], details: { id: 'run-1', tail: TAIL, exitCode: 0 } },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2" ref={openCard}>
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <BashToolMessage {...props({ args: { command: 'pnpm test' }, output: TAIL, running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2" ref={openCard}>
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">expanded · finished, with its log</span>
+        <BashToolMessage
+          {...props({
+            args: { command: 'pnpm test', timeout: 120 },
+            result: {
+              content: [],
+              details: {
+                id: 'run-1',
+                runner: 'rmux',
+                exitCode: 0,
+                lines: 13,
+                fileSize: 2048,
+                logPath: '/tmp/doom/runners/run-1.log',
+                tail: TAIL,
+              },
+            },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2" ref={openCard}>
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">expanded · promoted to the background</span>
+        <BashToolMessage
+          {...props({
+            args: { command: 'pnpm vitest --watch', background: true, name: 'vitest watch' },
+            result: { content: [], details: { id: 'bg-2', runner: 'vitest watch', promoted: true } },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2" ref={openCard}>
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">expanded · a stop already asked for</span>
+        <BashToolMessage
+          {...props({
+            args: { command: 'pnpm dev', background: true, interactive: true, name: 'dev server' },
+            result: { content: [], details: { id: 'bg-3', runner: 'dev server', promoted: true } },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2" ref={openCard}>
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <BashToolMessage
+          {...props({
+            args: { command: 'pnpm build' },
+            result: { content: [{ type: 'text', text: 'error TS2345: argument of type string' }], details: null },
+            output: 'error TS2345: argument of type string',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-runner/src/web/components/BashToolMessage.tsx
+++ b/packages/default/doompi-runner/src/web/components/BashToolMessage.tsx
@@ -101,7 +101,7 @@ export function BashToolMessage({
                     event.stopPropagation();
                     openTransientTab(runnerLogTab(run));
                   }}
-                  className="shrink-0 gap-1 px-1.5 text-[9px] font-bold"
+                  className="shrink-0 gap-1 px-1.5 text-2xs font-bold"
                 >
                   <FileIcon className="h-2.5 w-2.5" />
                   log
@@ -122,7 +122,7 @@ export function BashToolMessage({
                     if (sessionId !== null && runnerId !== undefined)
                       requestRunnerStop(sendSessionFrame, sessionId, runnerId);
                   }}
-                  className="shrink-0 px-1.5 text-[9px] font-bold"
+                  className="shrink-0 px-1.5 text-2xs font-bold"
                 >
                   {stopping ? 'stopping…' : 'stop'}
                 </Button>

--- a/packages/default/doompi-runner/src/web/components/LaunchRunnerDialog.stories.tsx
+++ b/packages/default/doompi-runner/src/web/components/LaunchRunnerDialog.stories.tsx
@@ -1,0 +1,38 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { LaunchRunnerDialog } from './LaunchRunnerDialog.tsx';
+
+const { props } = slotPropsFixture({ sessionId: 'runner-launch' });
+
+const meta = {
+  title: 'Runner/LaunchRunnerDialog',
+  component: LaunchRunnerDialog,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+/*
+ * One dialog only: it is modal and portals into the body, so a second instance
+ * would draw its overlay over the first. This is the state it opens in, with
+ * the command still empty, which is also the state that shows the problem line
+ * and the disabled submit.
+ */
+export const Playground = {
+  render: () => (
+    <div className="h-screen w-screen bg-doom-bg">
+      <LaunchRunnerDialog
+        sessionId="runner-launch"
+        sendSessionFrame={props.sendSessionFrame}
+        defaultCwd="/Users/doom/workspace/doompi"
+        onClose={() => undefined}
+      />
+    </div>
+  ),
+};

--- a/packages/default/doompi-runner/src/web/components/LaunchRunnerDialog.tsx
+++ b/packages/default/doompi-runner/src/web/components/LaunchRunnerDialog.tsx
@@ -19,7 +19,7 @@ const COMMAND_ROWS = 3;
 const INTERACTIVE_FIELD_ID = 'runner-launch-interactive-field';
 
 function FieldLabel({ children }: { children: string }) {
-  return <span className="text-[9px] font-bold tracking-[0.18em] text-doom-faint">{children}</span>;
+  return <span className="text-2xs font-bold tracking-widest text-doom-faint">{children}</span>;
 }
 
 /**
@@ -77,7 +77,7 @@ export function LaunchRunnerDialog({
               value={command}
               placeholder="pnpm test"
               onChange={(event) => setCommand(event.target.value)}
-              className="text-[11px]"
+              className="text-sm"
             />
           </div>
 
@@ -90,7 +90,7 @@ export function LaunchRunnerDialog({
                 value={cwd}
                 placeholder="the session's own directory"
                 onChange={(event) => setCwd(event.target.value)}
-                className="text-[10px]"
+                className="text-xs"
               />
             </div>
             <div className="flex min-w-0 flex-1 flex-col gap-1">
@@ -101,7 +101,7 @@ export function LaunchRunnerDialog({
                 value={name}
                 placeholder="chosen for you when empty"
                 onChange={(event) => setName(event.target.value)}
-                className="text-[10px]"
+                className="text-xs"
               />
             </div>
           </div>
@@ -115,29 +115,26 @@ export function LaunchRunnerDialog({
               checked={interactive}
               onCheckedChange={(checked) => setInteractive(checked === true)}
             />
-            <label htmlFor={INTERACTIVE_FIELD_ID} className="text-[10px] text-doom-dim">
+            <label htmlFor={INTERACTIVE_FIELD_ID} className="text-xs text-doom-dim">
               needs a terminal, for a command that prompts (requires rmux or tmux)
             </label>
           </div>
 
           <div className="flex flex-col gap-1 rounded-md border border-doom-border bg-doom-deep px-3 py-2">
             <FieldLabel>SENT TO THE SESSION</FieldLabel>
-            <pre
-              data-testid="runner-launch-line"
-              className="whitespace-pre-wrap break-words text-[10px] text-doom-green"
-            >
+            <pre data-testid="runner-launch-line" className="whitespace-pre-wrap break-words text-xs text-doom-green">
               {line}
             </pre>
           </div>
 
           {problems.length > 0 ? (
-            <p data-testid="runner-launch-problem" className="text-[10px] text-doom-red">
+            <p data-testid="runner-launch-problem" className="text-xs text-doom-red">
               {problems.join(' ')}
             </p>
           ) : null}
 
           <DialogFooter className="flex-wrap sm:flex-nowrap">
-            <span className="w-full text-[9px] text-doom-faint sm:w-auto">
+            <span className="w-full text-2xs text-doom-faint sm:w-auto">
               it appears above once the runtime starts it
             </span>
             <span className="min-w-0 flex-1" />

--- a/packages/default/doompi-runner/src/web/components/RunnerLogPanel.stories.tsx
+++ b/packages/default/doompi-runner/src/web/components/RunnerLogPanel.stories.tsx
@@ -1,0 +1,119 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { RunnerRunView } from '../../types/webRunners.ts';
+import { runners } from '../stores/runnersStore.ts';
+import { RunnerLogPanel } from './RunnerLogPanel.tsx';
+
+/** Its own session id, so a story that seeds this store cannot disturb another's. */
+const SESSION_ID = 'runner-log';
+const MINUTE_MS = 60_000;
+
+const LOG_LINES = [
+  '\u001B[2m$\u001B[0m pnpm vitest run packages/core',
+  '',
+  '\u001B[32m ✓\u001B[0m src/lib/cn.test.ts (4 tests) 12ms',
+  '\u001B[32m ✓\u001B[0m src/lib/hashlineView.test.ts (11 tests) 28ms',
+  '\u001B[33m ↓\u001B[0m src/lib/ansi.test.ts (1 skipped)',
+  '',
+  ' Test Files  2 passed | 1 skipped (3)',
+  '      Tests  15 passed | 1 skipped (16)',
+  '   Duration  1.42s',
+];
+
+const run = (overrides: Partial<RunnerRunView> & Pick<RunnerRunView, 'id' | 'name'>): RunnerRunView => ({
+  pid: 4242,
+  command: 'pnpm vitest run packages/core',
+  cwd: '/Users/doom/workspace/doompi',
+  interactive: false,
+  backend: 'rmux',
+  state: 'running',
+  promoted: true,
+  startedAt: new Date(Date.now() - 6 * MINUTE_MS).toISOString(),
+  logPath: `/tmp/doom/runners/${overrides.id}.log`,
+  ...overrides,
+});
+
+runners.update(SESSION_ID, () => ({
+  runs: [
+    run({ id: 'live', name: 'vitest watch' }),
+    run({
+      id: 'done',
+      name: 'docs build',
+      command: 'pnpm nx build @agimon-ai/doompi-docs',
+      state: 'completed',
+      exit: { reason: 'completed', code: 0, signal: null, finishedAt: new Date().toISOString() },
+    }),
+  ],
+  stopRequested: [],
+}));
+
+/*
+ * The panel reads its lines from the hub over HTTP, and a story has no hub, so
+ * the log route is answered here and everything else still reaches the real
+ * fetch. Without it every variant would be the "unreachable" banner. The
+ * follow stream is left unanswered: it fails, the panel stops following, and
+ * the shot is the settled state rather than a race.
+ */
+const LOG_URL = /\/api\/plugin\/runner\/runners\/([^/?]+)\/log\?/u;
+const realFetch = globalThis.fetch.bind(globalThis);
+globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = input instanceof Request ? input.url : String(input);
+  const runId = LOG_URL.exec(url)?.[1];
+  if (runId === undefined) return realFetch(input, init);
+  return Promise.resolve(
+    Response.json({
+      runId,
+      running: runId === 'live',
+      text: LOG_LINES.join('\n'),
+      lineCount: LOG_LINES.length,
+      totalLines: 1284,
+      fileSize: 48_212,
+      completeBytes: 48_212,
+      path: `/tmp/doom/runners/${runId}.log`,
+      exists: true,
+    }),
+  );
+};
+
+const props = slotPropsFixture({ sessionId: SESSION_ID }).props;
+
+const meta = {
+  title: 'Runner/RunnerLogPanel',
+  component: RunnerLogPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">a runner that is still writing</span>
+        <div className="flex h-96 flex-col rounded-md border border-doom-border bg-doom-bg">
+          <RunnerLogPanel {...props} runId="live" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">a finished runner</span>
+        <div className="flex h-96 flex-col rounded-md border border-doom-border bg-doom-bg">
+          <RunnerLogPanel {...props} runId="done" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no longer listed, log still readable</span>
+        <div className="flex h-80 flex-col rounded-md border border-doom-border bg-doom-bg">
+          <RunnerLogPanel {...props} runId="forgotten" />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-runner/src/web/components/RunnerLogPanel.tsx
+++ b/packages/default/doompi-runner/src/web/components/RunnerLogPanel.tsx
@@ -56,8 +56,8 @@ function isMatch(line: string, needle: string, ignoreCase: boolean): boolean {
 function MetaRow({ label, value }: { label: string; value: string }) {
   return (
     <span className="flex min-w-0 gap-2.5">
-      <span className="w-14 shrink-0 text-[10px] text-doom-faint">{label}</span>
-      <span className="min-w-0 flex-1 break-all text-[10px] text-doom-dim">{value}</span>
+      <span className="w-14 shrink-0 text-xs text-doom-faint">{label}</span>
+      <span className="min-w-0 flex-1 break-all text-xs text-doom-dim">{value}</span>
     </span>
   );
 }
@@ -74,17 +74,17 @@ function LogRow({ number, line, matched }: { number: number | undefined; line: s
   return (
     <div data-testid="runner-log-row" data-matched={matched} className="flex min-w-0 gap-2">
       {number === undefined ? null : (
-        <span className="w-12 shrink-0 select-none text-right text-[10px] leading-[1.6] text-doom-faint">{number}</span>
+        <span className="w-12 shrink-0 select-none text-right text-xs leading-relaxed text-doom-faint">{number}</span>
       )}
       <span
         aria-hidden
-        className={`w-4 shrink-0 select-none text-[10px] leading-[1.6] ${matched ? 'text-doom-yellow' : 'text-doom-faint'}`}
+        className={`w-4 shrink-0 select-none text-xs leading-relaxed ${matched ? 'text-doom-yellow' : 'text-doom-faint'}`}
       >
         {matched ? '>>' : ''}
       </span>
       <AnsiLine
         line={line}
-        className={`min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-[10px] leading-[1.6] ${
+        className={`min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-xs leading-relaxed ${
           matched ? 'text-doom-text' : 'text-doom-dim'
         }`}
       />
@@ -207,7 +207,7 @@ export function RunnerLogPanel({ sessionId, runId, sendSessionFrame }: WebPlugin
   return (
     <div data-testid="runner-log-panel" className="flex min-h-0 flex-1 flex-col">
       <div className="flex min-h-11 shrink-0 flex-wrap items-center gap-2 border-b border-doom-border-soft px-3 py-2 sm:h-11 sm:flex-nowrap sm:gap-2.5 sm:px-[26px] sm:py-0">
-        <span data-testid="runner-log-name" className="shrink-0 truncate text-[12px] font-bold text-doom-hi">
+        <span data-testid="runner-log-name" className="shrink-0 truncate text-sm font-bold text-doom-hi">
           {run?.name ?? runId}
         </span>
         <StatusBadge tone={badge.tone} data-testid="runner-log-state">
@@ -215,13 +215,13 @@ export function RunnerLogPanel({ sessionId, runId, sendSessionFrame }: WebPlugin
         </StatusBadge>
         {run ? (
           <>
-            <span className="shrink-0 text-[10px] text-doom-faint">{elapsed}</span>
-            <span className="shrink-0 text-[10px] text-doom-faint">
+            <span className="shrink-0 text-xs text-doom-faint">{elapsed}</span>
+            <span className="shrink-0 text-xs text-doom-faint">
               {`pid ${String(run.pid)} · ${run.backend}${run.interactive ? ' · tty' : ''}`}
             </span>
           </>
         ) : (
-          <span data-testid="runner-log-gone" className="text-[10px] text-doom-faint">
+          <span data-testid="runner-log-gone" className="text-xs text-doom-faint">
             no longer listed; its log stays readable
           </span>
         )}
@@ -234,7 +234,7 @@ export function RunnerLogPanel({ sessionId, runId, sendSessionFrame }: WebPlugin
             disabled={stopping}
             title={stopping ? 'stop requested; the runner reports its own exit' : 'ask the runtime to stop this runner'}
             onClick={() => requestRunnerStop(sendSessionFrame, sessionId, run.id)}
-            className="px-2 text-[9px] font-bold"
+            className="px-2 text-2xs font-bold"
           >
             {stopping ? 'stopping…' : 'stop'}
           </Button>
@@ -257,7 +257,7 @@ export function RunnerLogPanel({ sessionId, runId, sendSessionFrame }: WebPlugin
             value={typed}
             placeholder="search this log"
             onChange={(event) => setTyped(event.target.value)}
-            className="pl-7 text-[10px]"
+            className="pl-7 text-xs"
           />
         </span>
         <Button
@@ -267,7 +267,7 @@ export function RunnerLogPanel({ sessionId, runId, sendSessionFrame }: WebPlugin
           aria-pressed={ignoreCase}
           title="match regardless of case"
           onClick={() => setIgnoreCase((current) => !current)}
-          className="px-2 text-[9px] font-bold"
+          className="px-2 text-2xs font-bold"
         >
           aA
         </Button>
@@ -278,14 +278,14 @@ export function RunnerLogPanel({ sessionId, runId, sendSessionFrame }: WebPlugin
           disabled={!filtering}
           title="lines of context kept either side of a match"
           onClick={() => setContext((current) => (current === 0 ? CONTEXT_LINES : 0))}
-          className="px-2 text-[9px] font-bold"
+          className="px-2 text-2xs font-bold"
         >
           {`± ${String(context)} lines`}
         </Button>
         <span className="min-w-0 flex-1" />
         <span
           data-testid="runner-log-stats"
-          className="min-w-0 basis-full truncate text-[10px] text-doom-faint sm:basis-auto"
+          className="min-w-0 basis-full truncate text-xs text-doom-faint sm:basis-auto"
         >
           {slice === undefined
             ? 'reading…'
@@ -302,7 +302,7 @@ export function RunnerLogPanel({ sessionId, runId, sendSessionFrame }: WebPlugin
           disabled={filtering || slice?.running !== true}
           title={filtering ? 'a filtered view is a snapshot; clear the query to follow' : 'follow the log as it grows'}
           onClick={() => setFollowing((current) => !current)}
-          className="px-2 text-[9px] font-bold"
+          className="px-2 text-2xs font-bold"
         >
           {filtering ? 'follow · paused' : 'follow'}
         </Button>
@@ -316,17 +316,17 @@ export function RunnerLogPanel({ sessionId, runId, sendSessionFrame }: WebPlugin
           className="h-full overflow-auto bg-doom-panel-deep px-3 py-3 sm:px-[26px]"
         >
           {error !== undefined ? (
-            <p data-testid="runner-log-error" className="text-[10px] text-doom-red">
+            <p data-testid="runner-log-error" className="text-xs text-doom-red">
               {error}
             </p>
           ) : slice === undefined ? (
-            <p data-testid="runner-log-reading" className="text-[10px] text-doom-faint">
+            <p data-testid="runner-log-reading" className="text-xs text-doom-faint">
               reading…
             </p>
           ) : slice.exists === false ? (
-            <p className="text-[10px] text-doom-faint">this runner has not written a log yet</p>
+            <p className="text-xs text-doom-faint">this runner has not written a log yet</p>
           ) : view.lines.length === 0 ? (
-            <p className="text-[10px] text-doom-faint">{filtering ? 'nothing matched' : 'the log is empty'}</p>
+            <p className="text-xs text-doom-faint">{filtering ? 'nothing matched' : 'the log is empty'}</p>
           ) : (
             view.lines.map((line, index) => {
               const number = numbers[index];
@@ -338,7 +338,7 @@ export function RunnerLogPanel({ sessionId, runId, sendSessionFrame }: WebPlugin
                     <div
                       data-testid="runner-log-gap"
                       aria-hidden
-                      className="select-none py-0.5 pl-12 text-[10px] leading-[1.6] text-doom-faint"
+                      className="select-none py-0.5 pl-12 text-xs leading-relaxed text-doom-faint"
                     >
                       ⋯
                     </div>
@@ -360,7 +360,7 @@ export function RunnerLogPanel({ sessionId, runId, sendSessionFrame }: WebPlugin
               setPinned(true);
               bottom.current?.scrollIntoView({ block: 'end' });
             }}
-            className="absolute bottom-3 right-3 px-2 text-[9px] font-bold"
+            className="absolute bottom-3 right-3 px-2 text-2xs font-bold"
           >
             jump to latest
           </Button>
@@ -368,11 +368,11 @@ export function RunnerLogPanel({ sessionId, runId, sendSessionFrame }: WebPlugin
       </div>
 
       <div className="flex h-8 shrink-0 items-center gap-2.5 border-t border-doom-border-soft px-3 sm:px-[26px]">
-        <span data-testid="runner-log-path" className="min-w-0 flex-1 truncate text-[9px] text-doom-faint">
+        <span data-testid="runner-log-path" className="min-w-0 flex-1 truncate text-2xs text-doom-faint">
           {run?.logPath ?? slice?.path ?? ''}
         </span>
         {slice !== undefined ? (
-          <span className="shrink-0 text-[9px] text-doom-faint">{formatSize(slice.fileSize)}</span>
+          <span className="shrink-0 text-2xs text-doom-faint">{formatSize(slice.fileSize)}</span>
         ) : null}
       </div>
     </div>

--- a/packages/default/doompi-runner/src/web/components/RunnerShellPanel.stories.tsx
+++ b/packages/default/doompi-runner/src/web/components/RunnerShellPanel.stories.tsx
@@ -1,0 +1,76 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { RunnerRunView } from '../../types/webRunners.ts';
+import { runners } from '../stores/runnersStore.ts';
+import { RunnerShellPanel } from './RunnerShellPanel.tsx';
+
+/** Its own session id, so a story that seeds this store cannot disturb another's. */
+const SESSION_ID = 'runner-shell';
+
+const run = (overrides: Partial<RunnerRunView> & Pick<RunnerRunView, 'id' | 'name'>): RunnerRunView => ({
+  pid: 4242,
+  command: 'zsh -l',
+  cwd: '/Users/doom/workspace/doompi',
+  interactive: true,
+  backend: 'rmux',
+  state: 'running',
+  promoted: true,
+  startedAt: new Date().toISOString(),
+  logPath: `/tmp/doom/runners/${overrides.id}.log`,
+  ...overrides,
+});
+
+runners.update(SESSION_ID, () => ({
+  runs: [
+    run({ id: 'attached', name: 'dev shell' }),
+    run({
+      id: 'detached',
+      name: 'old shell',
+      state: 'completed',
+      exit: { reason: 'completed', code: 0, signal: null, finishedAt: new Date().toISOString() },
+    }),
+  ],
+  stopRequested: [],
+}));
+
+const props = slotPropsFixture({ sessionId: SESSION_ID }).props;
+
+const meta = {
+  title: 'Runner/RunnerShellPanel',
+  component: RunnerShellPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+/*
+ * The pane itself stays empty: its bytes arrive on a server-sent stream and a
+ * story has no hub to open one against. What is reviewable here is the chrome
+ * around the emulator, and that the emulator mounts at all, since xterm is
+ * imported only when this panel opens.
+ */
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">attached</span>
+        <div className="flex h-64 flex-col rounded-md border border-doom-border bg-doom-bg">
+          <RunnerShellPanel {...props} runId="attached" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">the runner has exited</span>
+        <div className="flex h-64 flex-col rounded-md border border-doom-border bg-doom-bg">
+          <RunnerShellPanel {...props} runId="detached" />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-runner/src/web/components/RunnerShellPanel.tsx
+++ b/packages/default/doompi-runner/src/web/components/RunnerShellPanel.tsx
@@ -80,7 +80,7 @@ export function RunnerShellPanel({ sessionId, runId }: WebPluginSlotProps & { ru
   return (
     <div data-testid="runner-shell-panel" className="flex min-h-0 flex-1 flex-col">
       <div className="flex min-h-11 shrink-0 items-center gap-2.5 border-b border-doom-border-soft px-3 sm:h-11 sm:px-[26px]">
-        <span data-testid="runner-shell-name" className="shrink-0 truncate text-[12px] font-bold text-doom-hi">
+        <span data-testid="runner-shell-name" className="shrink-0 truncate text-sm font-bold text-doom-hi">
           {run?.name ?? runId}
         </span>
         <StatusBadge tone={live ? 'running' : 'neutral'} data-testid="runner-shell-state">
@@ -88,7 +88,7 @@ export function RunnerShellPanel({ sessionId, runId }: WebPluginSlotProps & { ru
         </StatusBadge>
         <span className="min-w-0 flex-1" />
         {lost ? (
-          <span data-testid="runner-shell-lost" className="shrink-0 text-[9px] text-doom-red">
+          <span data-testid="runner-shell-lost" className="shrink-0 text-2xs text-doom-red">
             the connection to this pane dropped
           </span>
         ) : null}
@@ -99,7 +99,7 @@ export function RunnerShellPanel({ sessionId, runId }: WebPluginSlotProps & { ru
             data-testid="runner-shell-interrupt"
             title="send ctrl-c"
             onClick={() => send('\u0003')}
-            className="px-2 text-[9px] font-bold"
+            className="px-2 text-2xs font-bold"
           >
             ctrl-c
           </Button>
@@ -114,14 +114,14 @@ export function RunnerShellPanel({ sessionId, runId }: WebPluginSlotProps & { ru
           onReady={() => setReady(true)}
         />
         {ready ? null : (
-          <p data-testid="runner-shell-reading" className="text-[10px] text-doom-faint">
+          <p data-testid="runner-shell-reading" className="text-xs text-doom-faint">
             attaching…
           </p>
         )}
       </div>
 
       <div className="flex h-8 shrink-0 items-center border-t border-doom-border-soft px-3 sm:px-[26px]">
-        <span className="min-w-0 flex-1 truncate text-[9px] text-doom-faint">
+        <span className="min-w-0 flex-1 truncate text-2xs text-doom-faint">
           {live ? 'typing goes straight to the runner' : 'this runner is no longer accepting input'}
         </span>
       </div>

--- a/packages/default/doompi-runner/src/web/components/RunnersActivitySection.stories.tsx
+++ b/packages/default/doompi-runner/src/web/components/RunnersActivitySection.stories.tsx
@@ -1,0 +1,79 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { RunnerRunView } from '../../types/webRunners.ts';
+import { runners } from '../stores/runnersStore.ts';
+import { RunnersActivitySection } from './RunnersActivitySection.tsx';
+
+/** Its own session id, so a story that seeds this store cannot disturb another's. */
+const SESSION_ID = 'runners-activity';
+const IDLE_SESSION_ID = 'runners-activity-idle';
+const MINUTE_MS = 60_000;
+
+const run = (overrides: Partial<RunnerRunView> & Pick<RunnerRunView, 'id' | 'name'>): RunnerRunView => ({
+  pid: 4242,
+  command: 'pnpm test',
+  cwd: '/Users/doom/workspace/doompi',
+  interactive: false,
+  backend: 'rmux',
+  state: 'running',
+  promoted: true,
+  // Relative, so the uptime the row prints stays a plausible few minutes.
+  startedAt: new Date(Date.now() - 3 * MINUTE_MS).toISOString(),
+  logPath: `/tmp/doom/runners/${overrides.id}.log`,
+  ...overrides,
+});
+
+// The dock renders whatever the runners channel last reported, so the story
+// seeds the same store that channel writes into.
+runners.update(SESSION_ID, () => ({
+  runs: [
+    run({ id: 'r1', name: 'vitest watch', command: 'pnpm vitest --watch packages/core' }),
+    run({
+      id: 'r2',
+      name: 'dev shell',
+      interactive: true,
+      command: 'zsh -l',
+      startedAt: new Date(Date.now() - 47 * MINUTE_MS).toISOString(),
+    }),
+    run({ id: 'r3', name: 'docs build', command: 'pnpm nx build @agimon-ai/doompi-docs --verbose' }),
+  ],
+  stopRequested: ['r3'],
+}));
+
+const props = (sessionId: string) => slotPropsFixture({ sessionId }).props;
+
+const meta = {
+  title: 'Runner/RunnersActivitySection',
+  component: RunnersActivitySection,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          three running, one stop asked for · at the dock's width
+        </span>
+        <div className="w-72 rounded-md border border-doom-border bg-doom-panel p-2">
+          <RunnersActivitySection {...props(SESSION_ID)} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">idle</span>
+        <div className="w-72 rounded-md border border-doom-border bg-doom-panel p-2">
+          <RunnersActivitySection {...props(IDLE_SESSION_ID)} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-runner/src/web/components/RunnersActivitySection.tsx
+++ b/packages/default/doompi-runner/src/web/components/RunnersActivitySection.tsx
@@ -34,7 +34,7 @@ export function RunnersActivitySection({ sessionId, sendSessionFrame, openTransi
   if (running.length === 0) {
     return (
       <div className="flex items-center gap-2 px-1">
-        <p data-testid="activity-summary-runners" className="px-1 text-[10px] text-doom-faint">
+        <p data-testid="activity-summary-runners" className="px-1 text-xs text-doom-faint">
           idle
         </p>
         {sessionId === null ? null : (
@@ -98,12 +98,12 @@ function RunnerRow({
         if (sessionId === null) return;
         openTransientTab(runnerLogTab(run));
       }}
-      className="min-w-0 gap-0.5 rounded-[5px] px-1 py-1 hover:bg-doom-panel"
+      className="min-w-0 gap-0.5 rounded-md px-1 py-1 hover:bg-doom-panel"
     >
       <span className="flex min-w-0 items-center gap-1.5">
         <Dot tone="yellow" pulse />
-        <span className="min-w-0 flex-1 truncate text-left text-[10px] font-bold text-doom-hi">{run.name}</span>
-        <span className="shrink-0 text-[9px] text-doom-faint">
+        <span className="min-w-0 flex-1 truncate text-left text-xs font-bold text-doom-hi">{run.name}</span>
+        <span className="shrink-0 text-2xs text-doom-faint">
           {formatRunnerUptime(run.startedAt, now)}
           {run.interactive ? ' · tty' : ''}
         </span>
@@ -117,7 +117,7 @@ function RunnerRow({
             title={
               stopRequested ? 'stop requested; the runner reports its own exit' : 'ask the runtime to stop this runner'
             }
-            className="px-1.5 text-[8px] font-bold"
+            className="px-1.5 text-2xs font-bold"
           >
             {/* The row is already a button, so the stop control lends it
                 the primitive's styling rather than nesting a second one. */}
@@ -146,7 +146,7 @@ function RunnerRow({
       <span
         data-testid={`activity-runner-detail-${run.id}`}
         data-detail={tail === undefined ? 'command' : 'tail'}
-        className="truncate pl-3 text-left text-[9px] text-doom-faint"
+        className="truncate pl-3 text-left text-2xs text-doom-faint"
       >
         {tail ?? run.command}
       </span>

--- a/packages/default/doompi-runner/src/web/components/RunnersPanel.stories.tsx
+++ b/packages/default/doompi-runner/src/web/components/RunnersPanel.stories.tsx
@@ -1,0 +1,78 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { RunnerRunView } from '../../types/webRunners.ts';
+import { runners } from '../stores/runnersStore.ts';
+import { RunnersPanel } from './RunnersPanel.tsx';
+
+/** Its own session id, so a story that seeds this store cannot disturb another's. */
+const SESSION_ID = 'runners-panel';
+const EMPTY_SESSION_ID = 'runners-panel-empty';
+const MINUTE_MS = 60_000;
+
+const run = (overrides: Partial<RunnerRunView> & Pick<RunnerRunView, 'id' | 'name'>): RunnerRunView => ({
+  pid: 4242,
+  command: 'pnpm test',
+  cwd: '/Users/doom/workspace/doompi',
+  interactive: false,
+  backend: 'rmux',
+  state: 'running',
+  promoted: true,
+  // Relative, so the uptime the card prints stays a plausible few minutes.
+  startedAt: new Date(Date.now() - 4 * MINUTE_MS).toISOString(),
+  logPath: `/tmp/doom/runners/${overrides.id}.log`,
+  ...overrides,
+});
+
+// The panel renders whatever the runners channel last reported, so the story
+// seeds the same store that channel writes into.
+runners.update(SESSION_ID, () => ({
+  runs: [
+    run({ id: 'r1', name: 'vitest watch', command: 'pnpm vitest --watch packages/core' }),
+    run({
+      id: 'r2',
+      name: 'dev shell',
+      interactive: true,
+      command: 'zsh -l',
+      startedAt: new Date(Date.now() - 22 * MINUTE_MS).toISOString(),
+    }),
+    run({ id: 'r3', name: 'docs build', command: 'pnpm nx build @agimon-ai/doompi-docs --verbose' }),
+    run({ id: 'r4', name: 'exited', state: 'completed' }),
+  ],
+  stopRequested: ['r3'],
+}));
+
+const props = (sessionId: string) => slotPropsFixture({ sessionId }).props;
+
+const meta = {
+  title: 'Runner/RunnersPanel',
+  component: RunnersPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">three running, one stop asked for</span>
+        <div className="flex h-80 flex-col rounded-md border border-doom-border bg-doom-bg">
+          <RunnersPanel {...props(SESSION_ID)} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">nothing running</span>
+        <div className="flex h-64 flex-col rounded-md border border-doom-border bg-doom-bg">
+          <RunnersPanel {...props(EMPTY_SESSION_ID)} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/default/doompi-runner/src/web/components/RunnersPanel.tsx
+++ b/packages/default/doompi-runner/src/web/components/RunnersPanel.tsx
@@ -80,8 +80,8 @@ export function RunnersPanel({ sessionId, sendSessionFrame, openTransientTab }: 
   return (
     <div data-testid="runners-panel" className="flex min-h-0 flex-1 flex-col overflow-auto">
       <div className="flex min-h-11 shrink-0 items-center gap-2.5 border-b border-doom-border-soft px-3 sm:h-11 sm:px-[26px]">
-        <span className="text-[12px] font-bold text-doom-hi">runners</span>
-        <span data-testid="runners-panel-count" className="text-[10px] text-doom-faint">
+        <span className="text-sm font-bold text-doom-hi">runners</span>
+        <span data-testid="runners-panel-count" className="text-xs text-doom-faint">
           {running.length === 0 ? 'nothing running' : `${String(running.length)} running`}
         </span>
         <span className="min-w-0 flex-1" />
@@ -124,7 +124,7 @@ export function RunnersPanel({ sessionId, sendSessionFrame, openTransientTab }: 
               size="xs"
               data-testid="runners-panel-launch-empty"
               onClick={() => setLaunching(true)}
-              className="px-2 text-[9px] font-bold"
+              className="px-2 text-2xs font-bold"
             >
               launch a runner
             </Button>
@@ -181,26 +181,26 @@ function RunnerCard({
   return (
     <div
       data-testid={`runners-card-${run.id}`}
-      className="flex min-w-0 flex-col gap-1.5 rounded-[5px] border border-doom-border-soft bg-doom-panel p-2.5"
+      className="flex min-w-0 flex-col gap-1.5 rounded-md border border-doom-border-soft bg-doom-panel p-2.5"
     >
       <div className="flex min-w-0 items-center gap-1.5">
         <Dot tone="yellow" pulse />
-        <span className="min-w-0 flex-1 truncate text-[11px] font-bold text-doom-hi">{run.name}</span>
-        <span className="shrink-0 text-[9px] text-doom-faint">
+        <span className="min-w-0 flex-1 truncate text-sm font-bold text-doom-hi">{run.name}</span>
+        <span className="shrink-0 text-2xs text-doom-faint">
           {formatRunnerUptime(run.startedAt, now)}
           {run.interactive ? ' · tty' : ''}
         </span>
       </div>
 
-      <span className="min-w-0 break-all text-[9px] leading-[1.5] text-doom-dim">{run.command}</span>
-      <span className="min-w-0 truncate text-[9px] text-doom-faint">{run.cwd}</span>
+      <span className="min-w-0 break-all text-2xs leading-normal text-doom-dim">{run.command}</span>
+      <span className="min-w-0 truncate text-2xs text-doom-faint">{run.cwd}</span>
 
       {/* What it is doing, falling back to what it was asked to do until the
           first line of output arrives. */}
       <span
         data-testid={`runners-card-detail-${run.id}`}
         data-detail={tail === undefined ? 'command' : 'tail'}
-        className="min-w-0 truncate text-[9px] text-doom-faint"
+        className="min-w-0 truncate text-2xs text-doom-faint"
       >
         {tail ?? '…'}
       </span>
@@ -212,7 +212,7 @@ function RunnerCard({
           data-testid={`runners-card-log-${run.id}`}
           title="open this runner's log"
           onClick={() => openTransientTab(runnerLogTab(run))}
-          className="px-2 text-[9px] font-bold"
+          className="px-2 text-2xs font-bold"
         >
           log
         </Button>
@@ -225,7 +225,7 @@ function RunnerCard({
             data-testid={`runners-card-shell-${run.id}`}
             title="attach to this runner's terminal"
             onClick={() => openTransientTab(runnerShellTab(run))}
-            className="px-2 text-[9px] font-bold"
+            className="px-2 text-2xs font-bold"
           >
             shell
           </Button>
@@ -241,7 +241,7 @@ function RunnerCard({
               stopRequested ? 'stop requested; the runner reports its own exit' : 'ask the runtime to stop this runner'
             }
             onClick={() => requestRunnerStop(sendSessionFrame, sessionId, run.id)}
-            className="px-2 text-[9px] font-bold"
+            className="px-2 text-2xs font-bold"
           >
             {stopRequested ? 'stopping…' : 'stop'}
           </Button>

--- a/packages/default/doompi-runner/style-system.config.yaml
+++ b/packages/default/doompi-runner/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/default/doompi-runner/styles/preview.css
+++ b/packages/default/doompi-runner/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/default/doompi-runner/vibe-lint.config.yaml
+++ b/packages/default/doompi-runner/vibe-lint.config.yaml
@@ -19,6 +19,15 @@ rules:
   file-naming-convention: error
 
 overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off
   # responseEnvelope carries the bash tool result shape and reads the log files
   # that back it, so both the command and its renderer depend on it. Splitting
   # the pure shape from the filesystem reads is tracked separately; until then

--- a/packages/minor/doompi-author/package.json
+++ b/packages/minor/doompi-author/package.json
@@ -35,7 +35,8 @@
     "llms.txt",
     "README.md",
     "LICENSE",
-    "package.json"
+    "package.json",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/minor/doompi-author/src/web/components/AuthorDocumentPanel.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorDocumentPanel.stories.tsx
@@ -1,0 +1,63 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The panel loads the document over HTTP when
+ * the store has none, so each variant seeds the store first and only the
+ * inactive-mode branch is left to the fallback path.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { WebPluginSlotProps } from '@agimon-ai/doompi-web-contracts';
+import type { AuthorDocumentInput } from '../lib/authorViewportTypes.ts';
+import { putAuthorDocument, reviseAuthorDocument } from '../stores/authorWorkspaceStore.ts';
+import { AuthorDocumentPanel } from './AuthorDocumentPanel.tsx';
+
+const SPEC: AuthorDocumentInput = {
+  path: 'docs/spec.md',
+  kind: 'markdown',
+  title: 'Gateway spec',
+  content: '# Gateway retries\n\nThe gateway retries three times before giving up.\n\n- immediate\n- backed off',
+  sourceSha256: 'abc123',
+};
+
+const NOTES: AuthorDocumentInput = {
+  path: 'docs/notes.txt',
+  kind: 'text',
+  content: 'retry budget: 3\nbackoff: 2s\n',
+  sourceSha256: 'def456',
+};
+
+putAuthorDocument('doc-preview', SPEC);
+putAuthorDocument('doc-dirty', NOTES);
+reviseAuthorDocument('doc-dirty', NOTES.path, 'retry budget: 5\nbackoff: 2s\n');
+
+function props(sessionId: string, activeMinorModes: readonly string[]): WebPluginSlotProps {
+  return { ...slotPropsFixture({ sessionId }).props, activeMinorModes };
+}
+
+const meta = {
+  title: 'Author/AuthorDocumentPanel',
+  component: AuthorDocumentPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex h-64 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">markdown · preview</span>
+        <AuthorDocumentPanel {...props('doc-preview', ['author'])} path={SPEC.path} />
+      </div>
+
+      <div className="flex h-64 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">text · unsaved revision, save enabled</span>
+        <AuthorDocumentPanel {...props('doc-dirty', ['author'])} path={NOTES.path} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">author mode off · no file viewer</span>
+        <AuthorDocumentPanel {...props('doc-preview', [])} path={SPEC.path} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/AuthorDocumentPanel.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorDocumentPanel.tsx
@@ -53,7 +53,7 @@ export function AuthorDocumentPanel(props: AuthorDocumentPanelProps) {
       return <fallback.panel {...props} />;
     }
     return (
-      <p data-testid="author-mode-inactive" className="p-3 text-xs text-doom-dim">
+      <p data-testid="author-mode-inactive" className="p-3 text-sm text-doom-dim">
         No file viewer is available for this path.
       </p>
     );
@@ -114,7 +114,7 @@ function ActiveAuthorDocumentPanel({ path, sessionId, statuses }: AuthorDocument
     };
   }, [kind, path, sessionId]);
   if (document === undefined || sessionId === null) {
-    return <p className="p-4 text-[11px] text-doom-faint">{status ?? 'Loading document...'}</p>;
+    return <p className="p-4 text-sm text-doom-faint">{status ?? 'Loading document...'}</p>;
   }
 
   const save = async (): Promise<void> => {
@@ -145,7 +145,7 @@ function ActiveAuthorDocumentPanel({ path, sessionId, statuses }: AuthorDocument
   return (
     <section data-testid="author-document" className="flex min-h-0 flex-1 flex-col">
       <header className="flex items-center gap-2 border-b border-doom-border px-4 py-2">
-        <strong className="min-w-0 flex-1 truncate text-sm text-doom-hi">{document.title ?? document.path}</strong>
+        <strong className="min-w-0 flex-1 truncate text-base text-doom-hi">{document.title ?? document.path}</strong>
         {document.kind === 'markdown' ? (
           <Button
             size="xs"
@@ -157,10 +157,10 @@ function ActiveAuthorDocumentPanel({ path, sessionId, statuses }: AuthorDocument
           </Button>
         ) : null}
         {document.kind === 'video' ? (
-          <span className="text-sm text-doom-dim">Video feedback</span>
+          <span className="text-base text-doom-dim">Video feedback</span>
         ) : (
           <Button
-            className="min-h-11 px-4 text-sm"
+            className="min-h-11 px-4 text-base"
             variant="outline"
             data-testid="author-save"
             disabled={document.revisions.length === 0 || document.savingVersion !== undefined}
@@ -170,7 +170,7 @@ function ActiveAuthorDocumentPanel({ path, sessionId, statuses }: AuthorDocument
           </Button>
         )}
       </header>
-      {status === undefined ? null : <output className="px-4 py-1 text-[10px] text-doom-faint">{status}</output>}
+      {status === undefined ? null : <output className="px-4 py-1 text-xs text-doom-faint">{status}</output>}
       <div className="relative flex min-h-0 flex-1 overflow-hidden">
         {document.kind === 'text' || document.kind === 'markdown' ? (
           textPanel

--- a/packages/minor/doompi-author/src/web/components/AuthorGridOverlay.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorGridOverlay.stories.tsx
@@ -1,0 +1,49 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The overlay is absolutely positioned and
+ * measures its parent, so each variant supplies a sized relative host.
+ */
+import type { AuthorWorkspaceDocument } from '../stores/authorWorkspaceStore.ts';
+import { AuthorGridOverlay } from './AuthorGridOverlay.tsx';
+
+const spec: AuthorWorkspaceDocument = {
+  path: 'docs/spec.md',
+  kind: 'markdown',
+  content: '# Gateway retries\n\nThe gateway retries three times before giving up.',
+  sourceSha256: 'abc123',
+  annotations: [],
+  revisions: [],
+  saveRequest: 0,
+  version: 1,
+  savedVersion: 1,
+};
+
+const meta = {
+  title: 'Author/AuthorGridOverlay',
+  component: AuthorGridOverlay,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">visible · A1 to H8</span>
+        <div className="relative h-96 w-full max-w-2xl bg-doom-panel p-4 text-sm text-doom-text">
+          <p>The gateway retries three times before giving up.</p>
+          <AuthorGridOverlay sessionId="s1" document={spec} visible />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">hidden · renders nothing</span>
+        <div className="relative h-24 w-full max-w-2xl bg-doom-panel p-4 text-sm text-doom-text">
+          <p>The gateway retries three times before giving up.</p>
+          <AuthorGridOverlay sessionId="s2" document={spec} visible={false} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/AuthorGridOverlay.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorGridOverlay.tsx
@@ -69,7 +69,7 @@ export function AuthorGridOverlay({
         const row = Math.floor(index / AUTHOR_GRID_SIZE);
         return (
           <div key={index} className="relative border border-doom-red/25">
-            <span className="absolute left-1 top-0.5 rounded bg-doom-deep/80 px-1 text-[8px] font-bold text-doom-red">
+            <span className="absolute left-1 top-0.5 rounded bg-doom-deep/80 px-1 text-2xs font-bold text-doom-red">
               {AUTHOR_GRID_COLUMNS[column]}
               {row + 1}
             </span>

--- a/packages/minor/doompi-author/src/web/components/AuthorMediaPreview.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorMediaPreview.stories.tsx
@@ -1,0 +1,33 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The preview builds its own session file URL
+ * and fetches it, so outside a running cockpit only the pending and failed
+ * states are reachable; the loaded state needs the session file endpoint.
+ */
+import { AuthorMediaPreview } from './AuthorMediaPreview.tsx';
+
+const meta = {
+  title: 'Author/AuthorMediaPreview',
+  component: AuthorMediaPreview,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex w-full max-w-2xl flex-col gap-2 text-sm text-doom-text">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          fetching the session file · resolves to the failure notice without a host
+        </span>
+        <AuthorMediaPreview sessionId="s1" path="assets/diagram.png" />
+      </div>
+
+      <div className="flex w-full max-w-2xl flex-col gap-2 text-sm text-doom-text">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">second path · independent request</span>
+        <AuthorMediaPreview sessionId="s1" path="clips/intro.mp4" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/AuthorMediaView.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorMediaView.stories.tsx
@@ -1,0 +1,87 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The view fetches `document.mediaUrl` before
+ * it can paint, so the image variants use an inline data URL rather than a
+ * session endpoint that only exists inside a running cockpit. The video
+ * variant reuses that still, so it shows the player frame and the locked
+ * controls, not real playback.
+ */
+import type { AuthorDisplayedRegion } from '../lib/authorViewportTypes.ts';
+import type { AuthorWorkspaceDocument } from '../stores/authorWorkspaceStore.ts';
+import { AuthorMediaView } from './AuthorMediaView.tsx';
+
+const PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAABkCAIAAACO1KzYAAABGUlEQVR4nO3RwQmDABAAQQuRPC0lRaQIy/FtqalBJJhbBraAhVnW16Zwy+MH+mmA4wGOBzge4HiA4wGOBzge4HiA4wGOBzge4HiA4wGOBzge4HiA4wGOBzjeZeDPfup+gOMBjgc4HuB4gOMBjgc4HuB4gOMBjgc4HuB4gOP9L7BmBTge4HiA4wGOBzge4HiA4wGOBzge4HiA4wGOBzge4HiA410GPvZ3uMc9AAMGDBgwYMCRAAMGPDnAgAFPDjBgwJMDDBjw5AADBjw5wIABTw4wYMCTAwwY8OQAAwY8OcCANTnA8QDHAxwPcDzA8QDHAxwPcDzA8QDHAxwPcDzA8QDHAxwPcDzA8QDHAxwPcDzA8QDHAxwPcLwvgg7vHumFeDwAAAAASUVORK5CYII=';
+
+const picture: AuthorWorkspaceDocument = {
+  path: 'assets/diagram.png',
+  kind: 'image',
+  mediaUrl: PNG,
+  sourceSha256: 'abc123',
+  annotations: [],
+  revisions: [],
+  saveRequest: 0,
+  version: 1,
+  savedVersion: 1,
+};
+
+const clip: AuthorWorkspaceDocument = { ...picture, path: 'clips/intro.mp4', kind: 'video' };
+
+const marked: readonly AuthorDisplayedRegion[] = [
+  {
+    ordinal: 1,
+    region: {
+      id: 'r1',
+      documentPath: picture.path,
+      revision: 1,
+      comment: 'Re-align this block.',
+      anchor: {
+        kind: 'image-rect',
+        rect: { x: 0.09, y: 0.2, width: 0.69, height: 0.15 },
+        naturalWidth: 160,
+        naturalHeight: 100,
+      },
+      viewport: { width: 160, height: 100 },
+      createdAt: 1_717_000_000_000,
+    },
+  },
+];
+
+const meta = {
+  title: 'Author/AuthorMediaView',
+  component: AuthorMediaView,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">image · select mode</span>
+        <AuthorMediaView sessionId="s1" document={picture} activeTool="select" displayedRegions={[]} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">image · mark mode with one region</span>
+        <AuthorMediaView sessionId="s1" document={picture} activeTool="mark" displayedRegions={marked} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">video · locked by an unsent draft</span>
+        <AuthorMediaView sessionId="s2" document={clip} activeTool="select" displayedRegions={[]} pendingCandidate />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no media url · stays pending</span>
+        <AuthorMediaView
+          sessionId="s3"
+          document={{ ...picture, path: 'assets/missing.png', mediaUrl: undefined }}
+          activeTool="select"
+          displayedRegions={[]}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/AuthorMediaView.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorMediaView.tsx
@@ -279,7 +279,7 @@ export function AuthorMediaView({
                   height: `${String(rect.height * 100)}%`,
                 }}
               >
-                <span className="absolute -left-2 -top-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-doom-yellow px-1 text-[9px] font-bold text-doom-deep">
+                <span className="absolute -left-2 -top-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-doom-yellow px-1 text-2xs font-bold text-doom-deep">
                   {ordinal}
                 </span>
               </div>,
@@ -350,7 +350,7 @@ export function AuthorMediaView({
           }}
         />
       ) : null}
-      {error ? <output className="text-sm text-doom-red">{error}</output> : null}
+      {error ? <output className="text-base text-doom-red">{error}</output> : null}
     </div>
   );
 }

--- a/packages/minor/doompi-author/src/web/components/AuthorPanel.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorPanel.stories.tsx
@@ -1,0 +1,96 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The panel reads the focused document out of
+ * the workspace store, so each variant seeds its own session through the
+ * store's public mutations rather than faking the state shape.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { WebPluginSlotProps } from '@agimon-ai/doompi-web-contracts';
+import type { AuthorDocumentInput } from '../lib/authorViewportTypes.ts';
+import { updateAuthorGridGeometry } from '../lib/authorGrid.ts';
+import { addAuthorRegion, focusAuthorDocument, putAuthorDocument } from '../stores/authorWorkspaceStore.ts';
+import { AuthorPanel } from './AuthorPanel.tsx';
+
+const SPEC: AuthorDocumentInput = {
+  path: 'docs/spec.md',
+  kind: 'markdown',
+  content: '# Gateway retries\n\nThe gateway retries three times before giving up.',
+  sourceSha256: 'abc123',
+};
+
+function seed(sessionId: string, input: AuthorDocumentInput, comments: readonly string[] = []): void {
+  const stored = putAuthorDocument(sessionId, input);
+  focusAuthorDocument(sessionId, stored.path, stored.version, stored.sourceSha256);
+  comments.forEach((comment, index) => {
+    addAuthorRegion(sessionId, {
+      id: `${sessionId}-r${index + 1}`,
+      documentPath: stored.path,
+      revision: stored.version,
+      sourceSha256: stored.sourceSha256,
+      comment,
+      quote: 'The gateway retries three times before giving up.',
+      anchor: { kind: 'text-range', startOffset: 20, endOffset: 69, startLine: 3, endLine: 3 },
+      viewport: { width: 720, height: 480 },
+      createdAt: 1_717_000_000_000,
+    });
+  });
+}
+
+seed('panel-idle', SPEC);
+seed('panel-drafts', SPEC, ['Say how long the backoff waits.', 'Name the failure mode.']);
+seed('panel-video', { path: 'clips/intro.mp4', kind: 'video', sourceSha256: 'def456' });
+seed('panel-locked', SPEC, ['Say how long the backoff waits.']);
+seed('panel-grid', SPEC);
+updateAuthorGridGeometry('panel-grid', {
+  documentPath: SPEC.path,
+  revision: 1,
+  sourceSha256: SPEC.sourceSha256,
+  viewport: { width: 720, height: 480, originX: 0, originY: 0 },
+});
+
+function props(sessionId: string, statuses: Readonly<Record<string, string>> = {}): WebPluginSlotProps {
+  return {
+    ...slotPropsFixture({ sessionId, statuses }).props,
+    activeMinorModes: ['author'],
+    submitCapture: async () => undefined,
+  };
+}
+
+const meta = {
+  title: 'Author/AuthorPanel',
+  component: AuthorPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">markdown · no drafts yet</span>
+        <AuthorPanel {...props('panel-idle')} />
+      </div>
+
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">two drafts ready to submit</span>
+        <AuthorPanel {...props('panel-drafts')} />
+      </div>
+
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">video · frame reference notice</span>
+        <AuthorPanel {...props('panel-video')} />
+      </div>
+
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">submission unavailable</span>
+        <AuthorPanel {...{ ...props('panel-locked'), submitCapture: undefined }} />
+      </div>
+
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">autonomous voice grid active</span>
+        <AuthorPanel {...props('panel-grid', { 'doom-voice': 'voice auto: listening' })} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/AuthorPanel.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorPanel.tsx
@@ -34,12 +34,12 @@ export function AuthorPanel({ sessionId, activeMinorModes, submitCapture, status
     <section data-testid="author-panel" className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-3">
       {sessionId !== null && workspace !== undefined && focused !== undefined ? (
         <>
-          <h2 className="text-sm font-semibold text-doom-text">Annotations</h2>
-          <p className="text-sm leading-normal text-doom-dim sm:text-xs">
+          <h2 className="text-base font-semibold text-doom-text">Annotations</h2>
+          <p className="text-base leading-normal text-doom-dim sm:text-sm">
             Select a region, add a comment, then submit here. Requests queue while the agent is working.
           </p>
           {focused.kind === 'video' ? (
-            <p className="text-sm text-doom-dim sm:text-xs">
+            <p className="text-base text-doom-dim sm:text-sm">
               Annotations reference video frames. They do not save changes to the source video.
             </p>
           ) : null}
@@ -47,7 +47,7 @@ export function AuthorPanel({ sessionId, activeMinorModes, submitCapture, status
           {autonomousVoiceGridVisible(statuses) && grid !== undefined ? (
             <div
               data-testid="author-grid-snapshot"
-              className="rounded border border-doom-red/40 bg-doom-red/5 p-2 text-sm text-doom-dim"
+              className="rounded border border-doom-red/40 bg-doom-red/5 p-2 text-base text-doom-dim"
             >
               <strong className="text-doom-red">VOICE GRID A1–H8</strong>
               <p className="mt-1 truncate">token {grid.geometryToken}</p>
@@ -57,7 +57,7 @@ export function AuthorPanel({ sessionId, activeMinorModes, submitCapture, status
           {workspace.regions.length > 0 ? (
             <div className="space-y-1.5 border-b border-doom-border-soft pb-3">
               <Button
-                className="min-h-11 min-w-11 w-full text-sm [@media(pointer:fine)]:min-h-8 sm:text-xs"
+                className="min-h-11 min-w-11 w-full text-base [@media(pointer:fine)]:min-h-8 sm:text-sm"
                 variant="outline"
                 data-testid="author-attach-capture"
                 disabled={capturing || workspace.candidate !== undefined || submitCapture === undefined}
@@ -87,16 +87,16 @@ export function AuthorPanel({ sessionId, activeMinorModes, submitCapture, status
                   : `Submit ${workspace.regions.length} annotation${workspace.regions.length === 1 ? '' : 's'}`}
               </Button>
               {workspace.candidate ? (
-                <p className="text-sm text-doom-dim sm:text-xs">
+                <p className="text-base text-doom-dim sm:text-sm">
                   Add or discard the current selection before submitting.
                 </p>
               ) : null}
             </div>
           ) : null}
           {submitCapture === undefined ? (
-            <output className="text-xs text-doom-red">Submission unavailable. Reload to update the app.</output>
+            <output className="text-sm text-doom-red">Submission unavailable. Reload to update the app.</output>
           ) : null}
-          {captureStatus ? <output className="block text-xs text-doom-dim">{captureStatus}</output> : null}
+          {captureStatus ? <output className="block text-sm text-doom-dim">{captureStatus}</output> : null}
         </>
       ) : null}
       <AuthorRequestLog requests={workspace?.requests ?? []} />

--- a/packages/minor/doompi-author/src/web/components/AuthorRegionDrafts.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorRegionDrafts.stories.tsx
@@ -1,0 +1,98 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The drafts panel renders nothing without a
+ * candidate or a draft, so every variant carries one of the two.
+ */
+import type { AuthorRegionDraft } from '../lib/authorViewportTypes.ts';
+import type { AuthorSessionWorkspace } from '../stores/authorWorkspaceStore.ts';
+import { AuthorRegionDrafts } from './AuthorRegionDrafts.tsx';
+
+const draft = (id: string, comment: string): AuthorRegionDraft => ({
+  id,
+  documentPath: 'docs/spec.md',
+  revision: 3,
+  comment,
+  quote: 'The gateway retries three times before giving up.',
+  anchor: { kind: 'text-range', startOffset: 120, endOffset: 190, startLine: 12, endLine: 14 },
+  viewport: { width: 720, height: 480 },
+  createdAt: 1_717_000_000_000,
+});
+
+const videoDraft: AuthorRegionDraft = {
+  id: 'r-video',
+  documentPath: 'clips/intro.mp4',
+  revision: 1,
+  comment: 'Cut the pause before the logo.',
+  anchor: {
+    kind: 'video-time-rect',
+    timeSeconds: 12.5,
+    rect: { x: 0.1, y: 0.1, width: 0.4, height: 0.3 },
+  },
+  viewport: { width: 720, height: 480 },
+  createdAt: 1_717_000_000_000,
+};
+
+const workspace = (overrides: Partial<AuthorSessionWorkspace>): AuthorSessionWorkspace => ({
+  generation: 1,
+  activeTool: 'mark',
+  regions: [],
+  requests: [],
+  ...overrides,
+});
+
+const meta = {
+  title: 'Author/AuthorRegionDrafts',
+  component: AuthorRegionDrafts,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">text selection pending a comment</span>
+        <AuthorRegionDrafts
+          sessionId="s1"
+          workspace={workspace({
+            candidate: {
+              documentPath: 'docs/spec.md',
+              revision: 3,
+              quote: 'The gateway retries three times before giving up.',
+              anchor: { kind: 'text-range', startOffset: 120, endOffset: 190, startLine: 12, endLine: 14 },
+              viewport: { width: 720, height: 480 },
+              createdAt: 1_717_000_000_000,
+            },
+          })}
+        />
+      </div>
+
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">video frame selection</span>
+        <AuthorRegionDrafts
+          sessionId="s1"
+          workspace={workspace({
+            candidate: {
+              documentPath: 'clips/intro.mp4',
+              revision: 1,
+              anchor: videoDraft.anchor,
+              viewport: { width: 720, height: 480 },
+              createdAt: 1_717_000_000_000,
+            },
+          })}
+        />
+      </div>
+
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">unsent drafts only</span>
+        <AuthorRegionDrafts
+          sessionId="s1"
+          workspace={workspace({
+            regions: [draft('r1', 'Say how long the backoff waits.'), videoDraft],
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/AuthorRegionDrafts.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorRegionDrafts.tsx
@@ -25,10 +25,10 @@ export function AuthorRegionDrafts({ sessionId, workspace }: { sessionId: string
     <section className="space-y-2" data-testid="author-region-drafts">
       {workspace.candidate ? (
         <>
-          <h3 className="text-sm font-semibold text-doom-text">Current selection</h3>
-          <p className="text-sm text-doom-dim sm:text-xs">Add a comment to keep this selection as an unsent draft.</p>
+          <h3 className="text-base font-semibold text-doom-text">Current selection</h3>
+          <p className="text-base text-doom-dim sm:text-sm">Add a comment to keep this selection as an unsent draft.</p>
           {workspace.candidate.anchor.kind === 'video-time-rect' ? (
-            <p className="text-sm text-doom-dim sm:text-xs">
+            <p className="text-base text-doom-dim sm:text-sm">
               Frame at {workspace.candidate.anchor.timeSeconds.toFixed(3)}s
             </p>
           ) : null}
@@ -38,10 +38,10 @@ export function AuthorRegionDrafts({ sessionId, workspace }: { sessionId: string
             onChange={(event) => setComment(event.target.value)}
             placeholder="What should change here?"
             rows={3}
-            className="min-h-11 w-full resize-y rounded border border-doom-border bg-doom-deep p-2 text-base leading-normal text-doom-text focus:border-doom-red focus:outline-none sm:text-xs"
+            className="min-h-11 w-full resize-y rounded border border-doom-border bg-doom-deep p-2 text-lg leading-normal text-doom-text focus:border-doom-red focus:outline-none sm:text-sm"
           />
           <Button
-            className="min-h-11 min-w-11 text-sm [@media(pointer:fine)]:min-h-8 sm:text-xs"
+            className="min-h-11 min-w-11 text-base [@media(pointer:fine)]:min-h-8 sm:text-sm"
             variant="outline"
             onClick={add}
             disabled={!workspace.candidate || !comment.trim() || workspace.regions.length >= 16}
@@ -50,7 +50,7 @@ export function AuthorRegionDrafts({ sessionId, workspace }: { sessionId: string
           </Button>
           <Button
             variant="ghost"
-            className="min-h-11 min-w-11 text-sm [@media(pointer:fine)]:min-h-8 sm:text-xs"
+            className="min-h-11 min-w-11 text-base [@media(pointer:fine)]:min-h-8 sm:text-sm"
             onClick={() => {
               setAuthorRegionCandidate(sessionId, undefined);
               setComment('');
@@ -61,15 +61,15 @@ export function AuthorRegionDrafts({ sessionId, workspace }: { sessionId: string
           </Button>
         </>
       ) : null}
-      {error ? <output className="block text-sm text-doom-red">{error}</output> : null}
+      {error ? <output className="block text-base text-doom-red">{error}</output> : null}
       {workspace.regions.length > 0 ? (
-        <h3 className="text-sm font-semibold text-doom-text">Unsent drafts ({workspace.regions.length})</h3>
+        <h3 className="text-base font-semibold text-doom-text">Unsent drafts ({workspace.regions.length})</h3>
       ) : null}
       <ol className="space-y-2">
         {workspace.regions.map((region, index) => (
           <li
             key={region.id}
-            className="rounded border border-doom-border bg-doom-panel p-2 text-sm leading-normal text-doom-text sm:text-xs"
+            className="rounded border border-doom-border bg-doom-panel p-2 text-base leading-normal text-doom-text sm:text-sm"
           >
             <span>
               ({index + 1}) {region.comment}
@@ -77,7 +77,7 @@ export function AuthorRegionDrafts({ sessionId, workspace }: { sessionId: string
             {region.anchor.kind === 'video-time-rect' ? (
               <Button
                 variant="outline"
-                className="min-h-11 min-w-11 text-sm [@media(pointer:fine)]:min-h-8 sm:text-xs"
+                className="min-h-11 min-w-11 text-base [@media(pointer:fine)]:min-h-8 sm:text-sm"
                 disabled={workspace.candidate !== undefined}
                 onClick={() => {
                   if (region.anchor.kind === 'video-time-rect') seekAuthorVideo(sessionId, region.anchor.timeSeconds);
@@ -87,7 +87,7 @@ export function AuthorRegionDrafts({ sessionId, workspace }: { sessionId: string
               </Button>
             ) : null}
             <Button
-              className="min-h-11 min-w-11 text-sm [@media(pointer:fine)]:min-h-8 sm:text-xs"
+              className="min-h-11 min-w-11 text-base [@media(pointer:fine)]:min-h-8 sm:text-sm"
               variant="ghost"
               aria-label={`Remove region ${index + 1}`}
               onClick={() => removeAuthorRegion(sessionId, region.id)}

--- a/packages/minor/doompi-author/src/web/components/AuthorRequestLog.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorRequestLog.stories.tsx
@@ -1,0 +1,85 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The log takes the request history straight
+ * as a prop, so the states here are the request statuses it styles.
+ */
+import type { AuthorRegionDraft, AuthorRequestRecord } from '../lib/authorViewportTypes.ts';
+import { AuthorRequestLog } from './AuthorRequestLog.tsx';
+
+const region = (id: string, comment: string, startLine: number, endLine: number): AuthorRegionDraft => ({
+  id,
+  documentPath: 'docs/spec.md',
+  revision: 3,
+  comment,
+  quote: 'The gateway retries three times before giving up.',
+  anchor: { kind: 'text-range', startOffset: 120, endOffset: 190, startLine, endLine },
+  viewport: { width: 720, height: 480 },
+  createdAt: 1_717_000_000_000,
+});
+
+const request = (overrides: Partial<AuthorRequestRecord>): AuthorRequestRecord => ({
+  id: 'req-1',
+  documentPath: 'docs/spec.md',
+  requestText:
+    'Please address the attached feedback. Request ID: req-1 Tighten the retry wording and name the backoff.',
+  regions: [region('r1', 'Say how long the backoff waits.', 12, 14)],
+  status: 'REQUESTED',
+  createdAt: 1_717_000_000_000,
+  updatedAt: 1_717_000_000_000,
+  revision: 3,
+  ...overrides,
+});
+
+const working = request({
+  id: 'req-2',
+  status: 'CHANGING',
+  currentOperation: 'Rewriting the retry paragraph',
+  regions: [region('r1', 'Say how long the backoff waits.', 12, 14), region('r2', 'Drop the duplicate note.', 30, 30)],
+  pendingRegions: [region('r2', 'Drop the duplicate note.', 30, 30)],
+  before: 'The gateway retries three times before giving up.',
+  after: 'The gateway retries three times, backing off 2s between attempts.',
+});
+
+const meta = {
+  title: 'Author/AuthorRequestLog',
+  component: AuthorRequestLog,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">empty</span>
+        <AuthorRequestLog requests={[]} />
+      </div>
+
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">queued</span>
+        <AuthorRequestLog requests={[request({})]} />
+      </div>
+
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          working · with earlier requests collapsed
+        </span>
+        <AuthorRequestLog
+          requests={[
+            request({ id: 'req-0', status: 'COMPLETE', currentOperation: '' }),
+            request({ id: 'req-cancelled', status: 'CANCELLED', currentOperation: '' }),
+            working,
+          ]}
+        />
+      </div>
+
+      <div className="flex w-96 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <AuthorRequestLog
+          requests={[request({ id: 'req-3', status: 'FAILED', error: 'The document changed under the request.' })]}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/AuthorRequestLog.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorRequestLog.tsx
@@ -72,8 +72,8 @@ function RequestRecord({ request, prominent = false }: { request: AuthorRequestR
   return (
     <article data-testid={prominent ? 'author-active-request' : undefined} className="space-y-3">
       <header className="border-b border-doom-border-soft pb-3">
-        <p className="text-[9px] font-bold tracking-[0.18em] text-doom-faint">DOCUMENT CONTEXT</p>
-        <p className="mt-2 flex items-center gap-2 truncate text-[13px] font-bold text-doom-hi">
+        <p className="text-2xs font-bold tracking-widest text-doom-faint">DOCUMENT CONTEXT</p>
+        <p className="mt-2 flex items-center gap-2 truncate text-base font-bold text-doom-hi">
           <span aria-hidden className="text-doom-magenta">
             ↗
           </span>
@@ -85,16 +85,16 @@ function RequestRecord({ request, prominent = false }: { request: AuthorRequestR
         <ol className="space-y-3">
           {request.regions.map((region, index) => (
             <li key={region.id} className="space-y-2">
-              <p className="font-mono text-[9px] font-bold uppercase tracking-[0.14em] text-doom-yellow">
+              <p className="font-mono text-2xs font-bold uppercase tracking-wider text-doom-yellow">
                 WHERE · {request.regions.length > 1 ? `${index + 1} · ` : ''}
                 {documentName(request.documentPath)} / {anchorLabel(region.anchor)} · rev {request.revision}
               </p>
               {region.quote ? (
-                <blockquote className="line-clamp-3 text-[11px] italic leading-relaxed text-doom-text">
+                <blockquote className="line-clamp-3 text-sm italic leading-relaxed text-doom-text">
                   “{region.quote}”
                 </blockquote>
               ) : null}
-              <p className="text-[10px] leading-relaxed text-doom-dim">{region.comment}</p>
+              <p className="text-xs leading-relaxed text-doom-dim">{region.comment}</p>
             </li>
           ))}
         </ol>
@@ -104,7 +104,7 @@ function RequestRecord({ request, prominent = false }: { request: AuthorRequestR
         data-testid={prominent ? 'author-operation-card' : undefined}
         className={`rounded border p-3 ${STATUS_STYLES[request.status]}`}
       >
-        <p className="font-mono text-[10px] font-bold tracking-[0.14em]">
+        <p className="font-mono text-xs font-bold tracking-wider">
           ●{' '}
           {request.status === 'CHANGING'
             ? 'WORKING'
@@ -114,12 +114,12 @@ function RequestRecord({ request, prominent = false }: { request: AuthorRequestR
                 ? 'ERROR'
                 : request.status}
         </p>
-        <p className="mt-2 text-[12px] leading-relaxed text-doom-hi">
+        <p className="mt-2 text-sm leading-relaxed text-doom-hi">
           {request.currentOperation || STATUS_LABELS[request.status]}
         </p>
-        {request.error ? <p className="mt-2 text-[10px] leading-relaxed text-doom-red">{request.error}</p> : null}
+        {request.error ? <p className="mt-2 text-xs leading-relaxed text-doom-red">{request.error}</p> : null}
         {request.before !== undefined || request.after !== undefined ? (
-          <details className="mt-2 border-t border-current/20 pt-2 text-[10px] text-doom-dim">
+          <details className="mt-2 border-t border-current/20 pt-2 text-xs text-doom-dim">
             <summary className="cursor-pointer select-none">change preview</summary>
             {request.before !== undefined ? (
               <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words font-mono">
@@ -136,15 +136,15 @@ function RequestRecord({ request, prominent = false }: { request: AuthorRequestR
       </section>
 
       <section className="space-y-2">
-        <p className="text-[9px] font-bold tracking-[0.18em] text-doom-faint">REQUEST · HOW TO CHANGE</p>
+        <p className="text-2xs font-bold tracking-widest text-doom-faint">REQUEST · HOW TO CHANGE</p>
         <div className="rounded border border-doom-border bg-doom-deep p-3">
-          <p className="whitespace-pre-wrap text-[11px] leading-relaxed text-doom-text">
+          <p className="whitespace-pre-wrap text-sm leading-relaxed text-doom-text">
             {instruction || 'No additional instruction.'}
           </p>
         </div>
       </section>
 
-      <footer className="font-mono text-[9px] text-doom-dim">{progressLabel(request)}</footer>
+      <footer className="font-mono text-2xs text-doom-dim">{progressLabel(request)}</footer>
     </article>
   );
 }
@@ -154,15 +154,15 @@ export function AuthorRequestLog({ requests }: { requests: readonly AuthorReques
   const earlier = requests.slice(0, -1).toReversed();
   return (
     <section data-testid="author-request-history" className="space-y-3">
-      <h3 className="text-[9px] font-bold tracking-[0.18em] text-doom-faint">AUTHORING</h3>
+      <h3 className="text-2xs font-bold tracking-widest text-doom-faint">AUTHORING</h3>
       {latest === undefined ? (
-        <p className="text-[11px] leading-relaxed text-doom-dim">No requests or changes yet.</p>
+        <p className="text-sm leading-relaxed text-doom-dim">No requests or changes yet.</p>
       ) : (
         <RequestRecord request={latest} prominent />
       )}
       {earlier.length > 0 ? (
         <details className="border-t border-doom-border-soft pt-3" data-testid="author-earlier-requests">
-          <summary className="cursor-pointer select-none text-[9px] font-bold tracking-[0.14em] text-doom-faint">
+          <summary className="cursor-pointer select-none text-2xs font-bold tracking-wider text-doom-faint">
             EARLIER REQUESTS ({earlier.length})
           </summary>
           <ol className="mt-3 space-y-5">

--- a/packages/minor/doompi-author/src/web/components/AuthorStructuredView.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorStructuredView.stories.tsx
@@ -1,0 +1,84 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The view groups fragments differently for
+ * cell documents (csv/xlsx) than for slide documents, so both appear here.
+ */
+import type { AuthorDisplayedRegion } from '../lib/authorViewportTypes.ts';
+import type { AuthorWorkspaceDocument } from '../stores/authorWorkspaceStore.ts';
+import { AuthorStructuredView } from './AuthorStructuredView.tsx';
+
+const base = { annotations: [], revisions: [], saveRequest: 0, version: 1, savedVersion: 1 } as const;
+
+const sheet: AuthorWorkspaceDocument = {
+  ...base,
+  path: 'data/budget.csv',
+  kind: 'csv',
+  structuredFormat: 'csv',
+  fragments: [
+    { id: 'f1', kind: 'cell', text: 'quarter', location: '0,0', readOnly: true },
+    { id: 'f2', kind: 'cell', text: 'spend', location: '0,1', readOnly: true },
+    { id: 'f3', kind: 'cell', text: 'Q1', location: '1,0' },
+    { id: 'f4', kind: 'cell', text: '12400', location: '1,1' },
+    { id: 'f5', kind: 'cell', text: 'Q2', location: '2,0' },
+    { id: 'f6', kind: 'cell', text: '15900', location: '2,1' },
+  ],
+};
+
+const slides: AuthorWorkspaceDocument = {
+  ...base,
+  path: 'deck/launch.pptx',
+  kind: 'pptx',
+  structuredFormat: 'pptx',
+  fragments: [
+    { id: 's1', kind: 'slide', text: 'Launch plan', location: 'ppt/slides/slide1.xml' },
+    { id: 's2', kind: 'text-run', text: 'Ship the beta in week three.', location: 'ppt/slides/slide2.xml' },
+  ],
+};
+
+const marked: readonly AuthorDisplayedRegion[] = [
+  {
+    ordinal: 1,
+    region: {
+      id: 'r1',
+      documentPath: sheet.path,
+      revision: 1,
+      comment: 'Check this against the ledger.',
+      anchor: { kind: 'cell', fragmentId: 'f4', location: '1,1' },
+      viewport: { width: 720, height: 480 },
+      createdAt: 1_717_000_000_000,
+    },
+  },
+];
+
+const meta = {
+  title: 'Author/AuthorStructuredView',
+  component: AuthorStructuredView,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">csv · one region marked</span>
+        <AuthorStructuredView sessionId="s1" document={sheet} displayedRegions={marked} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">pptx · slide text view</span>
+        <AuthorStructuredView sessionId="s1" document={slides} displayedRegions={[]} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no fragments</span>
+        <AuthorStructuredView
+          sessionId="s1"
+          document={{ ...base, path: 'data/empty.csv', kind: 'csv', fragments: [] }}
+          displayedRegions={[]}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/AuthorStructuredView.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorStructuredView.tsx
@@ -65,10 +65,10 @@ export function AuthorStructuredView({
   }
   return (
     <div data-testid="author-structured" className="min-h-0 flex-1 space-y-3 overflow-auto p-4">
-      {!cells ? <p className="text-[10px] text-doom-faint">Slide text view, not a layout-faithful rendering.</p> : null}
+      {!cells ? <p className="text-xs text-doom-faint">Slide text view, not a layout-faithful rendering.</p> : null}
       {[...groups].map(([location, fragments]) => (
         <section key={location} className="space-y-1">
-          <h3 className="text-[10px] text-doom-faint">{location}</h3>
+          <h3 className="text-xs text-doom-faint">{location}</h3>
           <div className={cells ? 'flex gap-1' : 'space-y-2'}>
             {fragments.map((fragment) => (
               <div
@@ -78,7 +78,7 @@ export function AuthorStructuredView({
                 className={`${cells ? 'w-40 shrink-0' : ''} relative rounded ${displayedByFragment.has(fragment.id) ? 'ring-1 ring-doom-yellow' : ''}`}
               >
                 {displayedByFragment.has(fragment.id) ? (
-                  <span className="absolute -left-1 -top-1 z-10 flex h-4 min-w-4 items-center justify-center rounded-full bg-doom-yellow px-1 text-[9px] font-bold text-doom-deep">
+                  <span className="absolute -left-1 -top-1 z-10 flex h-4 min-w-4 items-center justify-center rounded-full bg-doom-yellow px-1 text-2xs font-bold text-doom-deep">
                     {displayedByFragment.get(fragment.id)}
                   </span>
                 ) : null}
@@ -108,7 +108,7 @@ export function AuthorStructuredView({
                   aria-label={fragment.location}
                   value={fragment.text}
                   readOnly={fragment.readOnly === true}
-                  className="w-full rounded border border-doom-border bg-doom-deep p-2 text-[11px] text-doom-text"
+                  className="w-full rounded border border-doom-border bg-doom-deep p-2 text-sm text-doom-text"
                   onChange={(event) => reviseAuthorFragment(sessionId, document.path, fragment.id, event.target.value)}
                 />
               </div>

--- a/packages/minor/doompi-author/src/web/components/AuthorTextView.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorTextView.stories.tsx
@@ -1,0 +1,77 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The view has exactly two shapes: the
+ * markdown preview and the editor, which is where marked ranges show up.
+ */
+import type { AuthorDisplayedRegion } from '../lib/authorViewportTypes.ts';
+import type { AuthorWorkspaceDocument } from '../stores/authorWorkspaceStore.ts';
+import { AuthorTextView } from './AuthorTextView.tsx';
+
+const CONTENT = [
+  '# Gateway retries',
+  '',
+  'The gateway retries three times before giving up.',
+  '',
+  '- first attempt is immediate',
+  '- the rest back off',
+].join('\n');
+
+const spec: AuthorWorkspaceDocument = {
+  path: 'docs/spec.md',
+  kind: 'markdown',
+  content: CONTENT,
+  annotations: [],
+  revisions: [],
+  saveRequest: 0,
+  version: 1,
+  savedVersion: 1,
+};
+
+const marked: readonly AuthorDisplayedRegion[] = [
+  {
+    ordinal: 1,
+    region: {
+      id: 'r1',
+      documentPath: spec.path,
+      revision: 1,
+      comment: 'Say how long the backoff waits.',
+      anchor: { kind: 'text-range', startOffset: 22, endOffset: 71, startLine: 3, endLine: 3 },
+      viewport: { width: 720, height: 480 },
+      createdAt: 1_717_000_000_000,
+    },
+  },
+];
+
+const meta = {
+  title: 'Author/AuthorTextView',
+  component: AuthorTextView,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex h-64 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">markdown preview</span>
+        <AuthorTextView sessionId="s1" document={spec} preview displayedRegions={[]} />
+      </div>
+
+      <div className="flex h-64 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">editor · one marked range</span>
+        <AuthorTextView sessionId="s1" document={spec} preview={false} displayedRegions={marked} />
+      </div>
+
+      <div className="flex h-40 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">empty document</span>
+        <AuthorTextView
+          sessionId="s1"
+          document={{ ...spec, path: 'docs/empty.md', content: '' }}
+          preview={false}
+          displayedRegions={[]}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/AuthorTextView.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorTextView.tsx
@@ -59,7 +59,7 @@ export function AuthorTextView({
   return (
     <div ref={host} className="flex min-h-0 flex-1 flex-col">
       {preview ? (
-        <div data-testid="author-markdown" className="min-h-0 flex-1 overflow-auto p-4 text-[12px] text-doom-text">
+        <div data-testid="author-markdown" className="min-h-0 flex-1 overflow-auto p-4 text-sm text-doom-text">
           <Markdown text={document.content ?? ''} />
         </div>
       ) : (

--- a/packages/minor/doompi-author/src/web/components/AuthorToolPalette.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorToolPalette.stories.tsx
@@ -1,0 +1,35 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The palette branches on the document kind
+ * (markdown adds the formatting tools) and on the active tool.
+ */
+import { AuthorToolPalette } from './AuthorToolPalette.tsx';
+
+const meta = {
+  title: 'Author/AuthorToolPalette',
+  component: AuthorToolPalette,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex w-80 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">markdown · select</span>
+        <AuthorToolPalette sessionId="s1" kind="markdown" activeTool="select" />
+      </div>
+
+      <div className="flex w-80 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">markdown · marking a region</span>
+        <AuthorToolPalette sessionId="s1" kind="markdown" activeTool="mark" />
+      </div>
+
+      <div className="flex w-80 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">image · no formatting tools</span>
+        <AuthorToolPalette sessionId="s1" kind="image" activeTool="select" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/AuthorToolPalette.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorToolPalette.tsx
@@ -72,7 +72,7 @@ export function AuthorToolPalette({
   ];
   return (
     <section data-testid="author-tool-palette" className="space-y-2 border-b border-doom-border-soft pb-3">
-      <div className="flex justify-between text-xs text-doom-dim">
+      <div className="flex justify-between text-sm text-doom-dim">
         <h3 className="font-bold tracking-widest">TOOLS</h3>
         <span>focused tab</span>
       </div>
@@ -85,19 +85,19 @@ export function AuthorToolPalette({
             aria-label={tool.label === 'Region' ? 'mark region' : tool.label}
             aria-pressed={tool.active}
             onClick={tool.action}
-            className={`min-h-11 min-w-11 gap-1.5 rounded border text-sm [@media(pointer:fine)]:min-h-8 sm:text-xs ${tool.active ? 'border-doom-red bg-doom-red/10 text-doom-red hover:bg-doom-red/15' : 'border-doom-border bg-doom-panel text-doom-dim'}`}
+            className={`min-h-11 min-w-11 gap-1.5 rounded border text-base [@media(pointer:fine)]:min-h-8 sm:text-sm ${tool.active ? 'border-doom-red bg-doom-red/10 text-doom-red hover:bg-doom-red/15' : 'border-doom-border bg-doom-panel text-doom-dim'}`}
           >
             <span aria-hidden="true">{tool.glyph}</span>
             {tool.label}
           </Button>
         ))}
       </div>
-      <p className="text-sm leading-normal text-doom-dim sm:text-xs">
+      <p className="text-base leading-normal text-doom-dim sm:text-sm">
         {activeTool === 'mark'
           ? 'Drag over the document to mark a region.'
           : 'Choose Region to mark an area for a comment.'}
       </p>
-      {error ? <output className="block text-sm text-doom-red">{error}</output> : null}
+      {error ? <output className="block text-base text-doom-red">{error}</output> : null}
     </section>
   );
 }

--- a/packages/minor/doompi-author/src/web/components/AuthorVideoControls.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorVideoControls.stories.tsx
@@ -1,0 +1,87 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The controls are fully driven by props, so
+ * each variant is one combination of playback, readiness and the draft lock.
+ */
+import { AuthorVideoControls } from './AuthorVideoControls.tsx';
+
+const noop = () => undefined;
+
+const meta = {
+  title: 'Author/AuthorVideoControls',
+  component: AuthorVideoControls,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex w-full max-w-2xl flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">paused · frame ready</span>
+        <AuthorVideoControls
+          playback={{ playing: false, currentTime: 12.5, duration: 94.25 }}
+          ready
+          locked={false}
+          marking={false}
+          onSeek={noop}
+          onToggle={noop}
+          onAnnotate={noop}
+        />
+      </div>
+
+      <div className="flex w-full max-w-2xl flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">playing · frame not ready</span>
+        <AuthorVideoControls
+          playback={{ playing: true, currentTime: 30.125, duration: 94.25 }}
+          ready={false}
+          locked={false}
+          marking={false}
+          onSeek={noop}
+          onToggle={noop}
+          onAnnotate={noop}
+        />
+      </div>
+
+      <div className="flex w-full max-w-2xl flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">marking a frame</span>
+        <AuthorVideoControls
+          playback={{ playing: false, currentTime: 30.125, duration: 94.25 }}
+          ready
+          locked={false}
+          marking
+          onSeek={noop}
+          onToggle={noop}
+          onAnnotate={noop}
+        />
+      </div>
+
+      <div className="flex w-full max-w-2xl flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">locked by an unsent draft</span>
+        <AuthorVideoControls
+          playback={{ playing: false, currentTime: 30.125, duration: 94.25 }}
+          ready
+          locked
+          marking={false}
+          onSeek={noop}
+          onToggle={noop}
+          onAnnotate={noop}
+        />
+      </div>
+
+      <div className="flex w-full max-w-2xl flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no duration yet</span>
+        <AuthorVideoControls
+          playback={{ playing: false, currentTime: 0, duration: 0 }}
+          ready={false}
+          locked={false}
+          marking={false}
+          onSeek={noop}
+          onToggle={noop}
+          onAnnotate={noop}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/AuthorVideoControls.tsx
+++ b/packages/minor/doompi-author/src/web/components/AuthorVideoControls.tsx
@@ -27,14 +27,14 @@ export function AuthorVideoControls({
   const duration = playback.duration;
   const invalid =
     seconds.trim() === '' || !Number.isFinite(Number(seconds)) || Number(seconds) < 0 || Number(seconds) > duration;
-  const buttonClass = 'min-h-11 px-3 text-sm [@media(pointer:fine)]:min-h-8 sm:text-xs';
+  const buttonClass = 'min-h-11 px-3 text-base [@media(pointer:fine)]:min-h-8 sm:text-sm';
   return (
     <section
       aria-label="Video annotation controls"
-      className="mt-2 space-y-2 rounded border border-doom-border bg-doom-panel p-2.5 text-sm text-doom-text sm:text-xs"
+      className="mt-2 space-y-2 rounded border border-doom-border bg-doom-panel p-2.5 text-base text-doom-text sm:text-sm"
     >
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <output aria-label="Playback position" className="font-mono text-sm tabular-nums">
+        <output aria-label="Playback position" className="font-mono text-base tabular-nums">
           {videoTimeLabel(playback.currentTime)} / {videoTimeLabel(duration)}
         </output>
         <span className="text-doom-dim">
@@ -99,7 +99,7 @@ export function AuthorVideoControls({
             onChange={(event) => setSeconds(event.target.value)}
             disabled={locked || duration <= 0}
             placeholder="1.250"
-            className="h-11 w-24 rounded border border-doom-border bg-doom-deep px-2 text-base [@media(pointer:fine)]:h-8 sm:text-xs"
+            className="h-11 w-24 rounded border border-doom-border bg-doom-deep px-2 text-lg [@media(pointer:fine)]:h-8 sm:text-sm"
           />
           <Button type="submit" className={buttonClass} disabled={locked || duration <= 0 || invalid}>
             Go

--- a/packages/minor/doompi-author/src/web/components/DescribeAuthorToolsToolCard.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/DescribeAuthorToolsToolCard.stories.tsx
@@ -1,0 +1,57 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. Props come from the contracts package's own
+ * testing fixture rather than a hand-rolled stub, so a change to the tool
+ * message contract breaks this story at the type level.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { DescribeAuthorToolsToolCard } from './DescribeAuthorToolsToolCard.tsx';
+
+const SHORT = ['author viewport tools', '- annotate_region', '- revise_fragment'].join('\n');
+
+const LONG = Array.from({ length: 12 }, (_, index) => `- tool_${String(index + 1).padStart(2, '0')}`).join('\n');
+
+const textResult = (text: string) => ({ content: [{ type: 'text', text }], details: null });
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'describe_author_tools', ...overrides }).props;
+
+const meta = {
+  title: 'Author/DescribeAuthorToolsToolCard',
+  component: DescribeAuthorToolsToolCard,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <DescribeAuthorToolsToolCard {...props({ running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete</span>
+        <DescribeAuthorToolsToolCard {...props({ result: textResult(SHORT), output: SHORT })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · collapsed past eight lines</span>
+        <DescribeAuthorToolsToolCard {...props({ result: textResult(LONG), output: LONG })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <DescribeAuthorToolsToolCard
+          {...props({
+            result: textResult('No Author viewport is focused.'),
+            output: 'No Author viewport is focused.',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/OpenAuthoringFileToolCard.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/OpenAuthoringFileToolCard.stories.tsx
@@ -1,0 +1,58 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The card reads the opened path out of
+ * `result.details.path`, so the "ready" state needs details, not just text.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { OpenAuthoringFileToolCard } from './OpenAuthoringFileToolCard.tsx';
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'open_authoring_file', ...overrides }).props;
+
+const meta = {
+  title: 'Author/OpenAuthoringFileToolCard',
+  component: OpenAuthoringFileToolCard,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running · validating</span>
+        <OpenAuthoringFileToolCard {...props({ args: { path: 'docs/spec.md' }, running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · no path in details</span>
+        <OpenAuthoringFileToolCard
+          {...props({ args: { path: 'docs/spec.md' }, result: { content: [], details: null } })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · ready to open</span>
+        <OpenAuthoringFileToolCard
+          {...props({
+            args: { path: 'docs/spec.md' },
+            result: { content: [], details: { path: 'docs/spec.md' } },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <OpenAuthoringFileToolCard
+          {...props({
+            args: { path: 'docs/missing.md' },
+            result: { content: [{ type: 'text', text: 'ENOENT: no such file or directory' }], details: null },
+            output: 'ENOENT: no such file or directory',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/src/web/components/UseAuthorToolsToolCard.stories.tsx
+++ b/packages/minor/doompi-author/src/web/components/UseAuthorToolsToolCard.stories.tsx
@@ -1,0 +1,59 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. Props come from the contracts package's own
+ * testing fixture rather than a hand-rolled stub.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { UseAuthorToolsToolCard } from './UseAuthorToolsToolCard.tsx';
+
+const SHORT = ['applied revision to docs/spec.md', 'fragment slide2 updated'].join('\n');
+
+const LONG = Array.from({ length: 11 }, (_, index) => `applied change ${index + 1} of 11`).join('\n');
+
+const textResult = (text: string) => ({ content: [{ type: 'text', text }], details: null });
+
+const props = (overrides: Omit<Parameters<typeof toolMessagePropsFixture>[0], 'toolName'>) =>
+  toolMessagePropsFixture({ toolName: 'use_author_tools', ...overrides }).props;
+
+const meta = {
+  title: 'Author/UseAuthorToolsToolCard',
+  component: UseAuthorToolsToolCard,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running · name in the header</span>
+        <UseAuthorToolsToolCard {...props({ args: { name: 'revise_fragment' }, running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete</span>
+        <UseAuthorToolsToolCard
+          {...props({ args: { name: 'revise_fragment' }, result: textResult(SHORT), output: SHORT })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · collapsed past eight lines</span>
+        <UseAuthorToolsToolCard {...props({ args: { name: 'apply_batch' }, result: textResult(LONG), output: LONG })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <UseAuthorToolsToolCard
+          {...props({
+            args: { name: 'revise_fragment' },
+            result: textResult('Unknown Author capability: revise_fragment'),
+            output: 'Unknown Author capability: revise_fragment',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-author/style-system.config.yaml
+++ b/packages/minor/doompi-author/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/minor/doompi-author/styles/preview.css
+++ b/packages/minor/doompi-author/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/minor/doompi-author/tests/web/authorSidebar.test.tsx
+++ b/packages/minor/doompi-author/tests/web/authorSidebar.test.tsx
@@ -123,7 +123,7 @@ describe('Author annotation sidebar', () => {
     for (const control of controls) {
       expect(control.props.className).toContain('min-h-11');
       expect(control.props.className).toContain('min-w-11');
-      expect(control.props.className).toContain('text-sm');
+      expect(control.props.className).toContain('text-base');
     }
   });
   it('keeps drafts when submission fails and handles the rejection', async () => {

--- a/packages/minor/doompi-author/vibe-lint.config.yaml
+++ b/packages/minor/doompi-author/vibe-lint.config.yaml
@@ -14,3 +14,14 @@ rules:
   public-export-boundary: error
   no-internal-public-import: error
   doom-layer-boundary: error
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/packages/minor/doompi-computer-use/package.json
+++ b/packages/minor/doompi-computer-use/package.json
@@ -35,7 +35,8 @@
     "llms.txt",
     "README.md",
     "LICENSE",
-    "package.json"
+    "package.json",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -85,6 +86,7 @@
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "5.0.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsdown": "0.23.0",
     "typescript": "7.0.2",
     "vitest": "5.0.0"

--- a/packages/minor/doompi-computer-use/src/web/components/ComputerActionToolCard.stories.tsx
+++ b/packages/minor/doompi-computer-use/src/web/components/ComputerActionToolCard.stories.tsx
@@ -1,0 +1,88 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { ComputerActionToolCard } from './ComputerActionToolCard.tsx';
+import { computerActionToolName } from '../lib/computerActionToolRender.ts';
+
+const props = (overrides: Parameters<typeof toolMessagePropsFixture>[0]) => toolMessagePropsFixture(overrides).props;
+
+const text = (value: string) => ({ content: [{ type: 'text', text: value }], details: null });
+
+const LONG = text(
+  [
+    'clicked Save in the authorized window',
+    'focus moved to the document body',
+    'a toast appeared: Draft saved',
+    'the title bar lost its modified marker',
+    'the sidebar list refreshed',
+    'row 3 became selected',
+    'the status strip read: saved 14:32',
+    'no dialog is open',
+    'the window remained frontmost',
+    'no further actions are pending',
+  ].join('\n'),
+);
+
+const meta = {
+  title: 'ComputerUse/ComputerActionToolCard',
+  component: ComputerActionToolCard,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <ComputerActionToolCard
+          {...props({
+            toolName: computerActionToolName,
+            args: { kind: 'click', elementRef: 'button:Save' },
+            running: true,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete</span>
+        <ComputerActionToolCard
+          {...props({
+            toolName: computerActionToolName,
+            args: { kind: 'click', elementRef: 'button:Save' },
+            result: text('clicked Save in the authorized window'),
+            output: 'clicked Save in the authorized window',
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · collapsed with more lines</span>
+        <ComputerActionToolCard
+          {...props({
+            toolName: computerActionToolName,
+            args: { kind: 'type', elementRef: 'textbox:Search' },
+            result: LONG,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <ComputerActionToolCard
+          {...props({
+            toolName: computerActionToolName,
+            args: { kind: 'click', elementRef: 'button:Publish' },
+            result: text('the element is not in the authorized window'),
+            output: 'the element is not in the authorized window',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-computer-use/src/web/components/ComputerExecToolCard.stories.tsx
+++ b/packages/minor/doompi-computer-use/src/web/components/ComputerExecToolCard.stories.tsx
@@ -1,0 +1,88 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { ComputerExecToolCard } from './ComputerExecToolCard.tsx';
+import { computerExecToolName } from '../lib/computerExecToolRender.ts';
+
+const props = (overrides: Parameters<typeof toolMessagePropsFixture>[0]) => toolMessagePropsFixture(overrides).props;
+
+const text = (value: string) => ({ content: [{ type: 'text', text: value }], details: null });
+
+const LONG = text(
+  [
+    'running scripts/export-report.scpt',
+    'opened the authorized window',
+    'selected the report tab',
+    'set the range to last 30 days',
+    'triggered the export',
+    'waited for the sheet to close',
+    'wrote ~/Downloads/report.csv',
+    'checksum 4f1c9ab2',
+    'exit status 0',
+    'elapsed 3.4s',
+  ].join('\n'),
+);
+
+const meta = {
+  title: 'ComputerUse/ComputerExecToolCard',
+  component: ComputerExecToolCard,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <ComputerExecToolCard
+          {...props({
+            toolName: computerExecToolName,
+            args: { scriptPath: 'scripts/export-report.scpt' },
+            running: true,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete</span>
+        <ComputerExecToolCard
+          {...props({
+            toolName: computerExecToolName,
+            args: { scriptPath: 'scripts/export-report.scpt' },
+            result: text('exit status 0 · wrote ~/Downloads/report.csv'),
+            output: 'exit status 0 · wrote ~/Downloads/report.csv',
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · collapsed with more lines</span>
+        <ComputerExecToolCard
+          {...props({
+            toolName: computerExecToolName,
+            args: { scriptPath: 'scripts/export-report.scpt' },
+            result: LONG,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <ComputerExecToolCard
+          {...props({
+            toolName: computerExecToolName,
+            args: { scriptPath: 'scripts/unsigned.scpt' },
+            result: text('the script is outside the authorized script directory'),
+            output: 'the script is outside the authorized script directory',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-computer-use/src/web/components/ComputerStateToolCard.stories.tsx
+++ b/packages/minor/doompi-computer-use/src/web/components/ComputerStateToolCard.stories.tsx
@@ -1,0 +1,76 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { ComputerStateToolCard } from './ComputerStateToolCard.tsx';
+import { computerStateToolName } from '../lib/computerStateToolRender.ts';
+
+const props = (overrides: Parameters<typeof toolMessagePropsFixture>[0]) => toolMessagePropsFixture(overrides).props;
+
+const text = (value: string) => ({ content: [{ type: 'text', text: value }], details: null });
+
+const TREE = text(
+  [
+    'window "Reports — Acme" frontmost',
+    'toolbar',
+    '  button:Save enabled',
+    '  button:Publish disabled',
+    'sidebar list · 4 rows',
+    '  row 1 "Q1" selected',
+    '  row 2 "Q2"',
+    '  row 3 "Q3"',
+    '  row 4 "Q4"',
+    'status "saved 14:32"',
+  ].join('\n'),
+);
+
+const meta = {
+  title: 'ComputerUse/ComputerStateToolCard',
+  component: ComputerStateToolCard,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <ComputerStateToolCard {...props({ toolName: computerStateToolName, args: {}, running: true })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete</span>
+        <ComputerStateToolCard
+          {...props({
+            toolName: computerStateToolName,
+            args: {},
+            result: text('window "Reports — Acme" frontmost · no dialog open'),
+            output: 'window "Reports — Acme" frontmost · no dialog open',
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete · collapsed with more lines</span>
+        <ComputerStateToolCard {...props({ toolName: computerStateToolName, args: {}, result: TREE })} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <ComputerStateToolCard
+          {...props({
+            toolName: computerStateToolName,
+            args: {},
+            result: text('no window is authorized for computer use'),
+            output: 'no window is authorized for computer use',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-computer-use/src/web/components/ComputerUsePanel.stories.tsx
+++ b/packages/minor/doompi-computer-use/src/web/components/ComputerUsePanel.stories.tsx
@@ -1,0 +1,99 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * The panel reads its own session store rather than props, so each variant is
+ * a different session id seeded with the payload the session channel would
+ * have delivered. The artifact carries no previewUrl: the renderer has nothing
+ * to serve it, and an empty <video> box says less than the rest of the card.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { ComputerUsePanel } from './ComputerUsePanel.tsx';
+import type { ComputerUseChannelPayload } from '../../types/computerUseApi.ts';
+import { computerUse } from '../stores/computerUseStore.ts';
+
+const TARGETS = [
+  { windowId: 'w-1', applicationName: 'Reports', windowTitle: 'Reports — Acme' },
+  { windowId: 'w-2', applicationName: 'Terminal', windowTitle: 'zsh — 120x40' },
+];
+
+const seed = (sessionId: string, payload: ComputerUseChannelPayload): string => {
+  computerUse.update(sessionId, () => payload);
+  return sessionId;
+};
+
+const INACTIVE = seed('cu-inactive', {
+  state: { sessionId: 'cu-inactive', revision: 4, wake: 1, phase: 'inactive' },
+  targets: TARGETS,
+});
+
+const ACTIVE = seed('cu-active', {
+  state: { sessionId: 'cu-active', revision: 9, wake: 3, phase: 'active', target: TARGETS[0], durationMs: 300_000 },
+  targets: TARGETS,
+});
+
+const FAILED = seed('cu-failed', {
+  state: {
+    sessionId: 'cu-failed',
+    revision: 12,
+    wake: 5,
+    phase: 'failed',
+    failure: { code: 'grant_expired', message: 'The activation grant expired before the action ran.' },
+    artifact: {
+      artifactId: 'rec-8f21',
+      status: 'ready',
+      downloadUrl: '/api/plugin/computer-use/artifacts/rec-8f21',
+      actionCount: 14,
+      completedAt: '2024-05-14T14:32:10.000Z',
+    },
+  },
+  targets: TARGETS,
+});
+
+const BUSY = seed('cu-busy', {
+  state: { sessionId: 'cu-busy', revision: 2, wake: 1, phase: 'inactive' },
+  targets: TARGETS,
+  busy: true,
+});
+
+const slot = (sessionId: string | null) => slotPropsFixture({ sessionId }).props;
+
+const meta = {
+  title: 'ComputerUse/ComputerUsePanel',
+  component: ComputerUsePanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">inactive · pick a window</span>
+        <ComputerUsePanel {...slot(INACTIVE)} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">active</span>
+        <ComputerUsePanel {...slot(ACTIVE)} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed · with a recording</span>
+        <ComputerUsePanel {...slot(FAILED)} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">busy in another session</span>
+        <ComputerUsePanel {...slot(BUSY)} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no session</span>
+        <ComputerUsePanel {...slot(null)} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-computer-use/src/web/components/ComputerUsePanel.tsx
+++ b/packages/minor/doompi-computer-use/src/web/components/ComputerUsePanel.tsx
@@ -23,7 +23,7 @@ export function ComputerUsePanel({ sessionId, sendSessionFrame }: WebPluginSlotP
     sendSessionFrame(sessionId, { type: computerUseChannelType, payload: { action: 'targets' } });
   }, [sendSessionFrame, sessionId]);
 
-  if (sessionId === null) return <p className="px-1 text-[10px] text-doom-faint">Select a session.</p>;
+  if (sessionId === null) return <p className="px-1 text-xs text-doom-faint">Select a session.</p>;
   const state = session.state;
   const target = session.targets[selected];
   const artifact = state.artifact;
@@ -45,7 +45,7 @@ export function ComputerUsePanel({ sessionId, sendSessionFrame }: WebPluginSlotP
   };
 
   return (
-    <div data-testid="computer-use-panel" className="flex flex-col gap-2 text-[10px] text-doom-text">
+    <div data-testid="computer-use-panel" className="flex flex-col gap-2 text-xs text-doom-text">
       <header className="flex items-center justify-between gap-2">
         <span className="text-doom-faint">{state.phase.replaceAll('_', ' ')}</span>
         <button type="button" className="rounded bg-doom-panel px-2 py-1" onClick={() => send({ action: 'targets' })}>

--- a/packages/minor/doompi-computer-use/style-system.config.yaml
+++ b/packages/minor/doompi-computer-use/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/minor/doompi-computer-use/styles/preview.css
+++ b/packages/minor/doompi-computer-use/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/minor/doompi-computer-use/vibe-lint.config.yaml
+++ b/packages/minor/doompi-computer-use/vibe-lint.config.yaml
@@ -14,3 +14,14 @@ rules:
   public-export-boundary: error
   no-internal-public-import: error
   doom-layer-boundary: error
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/packages/minor/doompi-goal/package.json
+++ b/packages/minor/doompi-goal/package.json
@@ -35,7 +35,8 @@
     "src/types/goal.ts",
     "README.md",
     "LICENSE",
-    "package.json"
+    "package.json",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/minor/doompi-goal/src/web/components/EditGoalDialog.stories.tsx
+++ b/packages/minor/doompi-goal/src/web/components/EditGoalDialog.stories.tsx
@@ -1,0 +1,36 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * One open dialog only. DialogContent is a centred fixed portal behind a
+ * scrim, so a second open instance would sit exactly on top of the first.
+ */
+import { EditGoalDialog } from './EditGoalDialog.tsx';
+
+const noop = (): void => undefined;
+
+const meta = {
+  title: 'Goal/EditGoalDialog',
+  component: EditGoalDialog,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">open · budgeted goal</span>
+        <EditGoalDialog
+          open
+          objective="ship the plan panel and its activity row"
+          budgetHint="100k"
+          onSubmit={noop}
+          onCancel={noop}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-goal/src/web/components/EditGoalDialog.tsx
+++ b/packages/minor/doompi-goal/src/web/components/EditGoalDialog.tsx
@@ -75,7 +75,7 @@ export function EditGoalDialog({
               rows={3}
               spellCheck={false}
               onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setDraft(event.target.value)}
-              className="text-[11px]"
+              className="text-sm"
             />
           </div>
           <div className="flex flex-col gap-1">
@@ -88,10 +88,10 @@ export function EditGoalDialog({
                 budgetHint === '' ? 'none; leave blank to keep it that way' : `${budgetHint}; blank keeps it`
               }
               onChange={(event: ChangeEvent<HTMLInputElement>) => setBudget(event.target.value)}
-              className="text-[11px]"
+              className="text-sm"
             />
           </div>
-          <p data-testid="goal-edit-preview" className="truncate font-mono text-[9px] text-doom-faint">
+          <p data-testid="goal-edit-preview" className="truncate font-mono text-2xs text-doom-faint">
             {command ?? 'nothing to send'}
           </p>
           <DialogFooter>

--- a/packages/minor/doompi-goal/src/web/components/GoalActivitySection.stories.tsx
+++ b/packages/minor/doompi-goal/src/web/components/GoalActivitySection.stories.tsx
@@ -1,0 +1,55 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * The row reads the session's own footer status, so the variants are status
+ * lines in the shape `formatGoalStatusView` writes, not hand-built view models.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { GoalActivitySection } from './GoalActivitySection.tsx';
+import { GOAL_VIEW_STATUS_KEY, formatGoalStatusView } from '../../types/goalView.ts';
+
+const slot = (status?: string, sessionId: string | null = 's1') =>
+  slotPropsFixture({
+    sessionId,
+    statuses: status === undefined ? {} : { [GOAL_VIEW_STATUS_KEY]: status },
+  }).props;
+
+const meta = {
+  title: 'Goal/GoalActivitySection',
+  component: GoalActivitySection,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no goal set</span>
+        <GoalActivitySection {...slot()} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">budgeted goal</span>
+        <GoalActivitySection
+          {...slot(formatGoalStatusView('ship the plan panel and its activity row', 'active 12.4k/100k'))}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">unbudgeted goal</span>
+        <GoalActivitySection {...slot(formatGoalStatusView('keep the cockpit render pipeline green', 'active 3.1k'))} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no session · menu disabled</span>
+        <GoalActivitySection
+          {...slot(formatGoalStatusView('ship the plan panel and its activity row', 'active 12.4k/100k'), null)}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-goal/src/web/components/GoalActivitySection.tsx
+++ b/packages/minor/doompi-goal/src/web/components/GoalActivitySection.tsx
@@ -37,7 +37,7 @@ export function GoalActivitySection({ sessionId, statuses, sendSessionFrame }: W
 
   if (view === undefined) {
     return (
-      <p data-testid="activity-summary-goal" className="px-1 text-[10px] text-doom-faint">
+      <p data-testid="activity-summary-goal" className="px-1 text-xs text-doom-faint">
         no goal set yet
       </p>
     );
@@ -54,10 +54,10 @@ export function GoalActivitySection({ sessionId, statuses, sendSessionFrame }: W
     <div data-testid="activity-goal-row" className="flex flex-col gap-0.5">
       <div className="flex min-w-0 items-start gap-1.5 px-1">
         <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <span data-testid="activity-goal-objective" className="text-[10px] font-bold text-doom-hi">
+          <span data-testid="activity-goal-objective" className="text-xs font-bold text-doom-hi">
             {view.objective}
           </span>
-          <span data-testid="activity-goal-state" className="text-[9px] tabular-nums text-doom-faint">
+          <span data-testid="activity-goal-state" className="text-2xs tabular-nums text-doom-faint">
             {view.state}
           </span>
         </span>

--- a/packages/minor/doompi-goal/src/web/components/GoalToolMessage.stories.tsx
+++ b/packages/minor/doompi-goal/src/web/components/GoalToolMessage.stories.tsx
@@ -1,0 +1,91 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { GoalToolMessage } from './GoalToolMessage.tsx';
+
+const props = (overrides: Parameters<typeof toolMessagePropsFixture>[0]) => toolMessagePropsFixture(overrides).props;
+
+const completeResult = {
+  content: [{ type: 'text', text: 'goal recorded as complete' }],
+  details: null,
+};
+
+const blockedResult = {
+  content: [{ type: 'text', text: 'goal marked blocked after 3 turns' }],
+  details: null,
+};
+
+const refusedResult = {
+  content: [{ type: 'text', text: 'no goal is active in this session' }],
+  details: { error: true },
+};
+
+const meta = {
+  title: 'Goal/GoalToolMessage',
+  component: GoalToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running</span>
+        <GoalToolMessage
+          {...props({
+            toolName: 'goal_complete',
+            args: { goal_id: 'g-41', summary: 'shipped the plan panel' },
+            running: true,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">goal_complete · expandable</span>
+        <GoalToolMessage
+          {...props({
+            toolName: 'goal_complete',
+            args: { goal_id: 'g-41', summary: 'shipped the plan panel and its activity row' },
+            result: completeResult,
+            output: 'goal recorded as complete',
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">goal_blocked · turn count</span>
+        <GoalToolMessage
+          {...props({
+            toolName: 'goal_blocked',
+            args: {
+              goal_id: 'g-41',
+              reason: 'the hub refuses the save route without a session token',
+              evidence: 'PUT /plan/content answered 401 on three attempts',
+              repeated_turns: 3,
+            },
+            result: blockedResult,
+            output: 'goal marked blocked after 3 turns',
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">refused</span>
+        <GoalToolMessage
+          {...props({
+            toolName: 'goal_complete',
+            args: { goal_id: 'g-41', summary: 'shipped the plan panel' },
+            result: refusedResult,
+            output: 'no goal is active in this session',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-goal/src/web/components/RemoveGoalDialog.stories.tsx
+++ b/packages/minor/doompi-goal/src/web/components/RemoveGoalDialog.stories.tsx
@@ -1,0 +1,30 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * One open dialog only. DialogContent is a centred fixed portal behind a
+ * scrim, so a second open instance would sit exactly on top of the first.
+ */
+import { RemoveGoalDialog } from './RemoveGoalDialog.tsx';
+
+const noop = (): void => undefined;
+
+const meta = {
+  title: 'Goal/RemoveGoalDialog',
+  component: RemoveGoalDialog,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">open · confirming a clear</span>
+        <RemoveGoalDialog open objective="ship the plan panel and its activity row" onConfirm={noop} onCancel={noop} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-goal/style-system.config.yaml
+++ b/packages/minor/doompi-goal/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/minor/doompi-goal/styles/preview.css
+++ b/packages/minor/doompi-goal/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/minor/doompi-goal/vibe-lint.config.yaml
+++ b/packages/minor/doompi-goal/vibe-lint.config.yaml
@@ -19,6 +19,15 @@ rules:
   file-naming-convention: error
 
 overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off
   # Reads time, randomness or process state ambiently instead of taking it as a
   # dependency. Each needs a clock, id factory or env threaded through its
   # caller; until then the rule stays on for every other module here.

--- a/packages/minor/doompi-loop/package.json
+++ b/packages/minor/doompi-loop/package.json
@@ -34,7 +34,8 @@
     "src/types/loopView.ts",
     "README.md",
     "LICENSE",
-    "package.json"
+    "package.json",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/minor/doompi-loop/src/web/components/LoopsActivitySection.stories.tsx
+++ b/packages/minor/doompi-loop/src/web/components/LoopsActivitySection.stories.tsx
@@ -1,0 +1,46 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`. The section reads its rows out of one
+ * session status string, so each variant is a different value for that key.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { LOOP_VIEW_STATUS_KEY } from '../../types/loopView.ts';
+import { LoopsActivitySection } from './LoopsActivitySection.tsx';
+
+const LOOPS = JSON.stringify([
+  { instanceId: 'loop-1', label: 'nightly digest', detail: 'every 30m · next in 12m', state: 'running' },
+  { instanceId: 'loop-2', label: 'inbox sweep', detail: 'waiting for first tick', state: 'starting' },
+  { instanceId: 'loop-3', label: 'release watch', detail: 'draining current run', state: 'stopping' },
+]);
+
+const props = (raw: string, sessionId: string | null = 's1') =>
+  slotPropsFixture({ sessionId, statuses: { [LOOP_VIEW_STATUS_KEY]: raw } }).props;
+
+const meta = {
+  title: 'Loop/LoopsActivitySection',
+  component: LoopsActivitySection,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex w-72 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">active loops</span>
+        <LoopsActivitySection {...props(LOOPS)} />
+      </div>
+
+      <div className="flex w-72 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">malformed status</span>
+        <LoopsActivitySection {...props('not json')} />
+      </div>
+
+      <div className="flex w-72 flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no focused session · manage off</span>
+        <LoopsActivitySection {...props(LOOPS, null)} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-loop/src/web/components/LoopsActivitySection.tsx
+++ b/packages/minor/doompi-loop/src/web/components/LoopsActivitySection.tsx
@@ -31,15 +31,15 @@ export function LoopsActivitySection({ sessionId, statuses, sendSessionFrame }: 
             >
               <span className="flex min-w-0 items-center gap-1.5">
                 <Dot tone={toneOf(loop.state)} pulse={loop.state !== 'running'} />
-                <span className="min-w-0 flex-1 truncate text-[10px] font-bold text-doom-hi">{loop.label}</span>
-                <span className="shrink-0 text-[9px] text-doom-faint">{loop.state}</span>
+                <span className="min-w-0 flex-1 truncate text-xs font-bold text-doom-hi">{loop.label}</span>
+                <span className="shrink-0 text-2xs text-doom-faint">{loop.state}</span>
               </span>
-              <span className="truncate pl-3 text-[9px] text-doom-faint">{loop.detail}</span>
+              <span className="truncate pl-3 text-2xs text-doom-faint">{loop.detail}</span>
             </li>
           ))}
         </ul>
       ) : (
-        <p className="px-1 text-[10px] text-doom-faint">loop status unavailable</p>
+        <p className="px-1 text-xs text-doom-faint">loop status unavailable</p>
       )}
       <Button
         variant="subtle"
@@ -51,7 +51,7 @@ export function LoopsActivitySection({ sessionId, statuses, sendSessionFrame }: 
           if (sessionId === null) return;
           sendSessionFrame(sessionId, { type: 'prompt', message: MANAGE_COMMAND });
         }}
-        className="self-end text-[8px] font-bold"
+        className="self-end text-2xs font-bold"
       >
         manage
       </Button>

--- a/packages/minor/doompi-loop/style-system.config.yaml
+++ b/packages/minor/doompi-loop/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/minor/doompi-loop/styles/preview.css
+++ b/packages/minor/doompi-loop/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/minor/doompi-loop/vibe-lint.config.yaml
+++ b/packages/minor/doompi-loop/vibe-lint.config.yaml
@@ -17,3 +17,14 @@ rules:
   no-raw-theme-color: error
   boundary-import-allowlist: error
   file-naming-convention: error
+
+overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off

--- a/packages/minor/doompi-plan/package.json
+++ b/packages/minor/doompi-plan/package.json
@@ -35,7 +35,8 @@
     "src/types/planSettings.ts",
     "README.md",
     "LICENSE",
-    "package.json"
+    "package.json",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/minor/doompi-plan/src/web/components/PlanActivitySection.stories.tsx
+++ b/packages/minor/doompi-plan/src/web/components/PlanActivitySection.stories.tsx
@@ -1,0 +1,48 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { PlanActivitySection } from './PlanActivitySection.tsx';
+import { formatPlanStatus, PLAN_STATUS_KEY } from '../../types/planApi.ts';
+
+const slot = (status?: string, sessionId: string | null = 's1') =>
+  slotPropsFixture({
+    sessionId,
+    statuses: status === undefined ? {} : { [PLAN_STATUS_KEY]: status },
+  }).props;
+
+const meta = {
+  title: 'Plan/PlanActivitySection',
+  component: PlanActivitySection,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no plan written</span>
+        <PlanActivitySection {...slot()} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">plan with a write stamp</span>
+        <PlanActivitySection {...slot(formatPlanStatus('Cockpit story coverage for plugin packages', '14:32'))} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no stamp</span>
+        <PlanActivitySection {...slot('Migrate every plugin web tree onto the shared style-system render pipeline')} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no session · open disabled</span>
+        <PlanActivitySection {...slot(formatPlanStatus('Cockpit story coverage', '14:32'), null)} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-plan/src/web/components/PlanActivitySection.tsx
+++ b/packages/minor/doompi-plan/src/web/components/PlanActivitySection.tsx
@@ -20,7 +20,7 @@ export function PlanActivitySection({ sessionId, statuses, openTransientTab }: W
 
   if (view === undefined) {
     return (
-      <p data-testid="activity-summary-plan" className="px-1 text-[10px] text-doom-faint">
+      <p data-testid="activity-summary-plan" className="px-1 text-xs text-doom-faint">
         no plan written yet
       </p>
     );
@@ -38,23 +38,23 @@ export function PlanActivitySection({ sessionId, statuses, openTransientTab }: W
           if (sessionId === null) return;
           openTransientTab(planTab());
         }}
-        className="min-w-0 gap-0.5 rounded-[5px] px-1 py-1 hover:bg-doom-panel"
+        className="min-w-0 gap-0.5 rounded-md px-1 py-1 hover:bg-doom-panel"
       >
         <span className="flex w-full min-w-0 items-center gap-1.5">
           <span
             data-testid="activity-plan-title"
-            className="min-w-0 flex-1 truncate text-left text-[10px] font-bold text-doom-hi"
+            className="min-w-0 flex-1 truncate text-left text-xs font-bold text-doom-hi"
           >
             {view.title}
           </span>
           {view.stamp === '' ? null : (
-            <span data-testid="activity-plan-stamp" className="shrink-0 text-[9px] tabular-nums text-doom-faint">
+            <span data-testid="activity-plan-stamp" className="shrink-0 text-2xs tabular-nums text-doom-faint">
               {view.stamp}
             </span>
           )}
         </span>
       </Button>
-      <p className="px-1 text-[9px] leading-relaxed text-doom-faint">
+      <p className="px-1 text-2xs leading-relaxed text-doom-faint">
         open to read or edit; the agent reads what you save.
       </p>
     </div>

--- a/packages/minor/doompi-plan/src/web/components/PlanPanel.stories.tsx
+++ b/packages/minor/doompi-plan/src/web/components/PlanPanel.stories.tsx
@@ -1,0 +1,100 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * The panel reads the plan over the session API on mount, and the renderer has
+ * no hub behind it, so every view but the error one would be unreachable. The
+ * plan route is answered here at module scope, from the same PlanDetailView the
+ * route returns; anything else still goes to the page's own fetch.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { PlanPanel } from './PlanPanel.tsx';
+import { currentUrl, type PlanDetailView } from '../../types/planApi.ts';
+
+const PLAN: PlanDetailView = {
+  path: '.doom/plans/story-coverage.md',
+  title: 'Cockpit story coverage for plugin packages',
+  writtenAt: '2024-05-14T14:32:00.000Z',
+  content: [
+    '# Cockpit story coverage',
+    '',
+    'One plain-CSF story beside every plugin component, rendered by the',
+    'style-system pipeline rather than a Storybook runtime.',
+    '',
+    '## Steps',
+    '',
+    '1. Read each component signature and derive its props from it.',
+    '2. Use the contracts package fixtures for slot and tool-message props.',
+    '3. Render every story and read the PNG back.',
+    '',
+    '## Out of scope',
+    '',
+    '- Component source changes.',
+    '- Anything under `package.json` or the workspace configs.',
+  ].join('\n'),
+  hash: 'b4c1f0a9',
+  unavailable: false,
+};
+
+const UNAVAILABLE: PlanDetailView = {
+  path: '.doom/plans/oversized.md',
+  title: 'oversized plan',
+  writtenAt: '2024-05-14T09:04:00.000Z',
+  content: '',
+  hash: '',
+  unavailable: true,
+  reason: 'this plan is larger than the cockpit will load; open it from the editor instead.',
+};
+
+const answers: Readonly<Record<string, PlanDetailView>> = {
+  [currentUrl('plan-preview')]: PLAN,
+  [currentUrl('plan-unavailable')]: UNAVAILABLE,
+};
+
+const pageFetch = globalThis.fetch.bind(globalThis);
+globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+  const detail = answers[url];
+  if (detail === undefined) return pageFetch(input, init);
+  return Promise.resolve(
+    new Response(JSON.stringify(detail), { status: 200, headers: { 'content-type': 'application/json' } }),
+  );
+};
+
+const slot = (sessionId: string | null) => slotPropsFixture({ sessionId }).props;
+
+const meta = {
+  title: 'Plan/PlanPanel',
+  component: PlanPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">preview</span>
+        <div className="flex h-96 flex-col border border-doom-border">
+          <PlanPanel {...slot('plan-preview')} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">plan too large to show</span>
+        <div className="flex h-40 flex-col border border-doom-border">
+          <PlanPanel {...slot('plan-unavailable')} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">session unreachable</span>
+        <div className="flex h-40 flex-col border border-doom-border">
+          <PlanPanel {...slot('plan-missing')} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-plan/src/web/components/PlanPanel.tsx
+++ b/packages/minor/doompi-plan/src/web/components/PlanPanel.tsx
@@ -87,7 +87,7 @@ export function PlanPanel({ sessionId, statuses, closeTransientTab }: WebPluginS
   return (
     <div data-testid="plan-panel" className="flex min-h-0 flex-1 flex-col">
       <header className="flex shrink-0 items-center gap-2 border-b border-doom-border px-4 py-2">
-        <span data-testid="plan-title" className="min-w-0 flex-1 truncate text-[12px] font-bold text-doom-hi">
+        <span data-testid="plan-title" className="min-w-0 flex-1 truncate text-sm font-bold text-doom-hi">
           {detail?.title ?? 'plan'}
         </span>
         <nav className="flex shrink-0 items-center gap-1">
@@ -98,7 +98,7 @@ export function PlanPanel({ sessionId, statuses, closeTransientTab }: WebPluginS
               size="xs"
               data-testid={`plan-view-${entry}`}
               onClick={() => setView(entry)}
-              className="text-[9px]"
+              className="text-2xs"
             >
               {entry}
             </Button>
@@ -109,32 +109,32 @@ export function PlanPanel({ sessionId, statuses, closeTransientTab }: WebPluginS
           size="xs"
           data-testid="plan-close"
           onClick={() => closeTransientTab(PLAN_TAB_ID)}
-          className="shrink-0 text-[9px]"
+          className="shrink-0 text-2xs"
         >
           close
         </Button>
       </header>
 
       {loading && detail === undefined ? (
-        <p data-testid="plan-loading" className="px-4 py-3 text-[11px] text-doom-faint">
+        <p data-testid="plan-loading" className="px-4 py-3 text-sm text-doom-faint">
           reading this session's plan…
         </p>
       ) : null}
       {error === undefined ? null : (
-        <p data-testid="plan-error" className="px-4 py-3 text-[11px] text-doom-red">
+        <p data-testid="plan-error" className="px-4 py-3 text-sm text-doom-red">
           {error}
         </p>
       )}
 
       <div className="flex min-h-0 flex-1 flex-col">
         {detail === undefined ? null : detail.unavailable ? (
-          <p data-testid="plan-unavailable" className="px-4 py-3 text-[11px] text-doom-faint">
+          <p data-testid="plan-unavailable" className="px-4 py-3 text-sm text-doom-faint">
             {detail.reason ?? 'this plan cannot be shown'}
           </p>
         ) : view === 'preview' ? (
           <div
             data-testid="plan-preview"
-            className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-4 text-[12px] text-doom-text"
+            className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-4 text-sm text-doom-text"
           >
             <Markdown text={content} />
           </div>
@@ -157,7 +157,7 @@ export function PlanPanel({ sessionId, statuses, closeTransientTab }: WebPluginS
                 loading={saving}
                 disabled={draft === undefined || saving}
                 onClick={() => void save()}
-                className="text-[9px]"
+                className="text-2xs"
               >
                 save to disk
               </Button>
@@ -167,7 +167,7 @@ export function PlanPanel({ sessionId, statuses, closeTransientTab }: WebPluginS
                   size="xs"
                   data-testid="plan-revert"
                   onClick={() => setDraft(undefined)}
-                  className="text-[9px]"
+                  className="text-2xs"
                 >
                   discard edits
                 </Button>
@@ -175,7 +175,7 @@ export function PlanPanel({ sessionId, statuses, closeTransientTab }: WebPluginS
               {saveNote === undefined ? null : (
                 <span
                   data-testid="plan-save-note"
-                  className={saveNote === SAVED_NOTE ? 'text-[9px] text-doom-green' : 'text-[9px] text-doom-red'}
+                  className={saveNote === SAVED_NOTE ? 'text-2xs text-doom-green' : 'text-2xs text-doom-red'}
                 >
                   {saveNote}
                 </span>
@@ -187,7 +187,7 @@ export function PlanPanel({ sessionId, statuses, closeTransientTab }: WebPluginS
 
       {detail === undefined ? null : (
         <footer data-testid="plan-source-path" className="shrink-0 truncate border-t border-doom-border px-4 py-1.5">
-          <span className="text-[9px] text-doom-faint">{detail.path}</span>
+          <span className="text-2xs text-doom-faint">{detail.path}</span>
         </footer>
       )}
     </div>

--- a/packages/minor/doompi-plan/src/web/components/PlanReviewPrompt.stories.tsx
+++ b/packages/minor/doompi-plan/src/web/components/PlanReviewPrompt.stories.tsx
@@ -1,0 +1,51 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * `ToolPromptRenderProps` is the tool-message contract plus the open request,
+ * so the message half comes from the contracts package's own fixture and only
+ * the dialog is written out here; the options come from the shared contract.
+ */
+import type { ToolPromptRenderProps } from '@agimon-ai/doompi-web-contracts';
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { PlanReviewPrompt } from './PlanReviewPrompt.tsx';
+import { PLAN_REVIEW_OPTIONS, PLAN_REVIEW_TITLE } from '../../types/planApi.ts';
+
+const noop = (): void => undefined;
+
+const promptProps = (id: string): ToolPromptRenderProps => ({
+  ...toolMessagePropsFixture({ toolName: 'complete_plan', running: true }).props,
+  dialog: {
+    id,
+    method: 'select',
+    title: PLAN_REVIEW_TITLE,
+    message: '',
+    options: PLAN_REVIEW_OPTIONS,
+    placeholder: '',
+    prefill: '',
+  },
+  answer: noop,
+  cancel: noop,
+});
+
+const meta = {
+  title: 'Plan/PlanReviewPrompt',
+  component: PlanReviewPrompt,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">awaiting the review decision</span>
+        <div className="rounded-md border border-doom-border bg-doom-panel">
+          <PlanReviewPrompt {...promptProps('prompt-1')} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-plan/src/web/components/PlanReviewPrompt.tsx
+++ b/packages/minor/doompi-plan/src/web/components/PlanReviewPrompt.tsx
@@ -51,8 +51,8 @@ export function PlanReviewPrompt({ dialog, answer, cancel }: ToolPromptRenderPro
     >
       <div className="flex flex-col gap-1 px-3.5 pt-3 pb-2">
         <SectionLabel>plan review</SectionLabel>
-        <p className="text-[13px] leading-relaxed text-doom-hi">{dialog.title}</p>
-        <p className="text-[11px] leading-relaxed text-doom-dim">
+        <p className="text-base leading-relaxed text-doom-hi">{dialog.title}</p>
+        <p className="text-sm leading-relaxed text-doom-dim">
           Review the plan in the conversation before choosing what happens next.
         </p>
       </div>
@@ -67,7 +67,7 @@ export function PlanReviewPrompt({ dialog, answer, cancel }: ToolPromptRenderPro
       />
 
       <div className="flex min-h-[34px] items-center gap-2 border-t border-doom-border-soft px-3.5 py-2">
-        <span className="text-[10px] text-doom-faint">
+        <span className="text-xs text-doom-faint">
           {optionListHint(dialog.options.length)} · <Kbd>esc</Kbd> cancels
         </span>
         <Button variant="outline" size="sm" data-testid="plan-review-cancel" className="ml-auto" onClick={cancel}>

--- a/packages/minor/doompi-plan/src/web/components/PlanToolMessage.stories.tsx
+++ b/packages/minor/doompi-plan/src/web/components/PlanToolMessage.stories.tsx
@@ -1,0 +1,113 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { PlanToolMessage } from './PlanToolMessage.tsx';
+
+const props = (overrides: Parameters<typeof toolMessagePropsFixture>[0]) => toolMessagePropsFixture(overrides).props;
+
+const text = (value: string) => ({ content: [{ type: 'text', text: value }], details: null });
+
+const meta = {
+  title: 'Plan/PlanToolMessage',
+  component: PlanToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">record_debug_evidence · recorded</span>
+        <PlanToolMessage
+          {...props({
+            toolName: 'record_debug_evidence',
+            args: {
+              issue: 'the plan tab reopens empty after a rewrite',
+              expectedBehavior: 'the tab shows the plan on disk',
+              logs: ['GET /plan/current 200', 'GET /plan/current 404'],
+              verifiedFacts: ['the status stamp changed between the two reads'],
+            },
+            result: { content: [], details: { recorded: true } },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">run_fable_plan · draft returned</span>
+        <PlanToolMessage
+          {...props({
+            toolName: 'run_fable_plan',
+            args: {
+              goal: ['ship story coverage for every plugin package'],
+              constraints: ['no component source changes'],
+              decisions: ['plain CSF, one Playground export'],
+              currentPlan: '# plan\n\n1. read each component',
+            },
+            result: {
+              content: [],
+              details: {
+                started: true,
+                status: 'completed',
+                draft:
+                  '1. read each component signature\n2. write one story per component\n3. render and check the png',
+              },
+            },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">write_plan · in flight</span>
+        <PlanToolMessage
+          {...props({
+            toolName: 'write_plan',
+            args: {},
+            result: { content: [], details: { phase: 'writing', path: '.doom/plans/story-coverage.md' } },
+            running: true,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">write_plan · written</span>
+        <PlanToolMessage
+          {...props({
+            toolName: 'write_plan',
+            args: {},
+            result: { content: [], details: { written: true, path: '.doom/plans/story-coverage.md', durationMs: 42 } },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">complete_plan · exited</span>
+        <PlanToolMessage
+          {...props({
+            toolName: 'complete_plan',
+            args: { decision: 'exit plan mode' },
+            result: { content: [{ type: 'text', text: 'implementation starts now' }], details: { exited: true } },
+            output: 'implementation starts now',
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <PlanToolMessage
+          {...props({
+            toolName: 'write_plan',
+            args: {},
+            result: text('the plan file moved under the editor'),
+            output: 'the plan file moved under the editor',
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-plan/style-system.config.yaml
+++ b/packages/minor/doompi-plan/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/minor/doompi-plan/styles/preview.css
+++ b/packages/minor/doompi-plan/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/minor/doompi-plan/vibe-lint.config.yaml
+++ b/packages/minor/doompi-plan/vibe-lint.config.yaml
@@ -19,6 +19,15 @@ rules:
   file-naming-convention: error
 
 overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off
   # Published as ./planMode, but this is the Pi orchestration boundary rather
   # than host-neutral policy: it drives the cordis Context and emits telemetry.
   # It moves to src/adapters when the composition root migration reaches this

--- a/packages/minor/doompi-voice/package.json
+++ b/packages/minor/doompi-voice/package.json
@@ -37,7 +37,8 @@
     "src/types/manualTranscription.ts",
     "README.md",
     "LICENSE",
-    "package.json"
+    "package.json",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",
@@ -98,6 +99,7 @@
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "5.0.0",
     "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsdown": "0.23.0",
     "typescript": "7.0.2",
     "vitest": "5.0.0"

--- a/packages/minor/doompi-voice/src/web/components/VoiceActivitySection.stories.tsx
+++ b/packages/minor/doompi-voice/src/web/components/VoiceActivitySection.stories.tsx
@@ -1,0 +1,68 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * The variants are the raw `doom-voice` status lines the session publishes,
+ * parsed by the component's own reader. The conflict row is the one state that
+ * is not in a status: it comes from the page-wide media store, which is keyed
+ * by session id, so only that variant's session sees it.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { VoiceActivitySection } from './VoiceActivitySection.tsx';
+import { voiceMediaBrowserState } from '../stores/voiceMediaWakeStore.ts';
+
+const CONFLICT_SESSION = 'voice-conflict';
+voiceMediaBrowserState.update(() => ({ sessionId: CONFLICT_SESSION, phase: 'conflict' }));
+
+const slot = (status?: string, sessionId: string | null = 's1') =>
+  slotPropsFixture({ sessionId, statuses: status === undefined ? {} : { 'doom-voice': status } }).props;
+
+const meta = {
+  title: 'Voice/VoiceActivitySection',
+  component: VoiceActivitySection,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">idle</span>
+        <VoiceActivitySection {...slot()} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">auto · listening</span>
+        <VoiceActivitySection {...slot('voice auto: listening')} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">auto · composing</span>
+        <VoiceActivitySection {...slot('voice auto: composing')} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">auto · microphone muted</span>
+        <VoiceActivitySection {...slot('voice auto: microphone muted')} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">manual · recording</span>
+        <VoiceActivitySection {...slot('⠹ voice: recording 1:07')} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">manual · transcribing</span>
+        <VoiceActivitySection {...slot('voice: transcribing')} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">microphone owned by another tab</span>
+        <VoiceActivitySection {...slot('voice auto: listening', CONFLICT_SESSION)} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-voice/src/web/components/VoiceActivitySection.tsx
+++ b/packages/minor/doompi-voice/src/web/components/VoiceActivitySection.tsx
@@ -24,7 +24,7 @@ function Meter({ tone }: { tone: VoiceTone }) {
       {bars.map((height, index) => (
         <span
           key={index}
-          className={`w-[2px] animate-pulse rounded-[1px] ${tone === 'attention' ? 'bg-doom-yellow' : 'bg-doom-cyan'}`}
+          className={`w-[2px] animate-pulse rounded-xs ${tone === 'attention' ? 'bg-doom-yellow' : 'bg-doom-cyan'}`}
           style={{ height: `${String(height)}px`, animationDelay: `${String(index * 120)}ms` }}
         />
       ))}
@@ -64,11 +64,11 @@ export function VoiceActivitySection({ sessionId, sendSessionFrame, statuses }: 
     >
       <span className="flex min-w-0 items-center gap-2">
         <Dot tone={TONE_DOT[tone]} pulse={mediaConflict ? false : view.active} />
-        <span data-testid="voice-label" className={`flex-1 truncate text-[11px] font-bold ${TONE_TEXT[tone]}`}>
+        <span data-testid="voice-label" className={`flex-1 truncate text-sm font-bold ${TONE_TEXT[tone]}`}>
           {mediaConflict ? 'microphone unavailable' : view.label}
         </span>
         {view.elapsed ? (
-          <span data-testid="voice-elapsed" className="shrink-0 text-[10px] tabular-nums text-doom-yellow">
+          <span data-testid="voice-elapsed" className="shrink-0 text-xs tabular-nums text-doom-yellow">
             {view.elapsed}
           </span>
         ) : null}
@@ -88,14 +88,14 @@ export function VoiceActivitySection({ sessionId, sendSessionFrame, statuses }: 
         {!mediaConflict && view.active ? <Meter tone={view.tone} /> : null}
       </span>
       {mediaConflict || view.detail ? (
-        <span data-testid="voice-detail" className="text-[9px] leading-relaxed text-doom-faint">
+        <span data-testid="voice-detail" className="text-2xs leading-relaxed text-doom-faint">
           {mediaConflict
             ? 'another browser tab owns voice capture. Close it or stop voice there, then retry.'
             : view.detail}
         </span>
       ) : null}
       {view.mode !== 'off' ? (
-        <span className="text-[8px] font-bold tracking-[0.14em] text-doom-faint/70 uppercase">
+        <span className="text-2xs font-bold tracking-wider text-doom-faint/70 uppercase">
           {view.mode === 'auto' ? 'autonomous capture' : 'one-shot dictation'}
         </span>
       ) : null}

--- a/packages/minor/doompi-voice/src/web/components/VoiceComposerAction.stories.tsx
+++ b/packages/minor/doompi-voice/src/web/components/VoiceComposerAction.stories.tsx
@@ -1,0 +1,50 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ *
+ * Only the states the props reach are here. Recording, starting and
+ * transcribing come from the button's own recorder, which opens the microphone
+ * through getUserMedia; the headless renderer has no device to grant, so
+ * driving it would be faking the one thing the button reports.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { VoiceComposerAction } from './VoiceComposerAction.tsx';
+
+const slot = (status?: string, sessionId: string | null = 's1') =>
+  slotPropsFixture({ sessionId, statuses: status === undefined ? {} : { 'doom-voice': status } }).props;
+
+const meta = {
+  title: 'Voice/VoiceComposerAction',
+  component: VoiceComposerAction,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">idle · ready to dictate</span>
+        <div className="flex items-center gap-2">
+          <VoiceComposerAction {...slot()} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">blocked · autonomous voice is on</span>
+        <div className="flex items-center gap-2">
+          <VoiceComposerAction {...slot('voice auto: listening')} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no session · disabled</span>
+        <div className="flex items-center gap-2">
+          <VoiceComposerAction {...slot(undefined, null)} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-voice/src/web/components/VoiceToolMessage.stories.tsx
+++ b/packages/minor/doompi-voice/src/web/components/VoiceToolMessage.stories.tsx
@@ -1,0 +1,127 @@
+/*
+ * Plain CSF objects: the style-system renderer parses this file statically and
+ * mounts the exported `render`, so no Storybook runtime is imported and the
+ * default export is a bare `const meta`.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { VoiceToolMessage } from './VoiceToolMessage.tsx';
+import {
+  VOICE_DESCRIBE_TOOL,
+  VOICE_NARRATE_TOOL,
+  VOICE_TRANSFER_TOOL,
+  VOICE_USE_TOOL,
+} from '../lib/voiceToolRender.ts';
+
+const props = (overrides: Parameters<typeof toolMessagePropsFixture>[0]) => toolMessagePropsFixture(overrides).props;
+
+const CATALOG = {
+  content: [],
+  details: {
+    catalogRevision: 7,
+    tools: [
+      {
+        name: 'set_timer',
+        label: 'Set a timer',
+        enabled: true,
+        description: 'Starts a countdown and announces it when it ends.',
+        inputSchema: { type: 'object', properties: { minutes: { type: 'number' } }, required: ['minutes'] },
+      },
+      { name: 'play_music', label: 'Play music', enabled: false },
+    ],
+    conflicts: [{ name: 'set_timer', message: 'Two extensions register this name.' }],
+    unknownNames: ['open_garage'],
+  },
+};
+
+const BATCH = {
+  content: [],
+  details: {
+    status: 'completed',
+    results: [
+      { name: 'set_timer', status: 'completed', result: { minutes: 10, endsAt: '14:42' } },
+      { name: 'play_music', status: 'rejected', error: { message: 'The capability is disabled.' } },
+    ],
+    errors: [],
+  },
+};
+
+const meta = {
+  title: 'Voice/VoiceToolMessage',
+  component: VoiceToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">narrate · spoken, as a message</span>
+        <VoiceToolMessage
+          {...props({
+            toolName: VOICE_NARRATE_TOOL,
+            args: { text: 'The plan panel is open and the first three steps are done.' },
+            result: { content: [], details: { outcome: 'completed' } },
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">narrate · playing</span>
+        <VoiceToolMessage
+          {...props({
+            toolName: VOICE_NARRATE_TOOL,
+            args: { text: 'Reading the reply aloud now.' },
+            running: true,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">describe_voice_tools · catalog</span>
+        <VoiceToolMessage
+          {...props({ toolName: VOICE_DESCRIBE_TOOL, args: { names: ['set_timer'] }, result: CATALOG })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">use_voice_tools · batch</span>
+        <VoiceToolMessage
+          {...props({
+            toolName: VOICE_USE_TOOL,
+            args: { calls: [{ name: 'set_timer' }, { name: 'play_music' }] },
+            result: BATCH,
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">transfer_voice · handed off</span>
+        <VoiceToolMessage
+          {...props({
+            toolName: VOICE_TRANSFER_TOOL,
+            args: { target: 2 },
+            result: { content: [{ type: 'text', text: 'Voice moved to session 2.' }], details: null },
+            output: 'Voice moved to session 2.',
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">failed</span>
+        <VoiceToolMessage
+          {...props({
+            toolName: VOICE_USE_TOOL,
+            args: { calls: [{ name: 'set_timer' }] },
+            result: {
+              content: [],
+              details: { error: { message: 'The voice broker is not running.', retryable: true } },
+            },
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-voice/src/web/components/VoiceToolMessage.tsx
+++ b/packages/minor/doompi-voice/src/web/components/VoiceToolMessage.tsx
@@ -23,7 +23,7 @@ export function VoiceToolMessage({ toolName, args, result, running, isError }: T
         aria-label="narration"
         data-testid="narration-message"
         data-narration-state={running ? 'playing' : isError ? 'failed' : 'complete'}
-        className="flex min-w-0 items-start gap-2 text-[13px] text-doom-text"
+        className="flex min-w-0 items-start gap-2 text-base text-doom-text"
       >
         <VolumeIcon aria-hidden="true" className="mt-0.5 h-3.5 w-3.5 shrink-0 text-doom-magenta" />
         <p className="min-w-0 flex-1 whitespace-pre-wrap break-words">{text || 'Narration unavailable.'}</p>

--- a/packages/minor/doompi-voice/style-system.config.yaml
+++ b/packages/minor/doompi-voice/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/minor/doompi-voice/styles/preview.css
+++ b/packages/minor/doompi-voice/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/minor/doompi-voice/vibe-lint.config.yaml
+++ b/packages/minor/doompi-voice/vibe-lint.config.yaml
@@ -19,6 +19,15 @@ rules:
   file-naming-convention: error
 
 overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off
   # Reads time, randomness or process state ambiently instead of taking it as a
   # dependency. Each needs a clock, id factory or env threaded through its
   # caller; until then the rule stays on for every other module here.

--- a/packages/minor/doompi-workflow/package.json
+++ b/packages/minor/doompi-workflow/package.json
@@ -34,7 +34,8 @@
     "src/web",
     "src/exports/webClient.ts",
     "src/types/webWorkflows.ts",
-    "src/types/webWorkflowTerminal.ts"
+    "src/types/webWorkflowTerminal.ts",
+    "!src/web/**/*.stories.tsx"
   ],
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/minor/doompi-workflow/src/web/components/ArtifactsPane.stories.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/ArtifactsPane.stories.tsx
@@ -1,0 +1,56 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition.
+ *
+ * The pane reads its listing from the workflow API inside an effect. The
+ * headless renderer has no backend, so the request fails and the pane shows
+ * the states it reaches without one. The rows themselves are covered by
+ * WorkflowsPanel, which reads the same registry from a seeded store.
+ */
+import type { WorkflowRunView } from '../../types/webWorkflows.ts';
+import { ArtifactsPane } from './ArtifactsPane.tsx';
+
+const MINUTE_MS = 60_000;
+
+const run: WorkflowRunView = {
+  runKey: 'release-14',
+  workspace: 'doompi',
+  displayName: 'release',
+  workflowPath: '.doom/workflows/release.workflow.yaml',
+  stage: 'completed',
+  outcome: 'success',
+  startedAt: new Date(Date.now() - 12 * MINUTE_MS).toISOString(),
+  finishedAt: new Date(Date.now() - 4 * MINUTE_MS).toISOString(),
+  jobs: [],
+};
+
+const meta = {
+  title: 'Workflow/ArtifactsPane',
+  component: ArtifactsPane,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          a finished run · listing unavailable without a backend
+        </span>
+        <div className="w-96 rounded-md border border-doom-border bg-doom-panel">
+          <ArtifactsPane run={run} sessionId="artifacts-pane" onOpen={() => undefined} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no session</span>
+        <div className="w-96 rounded-md border border-doom-border bg-doom-panel">
+          <ArtifactsPane run={run} sessionId={null} onOpen={() => undefined} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-workflow/src/web/components/ArtifactsPane.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/ArtifactsPane.tsx
@@ -76,7 +76,7 @@ function DelimitedPreview({ text, delimiter }: { text: string; delimiter: ',' | 
   const [head = [], ...body] = rows;
   return (
     <div className="overflow-auto">
-      <table data-testid="artifact-table" className="min-w-full border-collapse font-mono text-[11px]">
+      <table data-testid="artifact-table" className="min-w-full border-collapse font-mono text-sm">
         <thead className="sticky top-0 bg-doom-panel text-doom-hi">
           <tr>
             {head.map((cell, index) => (
@@ -142,12 +142,12 @@ function ArtifactPreview({
     return raw ? (
       <pre
         data-testid="artifact-raw"
-        className="whitespace-pre-wrap break-words font-mono text-[11px] leading-[17px] text-doom-text"
+        className="whitespace-pre-wrap break-words font-mono text-sm leading-snug text-doom-text"
       >
         {text}
       </pre>
     ) : (
-      <div data-testid="artifact-markdown" className="max-w-5xl text-[13px] text-doom-text">
+      <div data-testid="artifact-markdown" className="max-w-5xl text-base text-doom-text">
         <Markdown text={text} />
       </div>
     );
@@ -160,9 +160,7 @@ function ArtifactPreview({
       // An incomplete file remains useful as literal text while a workflow writes it.
     }
     return (
-      <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-[17px] text-doom-text">
-        {formatted}
-      </pre>
+      <pre className="whitespace-pre-wrap break-words font-mono text-sm leading-snug text-doom-text">{formatted}</pre>
     );
   }
   if (mimeType === 'text/csv' || mimeType === 'text/tab-separated-values') {
@@ -216,9 +214,7 @@ function ArtifactPreview({
     );
   }
   if (content.text !== undefined) {
-    return (
-      <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-[17px] text-doom-text">{text}</pre>
-    );
+    return <pre className="whitespace-pre-wrap break-words font-mono text-sm leading-snug text-doom-text">{text}</pre>;
   }
   return (
     <EmptyState title="preview unavailable" description="Download this artifact to open it with a local application." />
@@ -278,9 +274,9 @@ export function ArtifactViewerPanel({
   return (
     <div data-testid="artifact-viewer" className="flex min-h-0 flex-1 flex-col px-[26px] py-[18px]">
       <div className="flex items-center gap-2.5 pb-3">
-        <span className="truncate text-[12px] font-bold text-doom-hi">{path}</span>
+        <span className="truncate text-sm font-bold text-doom-hi">{path}</span>
         <Badge size="xs">{mimeType ?? 'artifact'}</Badge>
-        <span className="text-[9px] text-doom-faint">
+        <span className="text-2xs text-doom-faint">
           {content === undefined ? '' : `${formatSize(content.size)} · written ${formatWhen(content.modifiedAt)}`}
         </span>
         <span className="min-w-0 flex-1" />
@@ -320,17 +316,17 @@ export function ArtifactViewerPanel({
       </div>
       <div className="min-h-0 flex-1 overflow-auto rounded-md border border-doom-border bg-doom-deep p-4">
         {error !== undefined ? (
-          <span data-testid="artifact-error" className="text-[10px] text-doom-yellow">
+          <span data-testid="artifact-error" className="text-xs text-doom-yellow">
             {error}
           </span>
         ) : content === undefined ? (
-          <span className="text-[10px] text-doom-faint">loading preview</span>
+          <span className="text-xs text-doom-faint">loading preview</span>
         ) : (
           <ArtifactPreview content={content} rawUrl={rawUrl} raw={raw} />
         )}
       </div>
       {content?.truncated === true ? (
-        <span className="pt-2 text-[9px] text-doom-faint">
+        <span className="pt-2 text-2xs text-doom-faint">
           this preview shows the first {formatSize(content.text?.length)}; download the artifact for the complete file
         </span>
       ) : null}
@@ -397,8 +393,8 @@ export function ArtifactsPane({
         className={`flex flex-col gap-0.5 px-3 py-1.5 text-left ${openable ? 'cursor-pointer hover:bg-doom-panel' : 'cursor-default'}`}
       >
         <span className="flex min-w-0 items-center gap-2">
-          <span className={`w-3 shrink-0 text-[10px] ${glyph.className}`}>{glyph.glyph}</span>
-          <span className={`truncate text-[11px] ${entry.state === 'pending' ? 'text-doom-dim' : 'text-doom-hi'}`}>
+          <span className={`w-3 shrink-0 text-xs ${glyph.className}`}>{glyph.glyph}</span>
+          <span className={`truncate text-sm ${entry.state === 'pending' ? 'text-doom-dim' : 'text-doom-hi'}`}>
             {entry.path}
           </span>
           {entry.producedBy.length === 0 ? null : (
@@ -407,14 +403,14 @@ export function ArtifactsPane({
             </Badge>
           )}
           <span className="min-w-0 flex-1" />
-          <span className="shrink-0 text-[9px] text-doom-faint">
+          <span className="shrink-0 text-2xs text-doom-faint">
             {entry.state === 'pending'
               ? 'not written yet'
               : `${formatSize(entry.size)} · ${formatWhen(entry.modifiedAt)}`}
           </span>
         </span>
         {entry.description === '' ? null : (
-          <span className="truncate pl-5 text-[9px] text-doom-faint">{entry.description}</span>
+          <span className="truncate pl-5 text-2xs text-doom-faint">{entry.description}</span>
         )}
       </button>
     );
@@ -430,7 +426,7 @@ export function ArtifactsPane({
       ) : null}
       {declared.length === 0 ? null : (
         <>
-          <span className="px-3 pb-1 pt-2 text-[9px] font-bold tracking-[0.14em] text-doom-faint">
+          <span className="px-3 pb-1 pt-2 text-2xs font-bold tracking-wider text-doom-faint">
             DECLARED · {listing?.description || 'run-directory'}
           </span>
           {declared.map((entry) => (
@@ -440,16 +436,14 @@ export function ArtifactsPane({
       )}
       {found.length === 0 ? null : (
         <>
-          <span className="px-3 pb-1 pt-3 text-[9px] font-bold tracking-[0.14em] text-doom-faint">
-            ALSO IN THE FOLDER
-          </span>
+          <span className="px-3 pb-1 pt-3 text-2xs font-bold tracking-wider text-doom-faint">ALSO IN THE FOLDER</span>
           {found.map((entry) => (
             <Row key={entry.path} entry={entry} />
           ))}
         </>
       )}
       {listing === undefined ? null : (
-        <span className="truncate px-3 py-2 text-[9px] text-doom-faint">{listing.runDir}</span>
+        <span className="truncate px-3 py-2 text-2xs text-doom-faint">{listing.runDir}</span>
       )}
     </div>
   );

--- a/packages/minor/doompi-workflow/src/web/components/LaunchWorkflowDialog.stories.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/LaunchWorkflowDialog.stories.tsx
@@ -1,0 +1,66 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { WorkflowCatalogEntryView } from '../../types/webWorkflows.ts';
+import { LaunchWorkflowDialog } from './LaunchWorkflowDialog.tsx';
+
+const SESSION_ID = 'workflow-launch';
+const CWD = '/Users/doom/workspace/doompi';
+
+const RELEASE: WorkflowCatalogEntryView = {
+  path: `${CWD}/automations/workflows/release.workflow.yaml`,
+  relativePath: 'automations/workflows/release.workflow.yaml',
+  name: 'release',
+  description: 'Cut a release: build, verify, publish, tag.',
+  tags: ['release'],
+  triggers: ['workflow_dispatch'],
+  inputs: [
+    { name: 'version', required: true, type: 'string', description: 'semver to publish' },
+    { name: 'channel', default: 'stable', options: ['stable', 'next'] },
+    { name: 'dryRun', type: 'boolean', default: 'false' },
+  ],
+  jobs: [
+    { name: 'build', steps: ['pnpm build'] },
+    { name: 'verify', steps: ['pnpm test'] },
+    { name: 'publish', steps: ['pnpm publish -r'] },
+  ],
+  artifacts: [],
+  runners: ['rmux', 'tmux'],
+};
+
+const { props } = slotPropsFixture({ sessionId: SESSION_ID });
+
+const meta = {
+  title: 'Workflow/LaunchWorkflowDialog',
+  component: LaunchWorkflowDialog,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+/*
+ * One dialog only: it is modal and portals into the body, so a second instance
+ * would draw its overlay over the first. `version` is required and has no
+ * default, which is also what puts the problem line and the disabled submit in
+ * the shot.
+ */
+export const Playground = {
+  render: () => (
+    <div className="h-screen w-screen bg-doom-bg">
+      <LaunchWorkflowDialog
+        sessionId={SESSION_ID}
+        workflow={RELEASE}
+        cwd={CWD}
+        initialPrompt="cut 0.4.0 from main"
+        send={props.sendSessionFrame}
+        onClose={() => undefined}
+        onLaunched={() => undefined}
+      />
+    </div>
+  ),
+};

--- a/packages/minor/doompi-workflow/src/web/components/LaunchWorkflowDialog.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/LaunchWorkflowDialog.tsx
@@ -32,7 +32,7 @@ const BOOLEAN_TYPE = 'boolean';
 const BOOLEAN_VALUES = ['true', 'false'] as const;
 
 function FieldLabel({ children }: { children: string }) {
-  return <span className="text-[9px] font-bold tracking-[0.18em] text-doom-faint">{children}</span>;
+  return <span className="text-2xs font-bold tracking-widest text-doom-faint">{children}</span>;
 }
 
 /** One `workflow_dispatch` input: a picker when the workflow constrains it, a field otherwise. */
@@ -58,7 +58,7 @@ function InputField({
       className="flex flex-col gap-1.5 sm:flex-row sm:items-center sm:gap-2.5"
       data-testid={`launch-input-${input.name}`}
     >
-      <span className="min-w-0 truncate text-[10px] font-bold text-doom-text sm:w-28 sm:shrink-0">
+      <span className="min-w-0 truncate text-xs font-bold text-doom-text sm:w-28 sm:shrink-0">
         {input.name}
         {input.required === true ? <span className="text-doom-yellow"> *</span> : null}
       </span>
@@ -71,7 +71,7 @@ function InputField({
         />
       ) : (
         <Select value={value === '' ? undefined : value} onValueChange={onChange}>
-          <SelectTrigger className="h-7 w-full min-w-0 text-[10px] sm:min-w-[160px]">
+          <SelectTrigger className="h-7 w-full min-w-0 text-xs sm:min-w-[160px]">
             <SelectValue placeholder="choose…" />
           </SelectTrigger>
           <SelectContent>
@@ -83,7 +83,7 @@ function InputField({
           </SelectContent>
         </Select>
       )}
-      <span className="min-w-0 truncate text-[9px] text-doom-faint sm:w-40 sm:shrink-0">{hint}</span>
+      <span className="min-w-0 truncate text-2xs text-doom-faint sm:w-40 sm:shrink-0">{hint}</span>
     </div>
   );
 }
@@ -144,7 +144,7 @@ export function LaunchWorkflowDialog({
       <DialogContent width="lg" data-testid="launch-workflow-dialog" aria-describedby={undefined}>
         <DialogHeader>
           <div className="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-2.5">
-            <span className="text-[9px] text-doom-faint">launch workflow</span>
+            <span className="text-2xs text-doom-faint">launch workflow</span>
             <DialogTitle data-testid="launch-workflow-name" className="max-w-full break-words">
               {workflow.name}
             </DialogTitle>
@@ -154,7 +154,7 @@ export function LaunchWorkflowDialog({
           </div>
         </DialogHeader>
         <DialogBody>
-          <p className="text-[11px] leading-relaxed text-doom-dim">
+          <p className="text-sm leading-relaxed text-doom-dim">
             {workflow.description || 'This workflow declares no description.'}
           </p>
           <div className="flex flex-col gap-1.5">
@@ -168,15 +168,13 @@ export function LaunchWorkflowDialog({
               onChange={(event) => setPrompt(event.target.value)}
               onKeyDown={onPromptKeyDown}
             />
-            <span className="text-[9px] text-doom-faint">enter launches · shift+enter for a new line</span>
+            <span className="text-2xs text-doom-faint">enter launches · shift+enter for a new line</span>
           </div>
           {workflow.inputs.length === 0 ? null : (
             <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2">
                 <FieldLabel>INPUTS</FieldLabel>
-                <span className="text-[9px] text-doom-faint">
-                  workflow_dispatch · {workflow.inputs.length} declared
-                </span>
+                <span className="text-2xs text-doom-faint">workflow_dispatch · {workflow.inputs.length} declared</span>
               </div>
               {workflow.inputs.map((input) => (
                 <InputField
@@ -192,13 +190,10 @@ export function LaunchWorkflowDialog({
             <div className="flex flex-col gap-1.5">
               <FieldLabel>RUNNER</FieldLabel>
               {workflow.runners === undefined || workflow.runners.length === 0 ? (
-                <span className="flex h-7 items-center text-[10px] text-doom-dim">whatever the workflow resolves</span>
+                <span className="flex h-7 items-center text-xs text-doom-dim">whatever the workflow resolves</span>
               ) : (
                 <Select value={runner} onValueChange={setRunner}>
-                  <SelectTrigger
-                    data-testid="launch-runner"
-                    className="h-7 w-full min-w-0 text-[10px] sm:min-w-[160px]"
-                  >
+                  <SelectTrigger data-testid="launch-runner" className="h-7 w-full min-w-0 text-xs sm:min-w-[160px]">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -210,36 +205,36 @@ export function LaunchWorkflowDialog({
                   </SelectContent>
                 </Select>
               )}
-              <span className="text-[9px] text-doom-faint">
+              <span className="text-2xs text-doom-faint">
                 {workflow.runners === undefined ? 'no runner map declared' : 'the runners every step agrees on'}
               </span>
             </div>
             <div className="flex flex-col gap-1.5">
               <FieldLabel>JOBS</FieldLabel>
-              <span className="flex h-7 items-center text-[10px] text-doom-dim">
+              <span className="flex h-7 items-center text-xs text-doom-dim">
                 {workflow.jobs.map((job) => job.name).join(' → ') || 'none declared'}
               </span>
-              <span className="text-[9px] text-doom-faint">in the order the file declares them</span>
+              <span className="text-2xs text-doom-faint">in the order the file declares them</span>
             </div>
             <div className="flex flex-col gap-1.5">
               <FieldLabel>CWD</FieldLabel>
-              <span className="flex h-7 items-center text-[10px] text-doom-dim">{cwd}</span>
-              <span className="text-[9px] text-doom-faint">the session's directory</span>
+              <span className="flex h-7 items-center text-xs text-doom-dim">{cwd}</span>
+              <span className="text-2xs text-doom-faint">the session's directory</span>
             </div>
           </div>
           <div className="flex flex-col gap-1 rounded-md border border-doom-border bg-doom-deep px-3 py-2">
             <FieldLabel>SENT TO THE SESSION</FieldLabel>
-            <pre data-testid="launch-line" className="whitespace-pre-wrap break-words text-[10px] text-doom-green">
+            <pre data-testid="launch-line" className="whitespace-pre-wrap break-words text-xs text-doom-green">
               {line}
             </pre>
           </div>
           {problems.length === 0 ? null : (
-            <p data-testid="launch-problems" className="text-[10px] text-doom-yellow">
+            <p data-testid="launch-problems" className="text-xs text-doom-yellow">
               {problems.join(' ')}
             </p>
           )}
           <DialogFooter className="flex-wrap sm:flex-nowrap">
-            <span className="w-full text-[9px] text-doom-faint sm:w-auto">
+            <span className="w-full text-2xs text-doom-faint sm:w-auto">
               the run appears on the board as soon as it starts
             </span>
             <span className="min-w-0 flex-1" />

--- a/packages/minor/doompi-workflow/src/web/components/StepTerminalPanel.stories.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/StepTerminalPanel.stories.tsx
@@ -1,0 +1,55 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The slot props come from the contracts package's own testing
+ * fixture rather than a hand-rolled stub.
+ *
+ * The panel attaches a terminal that streams from the runner, which the
+ * headless renderer has no backend for. What a story can show is the frame:
+ * the header naming the job and step, and the empty terminal body.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { StepTerminalPanel, type StepTabTarget } from './StepTerminalPanel.tsx';
+
+const props = slotPropsFixture({ sessionId: 'step-terminal' }).props;
+
+const target: StepTabTarget = {
+  workspace: 'doompi',
+  runKey: 'release-14',
+  job: 'build',
+  step: 'pnpm build',
+};
+
+const jobOnly: StepTabTarget = {
+  workspace: 'doompi',
+  runKey: 'release-14',
+  job: 'test',
+};
+
+const meta = {
+  title: 'Workflow/StepTerminalPanel',
+  component: StepTerminalPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">job and step</span>
+        <div className="h-56 w-full max-w-3xl rounded-md border border-doom-border bg-doom-deep">
+          <StepTerminalPanel {...props} target={target} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">job with no step named</span>
+        <div className="h-56 w-full max-w-3xl rounded-md border border-doom-border bg-doom-deep">
+          <StepTerminalPanel {...props} target={jobOnly} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-workflow/src/web/components/StepTerminalPanel.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/StepTerminalPanel.tsx
@@ -160,15 +160,13 @@ export function StepTerminalPanel({ sessionId, target }: WebPluginSlotProps & { 
   return (
     <div data-testid="step-terminal-panel" className="flex min-h-0 flex-1 flex-col px-[26px] py-[18px]">
       <div data-testid="step-terminal-head" className="flex items-center gap-2.5 pb-3">
-        <span className="shrink-0 truncate text-[12px] font-bold text-doom-hi">
-          {run?.displayName ?? target.runKey}
-        </span>
-        <span className="text-[10px] text-doom-faint">›</span>
-        <span className="shrink-0 truncate text-[11px] font-bold text-doom-blue">{target.job}</span>
+        <span className="shrink-0 truncate text-sm font-bold text-doom-hi">{run?.displayName ?? target.runKey}</span>
+        <span className="text-xs text-doom-faint">›</span>
+        <span className="shrink-0 truncate text-sm font-bold text-doom-blue">{target.job}</span>
         {target.step === undefined ? null : (
           <>
-            <span className="text-[10px] text-doom-faint">›</span>
-            <span className="min-w-0 truncate text-[11px] text-doom-text">{target.step}</span>
+            <span className="text-xs text-doom-faint">›</span>
+            <span className="min-w-0 truncate text-sm text-doom-text">{target.step}</span>
           </>
         )}
         {run === undefined ? null : (
@@ -204,12 +202,12 @@ export function StepTerminalPanel({ sessionId, target }: WebPluginSlotProps & { 
         data-testid="step-terminal-screen"
         tabIndex={0}
         onKeyDown={onKeyDown}
-        className={`min-h-0 flex-1 overflow-y-auto rounded-md border bg-doom-deep px-4 py-3 font-mono text-[11px] leading-[15px] text-doom-text outline-none ${
+        className={`min-h-0 flex-1 overflow-y-auto rounded-md border bg-doom-deep px-4 py-3 font-mono text-sm leading-tight text-doom-text outline-none ${
           held ? 'border-doom-blue/60' : 'border-doom-border'
         }`}
       >
         {lines.length === 0 ? (
-          <span className="text-[10px] text-doom-faint">
+          <span className="text-xs text-doom-faint">
             {capabilities?.readable === false
               ? (capabilities.reason ?? 'This run has no terminal to read.')
               : 'waiting for the run to paint…'}
@@ -220,7 +218,7 @@ export function StepTerminalPanel({ sessionId, target }: WebPluginSlotProps & { 
         {held && !ended ? <StreamCursor className="mt-0.5 h-[12px] w-1.5" /> : null}
       </div>
       <div className="flex items-center gap-3 pt-2.5">
-        <span data-testid="step-terminal-hint" className="text-[9px] text-doom-faint">
+        <span data-testid="step-terminal-hint" className="text-2xs text-doom-faint">
           {held
             ? 'keys go to the run · ctrl-c and ctrl-d pass through · esc releases the keyboard'
             : capabilities?.writable === false
@@ -229,12 +227,12 @@ export function StepTerminalPanel({ sessionId, target }: WebPluginSlotProps & { 
         </span>
         <span className="min-w-0 flex-1" />
         {ended ? (
-          <span data-testid="step-terminal-ended" className="text-[9px] text-doom-faint">
+          <span data-testid="step-terminal-ended" className="text-2xs text-doom-faint">
             the run has settled; this is its last screen
           </span>
         ) : null}
         {notice === undefined ? null : (
-          <span data-testid="step-terminal-notice" className="text-[9px] text-doom-yellow">
+          <span data-testid="step-terminal-notice" className="text-2xs text-doom-yellow">
             {notice}
           </span>
         )}

--- a/packages/minor/doompi-workflow/src/web/components/WorkflowCatalogDrawer.stories.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/WorkflowCatalogDrawer.stories.tsx
@@ -1,0 +1,103 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import type { WorkflowCatalogEntryView } from '../../types/webWorkflows.ts';
+import { catalog } from '../stores/catalogStore.ts';
+import { WorkflowCatalogDrawer } from './WorkflowCatalogDrawer.tsx';
+
+/** Its own session id, so a story that seeds this store cannot disturb another's. */
+const SESSION_ID = 'workflow-catalog';
+const EMPTY_SESSION_ID = 'workflow-catalog-empty';
+const CWD = '/Users/doom/workspace/doompi';
+
+const entry = (
+  overrides: Partial<WorkflowCatalogEntryView> & Pick<WorkflowCatalogEntryView, 'name'>,
+): WorkflowCatalogEntryView => ({
+  path: `${CWD}/automations/workflows/${overrides.name}.workflow.yaml`,
+  relativePath: `automations/workflows/${overrides.name}.workflow.yaml`,
+  description: '',
+  tags: [],
+  triggers: ['workflow_dispatch'],
+  inputs: [],
+  jobs: [],
+  artifacts: [],
+  ...overrides,
+});
+
+const RELEASE = entry({
+  name: 'release',
+  description: 'Cut a release: build, verify, publish, tag.',
+  tags: ['release', 'ci'],
+  inputs: [
+    { name: 'version', required: true, type: 'string' },
+    { name: 'channel', default: 'stable', options: ['stable', 'next'] },
+  ],
+  jobs: [
+    { name: 'build', steps: ['pnpm install', 'pnpm build'] },
+    { name: 'verify', steps: ['pnpm test'] },
+    { name: 'publish', steps: ['pnpm publish -r'] },
+  ],
+  artifacts: [{ path: 'dist/report.json', kind: 'file', description: 'the release report', producedBy: ['verify'] }],
+  runners: ['rmux'],
+});
+
+// The drawer renders whatever the catalog channel last reported, so the story
+// seeds the same store that channel writes into.
+catalog.update(SESSION_ID, (current) => ({
+  ...current,
+  cwd: CWD,
+  open: true,
+  selected: RELEASE.path,
+  inspected: RELEASE.path,
+  workflows: [
+    RELEASE,
+    entry({
+      name: 'nightly',
+      description: 'Nightly checks across every package.',
+      tags: ['ci'],
+      jobs: [{ name: 'check', steps: ['pnpm lint'] }],
+    }),
+    entry({ name: 'hotfix', tags: ['release'], error: 'jobs: expected a mapping at line 12' }),
+  ],
+}));
+
+catalog.update(EMPTY_SESSION_ID, (current) => ({
+  ...current,
+  cwd: CWD,
+  open: true,
+  warning: 'automations/workflows is not readable from this session',
+}));
+
+const meta = {
+  title: 'Workflow/WorkflowCatalogDrawer',
+  component: WorkflowCatalogDrawer,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          three workflows · the selected row is unfolded
+        </span>
+        <div className="flex h-screen rounded-md border border-doom-border">
+          <WorkflowCatalogDrawer sessionId={SESSION_ID} onClose={() => undefined} onLaunch={() => undefined} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">nothing to list</span>
+        <div className="flex h-64 rounded-md border border-doom-border">
+          <WorkflowCatalogDrawer sessionId={EMPTY_SESSION_ID} onClose={() => undefined} onLaunch={() => undefined} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-workflow/src/web/components/WorkflowCatalogDrawer.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/WorkflowCatalogDrawer.tsx
@@ -27,7 +27,7 @@ function Detail({ workflow }: { workflow: WorkflowCatalogEntryView }) {
     ['file', workflow.relativePath],
   ];
   return (
-    <dl data-testid={`catalog-detail-${workflow.name}`} className="flex flex-col gap-1 pt-1 text-[9px]">
+    <dl data-testid={`catalog-detail-${workflow.name}`} className="flex flex-col gap-1 pt-1 text-2xs">
       {rows.map(([label, value]) => (
         <div key={label} className="flex gap-2">
           <dt className="w-16 shrink-0 text-doom-faint">{label}</dt>
@@ -69,26 +69,26 @@ function WorkflowRow({
       }`}
     >
       <div className="flex min-w-0 items-center gap-2">
-        <span className="truncate text-[12px] font-bold text-doom-hi">{workflow.name}</span>
+        <span className="truncate text-sm font-bold text-doom-hi">{workflow.name}</span>
         {workflow.tags.map((tag) => (
           <Badge key={tag} size="xs" className="shrink-0">
             {tag}
           </Badge>
         ))}
         <span className="min-w-0 flex-1" />
-        <span className={`shrink-0 text-[9px] ${workflow.error === undefined ? 'text-doom-cyan' : 'text-doom-red'}`}>
+        <span className={`shrink-0 text-2xs ${workflow.error === undefined ? 'text-doom-cyan' : 'text-doom-red'}`}>
           {workflow.error === undefined ? `${jobs} job${jobs === 1 ? '' : 's'}` : 'unreadable'}
         </span>
       </div>
-      <span className="truncate text-[10px] text-doom-dim">{workflow.description || workflow.relativePath}</span>
+      <span className="truncate text-xs text-doom-dim">{workflow.description || workflow.relativePath}</span>
       {workflow.error === undefined ? (
-        <span className="truncate text-[9px] text-doom-faint">
+        <span className="truncate text-2xs text-doom-faint">
           {workflow.inputs.length} input{workflow.inputs.length === 1 ? '' : 's'} ·{' '}
           {workflow.runners === undefined ? 'any runner' : workflow.runners.join(', ') || 'no runner in common'}
           {workflow.artifacts.length > 0 ? ` · ${workflow.artifacts.length} artifacts` : ''}
         </span>
       ) : (
-        <span className="truncate text-[9px] text-doom-red">{workflow.error}</span>
+        <span className="truncate text-2xs text-doom-red">{workflow.error}</span>
       )}
       {selected ? (
         <div className="flex items-center gap-3 pt-0.5">
@@ -179,7 +179,7 @@ export function WorkflowCatalogDrawer({
       className="flex w-[min(440px,calc(100vw-24px))] shrink-0 flex-col overflow-hidden border-l border-doom-border bg-doom-rail outline-none"
     >
       <div className="flex h-11 shrink-0 items-center gap-2.5 border-b border-doom-border px-4">
-        <span className="text-[13px] font-bold text-doom-hi">workflow catalog</span>
+        <span className="text-base font-bold text-doom-hi">workflow catalog</span>
         <Badge size="xs" data-testid="catalog-count">
           {state.workflows.length} workflow{state.workflows.length === 1 ? '' : 's'}
         </Badge>
@@ -200,7 +200,7 @@ export function WorkflowCatalogDrawer({
       </div>
       <div role="listbox" className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-2">
         {shown.length === 0 ? (
-          <p data-testid="catalog-empty" className="px-4 py-3 text-[10px] text-doom-faint">
+          <p data-testid="catalog-empty" className="px-4 py-3 text-xs text-doom-faint">
             {state.warning ??
               (state.workflows.length === 0
                 ? 'no workflows found for this session; add one under automations/workflows'
@@ -220,8 +220,8 @@ export function WorkflowCatalogDrawer({
         ))}
       </div>
       <div className="flex h-8 shrink-0 items-center justify-between border-t border-doom-border-soft bg-doom-deep px-4">
-        <span className="text-[9px] text-doom-faint">↑↓ choose · enter launch · i inspect · esc close</span>
-        <span className="text-[9px] text-doom-faint">{state.cwd}</span>
+        <span className="text-2xs text-doom-faint">↑↓ choose · enter launch · i inspect · esc close</span>
+        <span className="text-2xs text-doom-faint">{state.cwd}</span>
       </div>
     </aside>
   );

--- a/packages/minor/doompi-workflow/src/web/components/WorkflowToolMessage.stories.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/WorkflowToolMessage.stories.tsx
@@ -1,0 +1,148 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import { WorkflowToolMessage } from './WorkflowToolMessage.tsx';
+
+/** The tools answer in JSON text blocks, so the fixtures are the payloads themselves. */
+const json = (payload: unknown) => ({ content: [{ type: 'text', text: JSON.stringify(payload) }], details: null });
+const text = (value: string) => ({ content: [{ type: 'text', text: value }], details: null });
+
+const CATALOG = {
+  directory: '.doom/workflows',
+  page: 1,
+  pageSize: 10,
+  total: 3,
+  totalPages: 1,
+  tags: [
+    { tag: 'release', count: 2 },
+    { tag: 'ci', count: 1 },
+  ],
+  workflows: [
+    { name: 'release', path: '.doom/workflows/release.workflow.yaml', description: 'Cut a release', tags: ['release'] },
+    { name: 'nightly', path: '.doom/workflows/nightly.workflow.yaml', description: 'Nightly checks', tags: ['ci'] },
+    { name: 'hotfix', path: '.doom/workflows/hotfix.workflow.yaml', description: '', tags: ['release'] },
+  ],
+};
+
+const STATUS = {
+  runKey: 'release-2025-01-14',
+  workspace: 'doompi',
+  displayName: 'release',
+  stage: 'running',
+  runner: 'rmux',
+  startedAt: '2025-01-14T09:12:00.000Z',
+  executionCursor: { job: 'build', phase: 'job', stepName: 'pnpm build' },
+};
+
+const FAILED = {
+  runKey: 'release-2025-01-13',
+  workspace: 'doompi',
+  displayName: 'release',
+  stage: 'error',
+  outcome: 'failed',
+  errorMessage: 'job build exited 1',
+  exitCode: 1,
+  startedAt: '2025-01-13T21:40:00.000Z',
+};
+
+const LAUNCHED = [
+  'Started release in workspace doompi.',
+  'Run key: release-2025-01-14',
+  'Next steps for the agent: poll workflow_run status.',
+].join('\n');
+
+const props = (overrides: Parameters<typeof toolMessagePropsFixture>[0]) => toolMessagePropsFixture(overrides).props;
+
+const meta = {
+  title: 'Workflow/WorkflowToolMessage',
+  component: WorkflowToolMessage,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">list_workflows · the catalog</span>
+        <WorkflowToolMessage
+          {...props({
+            toolName: 'list_workflows',
+            args: { directory: '.doom/workflows', page: 1, pageSize: 10 },
+            result: json(CATALOG),
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">launch_workflow · accepted</span>
+        <WorkflowToolMessage
+          {...props({
+            toolName: 'launch_workflow',
+            args: { workflowPath: '.doom/workflows/release.workflow.yaml', workspace: 'doompi', runner: 'rmux' },
+            result: text(LAUNCHED),
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">workflow_run · running</span>
+        <WorkflowToolMessage
+          {...props({
+            toolName: 'workflow_run',
+            args: { action: 'status', workspace: 'doompi', runKey: 'release-2025-01-14' },
+            result: json(STATUS),
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">workflow_run · a stop asked for</span>
+        <WorkflowToolMessage
+          {...props({
+            toolName: 'workflow_run',
+            args: { action: 'stop', workspace: 'doompi', runKey: 'release-2025-01-14', reason: 'superseded' },
+            result: json({ runKey: 'release-2025-01-14', requestedAt: '2025-01-14T09:14:20.000Z' }),
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">workflow_run · a failed run</span>
+        <WorkflowToolMessage
+          {...props({
+            toolName: 'workflow_run',
+            args: { action: 'status', workspace: 'doompi', runKey: 'release-2025-01-13' },
+            result: json(FAILED),
+          })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">running, then failed</span>
+        <WorkflowToolMessage
+          {...props({
+            toolName: 'launch_workflow',
+            args: { workflowPath: '.doom/workflows/release.workflow.yaml' },
+            result: text('Resolving workflow…\nValidating inputs…'),
+            running: true,
+          })}
+        />
+        <WorkflowToolMessage
+          {...props({
+            toolName: 'launch_workflow',
+            args: { workflowPath: '.doom/workflows/missing.workflow.yaml' },
+            result: text('Workflow file not found.\nChecked .doom/workflows.'),
+            isError: true,
+          })}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-workflow/src/web/components/WorkflowsActivitySection.stories.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/WorkflowsActivitySection.stories.tsx
@@ -1,0 +1,95 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The props come from the contracts package's own testing fixture
+ * rather than a hand-rolled stub, so a change to the slot contract breaks this
+ * story at the type level instead of silently drifting.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { WorkflowRunView } from '../../types/webWorkflows.ts';
+import { workflows } from '../stores/workflowsStore.ts';
+import { WorkflowsActivitySection } from './WorkflowsActivitySection.tsx';
+
+/** Its own session id, so a story that seeds this store cannot disturb another's. */
+const SESSION_ID = 'workflows-activity';
+const IDLE_SESSION_ID = 'workflows-activity-idle';
+const MINUTE_MS = 60_000;
+
+const run = (
+  overrides: Partial<WorkflowRunView> & Pick<WorkflowRunView, 'runKey' | 'displayName'>,
+): WorkflowRunView => ({
+  workspace: 'doompi',
+  workflowPath: '.doom/workflows/release.workflow.yaml',
+  stage: 'running',
+  // Relative, so the elapsed time each row prints stays a plausible few minutes.
+  startedAt: new Date(Date.now() - 7 * MINUTE_MS).toISOString(),
+  jobs: [],
+  ...overrides,
+});
+
+// The dock renders whatever the workflow registry channel last reported, so
+// the story seeds the same store that channel writes into.
+workflows.update(SESSION_ID, (current) => ({
+  ...current,
+  runs: [
+    run({ runKey: 'release-14', displayName: 'release', position: { job: 'build', step: 'pnpm build' } }),
+    run({ runKey: 'nightly-14', displayName: 'nightly', executionState: 'paused' }),
+    run({
+      runKey: 'release-13',
+      displayName: 'release',
+      stage: 'error',
+      outcome: 'failed',
+      errorMessage: "job 'test' exited 1",
+      finishedAt: new Date(Date.now() - 40 * MINUTE_MS).toISOString(),
+      startedAt: new Date(Date.now() - 52 * MINUTE_MS).toISOString(),
+    }),
+    run({
+      runKey: 'hotfix-12',
+      displayName: 'hotfix',
+      stage: 'completed',
+      outcome: 'success',
+      finishedAt: new Date(Date.now() - 90 * MINUTE_MS).toISOString(),
+      startedAt: new Date(Date.now() - 95 * MINUTE_MS).toISOString(),
+    }),
+    run({
+      runKey: 'nightly-11',
+      displayName: 'nightly',
+      stage: 'completed',
+      outcome: 'skipped',
+      finishedAt: new Date(Date.now() - 300 * MINUTE_MS).toISOString(),
+      startedAt: new Date(Date.now() - 301 * MINUTE_MS).toISOString(),
+    }),
+  ],
+}));
+
+const props = (sessionId: string) => slotPropsFixture({ sessionId }).props;
+
+const meta = {
+  title: 'Workflow/WorkflowsActivitySection',
+  component: WorkflowsActivitySection,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          running and failed open, successful folded · at the dock's width
+        </span>
+        <div className="w-72 rounded-md border border-doom-border bg-doom-panel p-2">
+          <WorkflowsActivitySection {...props(SESSION_ID)} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">idle</span>
+        <div className="w-72 rounded-md border border-doom-border bg-doom-panel p-2">
+          <WorkflowsActivitySection {...props(IDLE_SESSION_ID)} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-workflow/src/web/components/WorkflowsActivitySection.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/WorkflowsActivitySection.tsx
@@ -59,7 +59,7 @@ export function WorkflowsActivitySection({ sessionId, openTransientTab }: WebPlu
   if (groups.length === 0) {
     return (
       <div className="flex items-center gap-2 px-1">
-        <p data-testid="activity-summary-workflows" className="text-[10px] text-doom-faint">
+        <p data-testid="activity-summary-workflows" className="text-xs text-doom-faint">
           idle
         </p>
         <Button
@@ -91,20 +91,20 @@ export function WorkflowsActivitySection({ sessionId, openTransientTab }: WebPlu
         focusRun(sessionId, row.identity);
         openTransientTab(workflowsTab());
       }}
-      className="min-w-0 gap-0.5 rounded-[5px] px-1 py-1 hover:bg-doom-panel"
+      className="min-w-0 gap-0.5 rounded-md px-1 py-1 hover:bg-doom-panel"
     >
       <span className="flex min-w-0 items-center gap-1.5">
         <Dot tone={TONE_DOT[row.tone]} pulse={row.tone === 'running'} />
         <span
-          className={`min-w-0 flex-1 truncate text-[10px] font-bold ${
+          className={`min-w-0 flex-1 truncate text-xs font-bold ${
             row.tone === 'running' || row.tone === 'paused' ? 'text-doom-hi' : 'text-doom-dim'
           }`}
         >
           {row.name}
         </span>
-        <span className="shrink-0 text-[9px] text-doom-faint">{row.elapsed}</span>
+        <span className="shrink-0 text-2xs text-doom-faint">{row.elapsed}</span>
       </span>
-      <span className={`truncate pl-3 text-[9px] ${TONE_DETAIL[row.tone]}`}>{row.detail}</span>
+      <span className={`truncate pl-3 text-2xs ${TONE_DETAIL[row.tone]}`}>{row.detail}</span>
     </Button>
   );
 
@@ -121,15 +121,15 @@ export function WorkflowsActivitySection({ sessionId, openTransientTab }: WebPlu
               data-open={open}
               aria-expanded={open}
               onClick={() => setFolded((current) => ({ ...current, [group.name]: !open }))}
-              className="justify-start gap-1.5 rounded-[5px] px-1 py-0.5 hover:bg-doom-panel"
+              className="justify-start gap-1.5 rounded-md px-1 py-0.5 hover:bg-doom-panel"
             >
               {open ? (
                 <ChevronDownIcon className="h-2.5 w-2.5 text-doom-faint" />
               ) : (
                 <ChevronRightIcon className="h-2.5 w-2.5 text-doom-faint" />
               )}
-              <span className={`text-[10px] font-bold ${GROUP_LABEL[group.name]}`}>{group.name}</span>
-              <span className="text-[9px] text-doom-faint">{group.rows.length}</span>
+              <span className={`text-xs font-bold ${GROUP_LABEL[group.name]}`}>{group.name}</span>
+              <span className="text-2xs text-doom-faint">{group.rows.length}</span>
             </Button>
             {open ? (
               <div className="flex flex-col gap-0.5 pl-2">
@@ -138,7 +138,7 @@ export function WorkflowsActivitySection({ sessionId, openTransientTab }: WebPlu
                 ))}
               </div>
             ) : (
-              <span className="truncate pl-5 text-[9px] text-doom-faint">
+              <span className="truncate pl-5 text-2xs text-doom-faint">
                 {group.rows
                   .slice(0, 2)
                   .map((row) => row.name)

--- a/packages/minor/doompi-workflow/src/web/components/WorkflowsPanel.stories.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/WorkflowsPanel.stories.tsx
@@ -1,0 +1,87 @@
+/*
+ * Plain CSF objects; the style-system renderer resolves the default export by
+ * looking for a bare `const meta`, so the export is not named at the point of
+ * definition. The slot props come from the contracts package's own testing
+ * fixture rather than a hand-rolled stub.
+ *
+ * The panel renders whatever the workflow registry channel last reported, so
+ * the story seeds the same store that channel writes into, exactly as
+ * WorkflowsActivitySection.stories.tsx does.
+ */
+import { slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
+import type { WorkflowRunView } from '../../types/webWorkflows.ts';
+import { workflows } from '../stores/workflowsStore.ts';
+import { WorkflowsPanel } from './WorkflowsPanel.tsx';
+
+/** Its own session id, so seeding this store cannot disturb another story's. */
+const SESSION_ID = 'workflows-panel';
+const EMPTY_SESSION_ID = 'workflows-panel-empty';
+const MINUTE_MS = 60_000;
+
+const run = (
+  overrides: Partial<WorkflowRunView> & Pick<WorkflowRunView, 'runKey' | 'displayName'>,
+): WorkflowRunView => ({
+  workspace: 'doompi',
+  workflowPath: '.doom/workflows/release.workflow.yaml',
+  stage: 'running',
+  startedAt: new Date(Date.now() - 7 * MINUTE_MS).toISOString(),
+  jobs: [],
+  ...overrides,
+});
+
+workflows.update(SESSION_ID, (current) => ({
+  ...current,
+  runs: [
+    run({ runKey: 'release-14', displayName: 'release', position: { job: 'build', step: 'pnpm build' } }),
+    run({ runKey: 'nightly-14', displayName: 'nightly', executionState: 'paused' }),
+    run({
+      runKey: 'release-13',
+      displayName: 'release',
+      stage: 'error',
+      outcome: 'failed',
+      errorMessage: "job 'test' exited 1",
+      startedAt: new Date(Date.now() - 52 * MINUTE_MS).toISOString(),
+      finishedAt: new Date(Date.now() - 40 * MINUTE_MS).toISOString(),
+    }),
+    run({
+      runKey: 'hotfix-12',
+      displayName: 'hotfix',
+      stage: 'completed',
+      outcome: 'success',
+      startedAt: new Date(Date.now() - 95 * MINUTE_MS).toISOString(),
+      finishedAt: new Date(Date.now() - 90 * MINUTE_MS).toISOString(),
+    }),
+  ],
+}));
+
+const props = (sessionId: string) => slotPropsFixture({ sessionId }).props;
+
+const meta = {
+  title: 'Workflow/WorkflowsPanel',
+  component: WorkflowsPanel,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">
+          running, paused, failed and successful runs
+        </span>
+        <div className="h-96 w-full rounded-md border border-doom-border bg-doom-panel">
+          <WorkflowsPanel {...props(SESSION_ID)} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-2xs text-doom-dim uppercase tracking-widest">no runs yet</span>
+        <div className="h-64 w-full rounded-md border border-doom-border bg-doom-panel">
+          <WorkflowsPanel {...props(EMPTY_SESSION_ID)} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/minor/doompi-workflow/src/web/components/WorkflowsPanel.tsx
+++ b/packages/minor/doompi-workflow/src/web/components/WorkflowsPanel.tsx
@@ -154,7 +154,7 @@ function WorkflowPicker({
         >
           <SearchIcon className="h-3 w-3 shrink-0 text-doom-faint" />
           <span className="min-w-0 flex-1 truncate text-left font-bold text-doom-hi">{selected.displayName}</span>
-          <span className="shrink-0 text-[9px] font-normal text-doom-faint">{runs.length} workflows</span>
+          <span className="shrink-0 text-2xs font-normal text-doom-faint">{runs.length} workflows</span>
           <ChevronDownIcon className="h-3 w-3 shrink-0 text-doom-dim" />
         </Button>
       </PopoverTrigger>
@@ -175,13 +175,11 @@ function WorkflowPicker({
         </PopoverHeader>
         <div className="grid max-h-[360px] grid-cols-1 gap-2 overflow-y-auto p-2 sm:grid-cols-2">
           {sections.length === 0 ? (
-            <span className="px-2 py-5 text-center text-[10px] text-doom-faint sm:col-span-2">
-              no matching workflows
-            </span>
+            <span className="px-2 py-5 text-center text-xs text-doom-faint sm:col-span-2">no matching workflows</span>
           ) : (
             sections.map((section) => (
               <div key={section.label} className="flex min-w-0 flex-col gap-0.5">
-                <span className="px-2 py-1 text-[8px] font-bold uppercase tracking-[0.14em] text-doom-faint">
+                <span className="px-2 py-1 text-2xs font-bold uppercase tracking-wider text-doom-faint">
                   {section.label} · {section.runs.length}
                 </span>
                 {section.runs.map((run) => {
@@ -204,12 +202,12 @@ function WorkflowPicker({
                     >
                       <span className="flex min-w-0 items-center gap-2">
                         <Dot tone={runDot(run)} pulse={run.stage === 'running'} />
-                        <span className={cn('min-w-0 flex-1 truncate text-[10px]', active && 'font-bold text-doom-hi')}>
+                        <span className={cn('min-w-0 flex-1 truncate text-xs', active && 'font-bold text-doom-hi')}>
                           {run.displayName}
                         </span>
-                        <span className="shrink-0 text-[8px] text-doom-faint">{runState(run)}</span>
+                        <span className="shrink-0 text-2xs text-doom-faint">{runState(run)}</span>
                       </span>
-                      <span className="truncate pl-3.5 text-[8px] text-doom-dim">
+                      <span className="truncate pl-3.5 text-2xs text-doom-dim">
                         {[run.position?.job, run.position?.step].filter(Boolean).join(' · ') || 'settled'}
                       </span>
                     </button>
@@ -244,10 +242,10 @@ function SelectedAttention({ run }: { run: WorkflowRunView }) {
       <StatusBadge size="xs" tone={attention.kind === 'error' ? 'error' : 'running'}>
         {attention.kind === 'error' ? 'ERROR' : 'PAUSED'}
       </StatusBadge>
-      <span data-testid={`needs-card-${run.runKey}`} className="min-w-0 flex-1 truncate text-[10px] text-doom-text">
+      <span data-testid={`needs-card-${run.runKey}`} className="min-w-0 flex-1 truncate text-xs text-doom-text">
         {run.displayName}: {attention.text}
       </span>
-      <span className="shrink-0 text-[9px] text-doom-faint">
+      <span className="shrink-0 text-2xs text-doom-faint">
         {attention.kind === 'error' ? 'recover from the owning session' : 'resume from the owning session'}
       </span>
     </div>
@@ -275,11 +273,11 @@ function JobRow({
       onClick={onSelect}
       className={cn('gap-2 rounded px-2 py-1.5', !selected && 'hover:bg-doom-deep')}
     >
-      <span className={`w-3 shrink-0 text-[10px] ${icon.className}`}>{icon.glyph}</span>
-      <OptionLabel density="compact" className={cn('text-[10px]', selected ? 'text-doom-hi' : 'text-doom-text')}>
+      <span className={`w-3 shrink-0 text-xs ${icon.className}`}>{icon.glyph}</span>
+      <OptionLabel density="compact" className={cn('text-xs', selected ? 'text-doom-hi' : 'text-doom-text')}>
         {job.name}
       </OptionLabel>
-      <span className="shrink-0 text-[8px] text-doom-faint">{spanDuration(job.startedAt, job.endedAt, now) ?? ''}</span>
+      <span className="shrink-0 text-2xs text-doom-faint">{spanDuration(job.startedAt, job.endedAt, now) ?? ''}</span>
     </OptionRow>
   );
 }
@@ -309,23 +307,21 @@ function StepRow({
       )}
     >
       <span className="flex items-center gap-2">
-        <span className={`w-3 shrink-0 text-[10px] ${icon.className}`}>{icon.glyph}</span>
+        <span className={`w-3 shrink-0 text-xs ${icon.className}`}>{icon.glyph}</span>
         <span
           className={cn(
-            'min-w-0 flex-1 truncate text-[9px]',
+            'min-w-0 flex-1 truncate text-2xs',
             step.status === 'failed' ? 'text-doom-red' : 'text-doom-text',
           )}
         >
           {step.name}
         </span>
-        <span className="shrink-0 text-[8px] text-doom-faint">
+        <span className="shrink-0 text-2xs text-doom-faint">
           {spanDuration(step.startedAt, step.endedAt, now) ?? ''}
         </span>
       </span>
       {step.reason === undefined ? null : (
-        <span
-          className={cn('truncate pl-5 text-[8px]', step.status === 'failed' ? 'text-doom-red' : 'text-doom-faint')}
-        >
+        <span className={cn('truncate pl-5 text-2xs', step.status === 'failed' ? 'text-doom-red' : 'text-doom-faint')}>
           {step.reason}
         </span>
       )}
@@ -385,12 +381,12 @@ function InlineStepOutput({
     <div data-testid="workflow-inline-output" className="flex min-h-0 flex-1 flex-col bg-doom-deep">
       <div className="flex h-9 shrink-0 items-center gap-2 border-b border-doom-border-soft px-3">
         <Dot tone={ended ? 'neutral' : 'blue'} pulse={!ended && run.stage === 'running'} />
-        <span className={cn('text-[9px] font-bold', ended ? 'text-doom-faint' : 'text-doom-blue')}>
+        <span className={cn('text-2xs font-bold', ended ? 'text-doom-faint' : 'text-doom-blue')}>
           {ended ? 'FINAL OUTPUT' : 'LIVE OUTPUT'}
         </span>
-        <span className="min-w-0 truncate text-[10px] font-bold text-doom-hi">{step?.name ?? job.name}</span>
+        <span className="min-w-0 truncate text-xs font-bold text-doom-hi">{step?.name ?? job.name}</span>
         <span className="min-w-0 flex-1" />
-        <span className="text-[8px] text-doom-faint">{ended ? 'settled' : 'following · 500ms'}</span>
+        <span className="text-2xs text-doom-faint">{ended ? 'settled' : 'following · 500ms'}</span>
         <Button variant="outline" size="xs" data-testid="workflow-open-terminal" onClick={onOpenTerminal}>
           open terminal
         </Button>
@@ -398,10 +394,10 @@ function InlineStepOutput({
       <div
         ref={screenRef}
         data-testid="workflow-inline-screen"
-        className="min-h-0 flex-1 overflow-y-auto px-4 py-3 font-mono text-[11px] leading-[15px] text-doom-text"
+        className="min-h-0 flex-1 overflow-y-auto px-4 py-3 font-mono text-sm leading-tight text-doom-text"
       >
         {lines.length === 0 ? (
-          <span className="text-[10px] text-doom-faint">
+          <span className="text-xs text-doom-faint">
             {capabilities?.readable === false
               ? (capabilities.reason ?? 'This run has no terminal to read.')
               : 'waiting for the run to paint…'}
@@ -411,7 +407,7 @@ function InlineStepOutput({
         )}
         {!ended && run.stage === 'running' ? <StreamCursor className="mt-0.5 h-[12px] w-1.5" /> : null}
       </div>
-      <div className="flex h-7 shrink-0 items-center gap-2 border-t border-doom-border-soft px-3 text-[8px] text-doom-faint">
+      <div className="flex h-7 shrink-0 items-center gap-2 border-t border-doom-border-soft px-3 text-2xs text-doom-faint">
         <span>output follows automatically · select another step to inspect its current screen</span>
         <span className="min-w-0 flex-1" />
         <span>last 48 lines</span>
@@ -459,11 +455,11 @@ function DeleteWorkflowDialog({
           <DialogTitle>Delete {run.displayName}?</DialogTitle>
         </DialogHeader>
         <DialogBody>
-          <p className="text-[11px] leading-relaxed text-doom-dim">
+          <p className="text-sm leading-relaxed text-doom-dim">
             This permanently removes the workflow run, including its logs and artifacts. This action cannot be undone.
           </p>
           {error === undefined ? null : (
-            <p data-testid="delete-workflow-error" className="text-[10px] text-doom-red">
+            <p data-testid="delete-workflow-error" className="text-xs text-doom-red">
               {error}
             </p>
           )}
@@ -569,13 +565,13 @@ export function WorkflowsPanel({ sessionId, openTransientTab, sendSessionFrame }
               <StatusBadge tone={run.stage === 'error' ? 'error' : run.stage === 'running' ? 'info' : 'ok'}>
                 {runState(run)}
               </StatusBadge>
-              <span className="truncate text-[9px] text-doom-dim">
+              <span className="truncate text-2xs text-doom-dim">
                 {[run.position?.job, run.position?.step].filter(Boolean).join(' · ') ||
                   run.workflowName ||
                   run.displayName}
               </span>
               <span className="min-w-0 flex-1" />
-              <span data-testid="workflows-tally" className="text-[9px] text-doom-faint">
+              <span data-testid="workflows-tally" className="text-2xs text-doom-faint">
                 {runs.filter((candidate) => candidate.stage === 'running').length} running · {runs.length} total
               </span>
               {run.stage === 'running' ? null : (
@@ -606,9 +602,9 @@ export function WorkflowsPanel({ sessionId, openTransientTab, sendSessionFrame }
                 className="flex max-h-44 w-full shrink-0 flex-col overflow-y-auto rounded-md border border-doom-border bg-doom-panel p-1.5 sm:max-h-none sm:w-[214px]"
               >
                 <div className="flex items-center px-2 pb-1 pt-1">
-                  <span className="text-[8px] font-bold tracking-[0.14em] text-doom-faint">JOBS</span>
+                  <span className="text-2xs font-bold tracking-wider text-doom-faint">JOBS</span>
                   <span className="min-w-0 flex-1" />
-                  <span className="text-[8px] text-doom-faint">
+                  <span className="text-2xs text-doom-faint">
                     {jobs.filter((candidate) => candidate.status === 'completed').length}/{jobs.length}
                   </span>
                 </div>
@@ -635,11 +631,11 @@ export function WorkflowsPanel({ sessionId, openTransientTab, sendSessionFrame }
                     <div className="flex items-center px-2 pb-1">
                       <span
                         data-testid="job-pane-name"
-                        className="min-w-0 flex-1 truncate text-[9px] font-bold text-doom-hi"
+                        className="min-w-0 flex-1 truncate text-2xs font-bold text-doom-hi"
                       >
                         {job.name}
                       </span>
-                      <span className="text-[8px] text-doom-faint">
+                      <span className="text-2xs text-doom-faint">
                         {spanDuration(job.startedAt, job.endedAt, now) ?? ''}
                       </span>
                     </div>
@@ -662,7 +658,7 @@ export function WorkflowsPanel({ sessionId, openTransientTab, sendSessionFrame }
               </div>
               <DetailPane>
                 <div className="flex h-9 shrink-0 items-center gap-2 border-b border-doom-border-soft bg-doom-panel px-3">
-                  <span className="min-w-0 truncate text-[10px] font-bold text-doom-hi">
+                  <span className="min-w-0 truncate text-xs font-bold text-doom-hi">
                     {job?.name ?? run.displayName}
                   </span>
                   {job === undefined ? null : (

--- a/packages/minor/doompi-workflow/style-system.config.yaml
+++ b/packages/minor/doompi-workflow/style-system.config.yaml
@@ -1,0 +1,1 @@
+extends: doom-plugin

--- a/packages/minor/doompi-workflow/styles/preview.css
+++ b/packages/minor/doompi-workflow/styles/preview.css
@@ -1,0 +1,16 @@
+/*
+ * Render entrypoint for style-system story screenshots.
+ *
+ * A plugin consumes the component library as a package, so the palette and the
+ * Tailwind token mapping come from its published `styles.css` rather than from
+ * a relative path: `cssFiles` entries are app-relative and may not contain
+ * `..`. Tailwind itself has to be imported here, because the renderer only
+ * injects it for a project that configures no `cssFiles` at all.
+ *
+ * `@source` for this plugin's own sources is appended by the renderer, which
+ * scans `<appPath>/src`.
+ *
+ * Referenced by `style-system.config.yaml` (preset `doom-plugin`).
+ */
+@import 'tailwindcss';
+@import '@agimon-ai/doompi-web-components/styles.css';

--- a/packages/minor/doompi-workflow/vibe-lint.config.yaml
+++ b/packages/minor/doompi-workflow/vibe-lint.config.yaml
@@ -19,6 +19,15 @@ rules:
   file-naming-convention: error
 
 overrides:
+  # Story files are read by the style-system renderer, which resolves the
+  # default export by looking for a bare `const meta`. Naming the export at the
+  # point of definition breaks the render, so the export-shape rules are off
+  # here. Every other rule, theming included, still applies to stories.
+  - files:
+      - src/web/components/*.stories.tsx
+    rules:
+      no-default-export: off
+      direct-export-only: off
   - files:
       - src/exports/index.ts
     rules:

--- a/packages/tooling/vibe-lint-plugin-doom-extension/src/rules/webPlugin.ts
+++ b/packages/tooling/vibe-lint-plugin-doom-extension/src/rules/webPlugin.ts
@@ -34,6 +34,17 @@ const ALLOWED_BARE_SPECIFIERS = new Set([
   COMPONENTS_PACKAGE,
   SECURITY_BROWSER_PACKAGE,
 ]);
+/**
+ * Story files may also reach for the contract's own slot fixtures.
+ *
+ * The allowlist exists because the cockpit's bundler compiles a plugin's web/
+ * folder into the host bundle. A story is never imported by the plugin entry,
+ * so the bundler never reaches it, and `files` in each package excludes
+ * `*.stories.tsx` from the tarball. Hand-rolled prop stubs would be the only
+ * alternative, and those drift silently when the slot contract changes.
+ */
+const STORY_SUFFIX = '.stories.tsx';
+const CONTRACTS_TESTING_PACKAGE = `${CONTRACTS_PACKAGE}/testing`;
 const PLUGIN_ID_PATTERN = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
 const WEB_PLUGIN_EXPORT = 'webPlugin';
 const DEFINE_WEB_PLUGIN = 'defineWebPlugin';
@@ -239,13 +250,16 @@ export const webPluginImportAllowlist: RuleDefinition = {
     const sourceFile = readSource(filePath);
     if (!sourceFile) return null;
     const offenders = new Set<string>();
+    const allowed = filePath.endsWith(STORY_SUFFIX)
+      ? new Set([...ALLOWED_BARE_SPECIFIERS, CONTRACTS_TESTING_PACKAGE])
+      : ALLOWED_BARE_SPECIFIERS;
     for (const specifier of moduleSpecifiers(sourceFile)) {
       if (specifier.startsWith('.')) {
         const target = relativeTarget(filePath, specifier, configRoot);
         if (target === null || !(isWebPath(target) || isTypesPath(target))) {
           offenders.add(specifier);
         }
-      } else if (!ALLOWED_BARE_SPECIFIERS.has(specifier)) {
+      } else if (!allowed.has(specifier)) {
         offenders.add(specifier);
       }
     }

--- a/packages/tooling/vibe-lint-plugin-doom-web/src/configs/recommended.ts
+++ b/packages/tooling/vibe-lint-plugin-doom-web/src/configs/recommended.ts
@@ -3,6 +3,7 @@ import type { PluginConfigPreset, Severity } from '@agimon-ai/vibe-lint';
 const rules: Record<string, Severity> = {
   'doom-components-layer-boundary': 'error',
   'doom-web-layer-boundary': 'error',
+  'no-arbitrary-style-value': 'error',
   'no-cross-feature-import': 'error',
   'no-raw-theme-color': 'error',
   'prefer-shared-primitive': 'error',

--- a/packages/tooling/vibe-lint-plugin-doom-web/src/index.ts
+++ b/packages/tooling/vibe-lint-plugin-doom-web/src/index.ts
@@ -5,6 +5,7 @@ export {
   doomComponentsLayerBoundary,
   doomWebLayerBoundary,
   isComponentLibrary,
+  noArbitraryStyleValue,
   noCrossFeatureImport,
   noRawThemeColor,
   preferSharedPrimitive,

--- a/packages/tooling/vibe-lint-plugin-doom-web/src/rules/index.ts
+++ b/packages/tooling/vibe-lint-plugin-doom-web/src/rules/index.ts
@@ -4,4 +4,4 @@ export { noCrossFeatureImport } from './features.js';
 export { doomWebLayerBoundary } from './layers.js';
 export { preferSharedPrimitive } from './primitives.js';
 export { rules } from './registry.js';
-export { noRawThemeColor } from './theming.js';
+export { noArbitraryStyleValue, noRawThemeColor } from './theming.js';

--- a/packages/tooling/vibe-lint-plugin-doom-web/src/rules/registry.ts
+++ b/packages/tooling/vibe-lint-plugin-doom-web/src/rules/registry.ts
@@ -4,11 +4,12 @@ import { webFileNaming } from './conventions.js';
 import { noCrossFeatureImport } from './features.js';
 import { preferSharedPrimitive } from './primitives.js';
 import { doomWebLayerBoundary } from './layers.js';
-import { noRawThemeColor } from './theming.js';
+import { noArbitraryStyleValue, noRawThemeColor } from './theming.js';
 
 export const rules: Record<string, RuleDefinition> = {
   'doom-components-layer-boundary': doomComponentsLayerBoundary,
   'doom-web-layer-boundary': doomWebLayerBoundary,
+  'no-arbitrary-style-value': noArbitraryStyleValue,
   'no-cross-feature-import': noCrossFeatureImport,
   'no-raw-theme-color': noRawThemeColor,
   'prefer-shared-primitive': preferSharedPrimitive,

--- a/packages/tooling/vibe-lint-plugin-doom-web/src/rules/theming.ts
+++ b/packages/tooling/vibe-lint-plugin-doom-web/src/rules/theming.ts
@@ -53,3 +53,63 @@ export const noRawThemeColor: RuleDefinition = {
     return `${relativePath} hardcodes ${[...offenders].map((value) => `'${value}'`).join(', ')}. Browser code names a theme token instead: a Tailwind class such as bg-doom-panel, text-doom-hi, border-doom-edge-red, or bg-doom-tint-yellow, or the CSS custom property var(--doom-blue). If the palette has no token for what you mean, add one to the theme contract rather than spelling the colour here.`;
   },
 };
+
+/**
+ * A Tailwind arbitrary value on one of the four scales the theme owns:
+ * `text-[11px]`, `rounded-[3px]`, `tracking-[0.14em]`, `leading-[17px]`, and
+ * the side-specific radius forms such as `rounded-tl-[3px]`.
+ */
+const ARBITRARY_SCALE = /(?<![\w-])(text|rounded|tracking|leading)(?:-(?:[trbl]{1,2}|[a-z]+))?-\[([^\]]+)\]/g;
+
+/**
+ * `rounded-[inherit]` is not a size, it is a child agreeing to whatever radius
+ * its clipping parent already chose, and no token can express that.
+ */
+const ALLOWED_ARBITRARY = new Set(['inherit']);
+
+/** The token each scale expects, quoted back at whoever tripped the rule. */
+const SCALE_TOKENS: Record<string, string> = {
+  text: 'text-2xs (9px), text-xs (10px), text-sm (12px), text-base (13px), text-lg (15px)',
+  rounded: 'rounded-xs (2px), rounded-sm (3px), rounded-md (5px), rounded-lg (10px), rounded-full',
+  tracking: 'tracking-wide (0.08em), tracking-wider (0.14em), tracking-widest (0.18em)',
+  leading: 'leading-none, leading-tight, leading-snug, leading-normal, leading-relaxed',
+};
+
+export const noArbitraryStyleValue: RuleDefinition = {
+  preflight: true,
+  rule: 'Browser code sizes type, radius, tracking and leading from the scale, never an arbitrary value',
+  rationale:
+    'A scale is only a scale if nothing steps outside it. One `text-[11px]` looks harmless, but it is a rung nobody else can land on: the next component copies it, and soon the same visual weight exists at 10px, 11px and 12px with no way to tell which was deliberate. Arbitrary values also survive a token change silently, so retuning the ramp moves every honest call site and leaves the opt-outs behind, drifting further each time. Naming a rung states the intent, and a reviewer can see that two things match without measuring them.',
+  check(filePath, configRoot) {
+    const relativePath = projectPath(filePath, configRoot);
+    if (relativePath === null || declaresColors(relativePath) || !isBrowserSource(relativePath)) return null;
+    const sourceFile = readSource(filePath);
+    if (!sourceFile) return null;
+
+    const offenders = new Set<string>();
+    const scales = new Set<string>();
+    const visit = (node: ts.Node): void => {
+      // Template spans matter: many className values are built with `${}`.
+      if (
+        ts.isStringLiteralLike(node) ||
+        ts.isTemplateHead(node) ||
+        ts.isTemplateMiddle(node) ||
+        ts.isTemplateTail(node)
+      ) {
+        for (const match of node.text.matchAll(ARBITRARY_SCALE)) {
+          const [utility, scale, value] = [match[0], match[1] ?? '', match[2] ?? ''];
+          // A colour written into a text utility is the other rule's business.
+          if (ALLOWED_ARBITRARY.has(value) || BARE_COLOR.test(value)) continue;
+          offenders.add(utility.slice(0, 60));
+          scales.add(scale);
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    if (offenders.size === 0) return null;
+
+    const expected = [...scales].map((scale) => `${scale}: ${SCALE_TOKENS[scale]}`).join('; ');
+    return `${relativePath} hardcodes ${[...offenders].map((value) => `'${value}'`).join(', ')}. Browser code names a rung on the scale instead (${expected}). If the ramp has no rung for what you mean, add one to styles/tokens.css so every caller can reach it, rather than spelling the value here.`;
+  },
+};

--- a/packages/tooling/vibe-lint-plugin-doom-web/tests/pluginContract.test.ts
+++ b/packages/tooling/vibe-lint-plugin-doom-web/tests/pluginContract.test.ts
@@ -3,6 +3,7 @@ import doomWebPlugin, {
   doomComponentsLayerBoundary,
   doomWebLayerBoundary,
   doomWebPlugin as namedPlugin,
+  noArbitraryStyleValue,
   noCrossFeatureImport,
   noRawThemeColor,
   patterns,
@@ -15,6 +16,7 @@ import doomWebPlugin, {
 const EXPECTED_RULE_IDS = [
   'doom-components-layer-boundary',
   'doom-web-layer-boundary',
+  'no-arbitrary-style-value',
   'no-cross-feature-import',
   'no-raw-theme-color',
   'prefer-shared-primitive',
@@ -29,6 +31,7 @@ const EXPECTED_RULE_IDS = [
 const RULE_SEVERITY: Readonly<Record<(typeof EXPECTED_RULE_IDS)[number], 'error' | 'warn'>> = {
   'doom-components-layer-boundary': 'error',
   'doom-web-layer-boundary': 'error',
+  'no-arbitrary-style-value': 'error',
   'no-cross-feature-import': 'error',
   'no-raw-theme-color': 'error',
   'prefer-shared-primitive': 'error',
@@ -72,6 +75,7 @@ describe('Doom web plugin contract', () => {
     expect(Object.values(rules)).toEqual([
       doomComponentsLayerBoundary,
       doomWebLayerBoundary,
+      noArbitraryStyleValue,
       noCrossFeatureImport,
       noRawThemeColor,
       preferSharedPrimitive,

--- a/plugins/development/README.md
+++ b/plugins/development/README.md
@@ -1,14 +1,15 @@
 # DoomPi Development Plugin
 
-This example plugin provides one portable implementation workflow for Codex, Claude Code, and DoomPi. Both native plugin manifests load the same skill instead of maintaining host-specific prompt copies.
+This example plugin provides portable implementation guidance for Codex, Claude Code, and DoomPi. Both native plugin manifests load the same skills instead of maintaining host-specific prompt copies.
 
 ## What it includes
 
 - [`doompi-development`](skills/doompi-development/SKILL.md) scopes a requested code change, implements the smallest coherent solution, and verifies it with the target repository's own checks.
+- [`style-system`](skills/style-system/SKILL.md) renders a DoomPi web component in a real browser and checks it against the design tokens, for changes where appearance is the question.
 - [`doompi-developer`](agents/doompi-developer.md) provides the corresponding implementation agent on hosts that support Markdown agents.
 - `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json` expose the shared `skills/` directory to their respective hosts.
 
-The plugin does not choose a model, framework, package manager, or test runner. It reads and follows the target repository's instructions and existing conventions.
+The `doompi-development` skill does not choose a model, framework, package manager, or test runner. It reads and follows the target repository's instructions and existing conventions. The `style-system` skill is specific to this repository's web component library and its token contract.
 
 ## Install the plugin directly
 

--- a/plugins/development/skills/style-system/SKILL.md
+++ b/plugins/development/skills/style-system/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: style-system
+description: Render DoomPi web components in a real browser and check their styling against the design tokens. Use when adding or changing a component's visual appearance, adding a story, adjusting styles/tokens.css, or when asked whether a surface looks right, not for non-visual React logic.
+---
+
+# Style System
+
+`@agimon-ai/style-system` compiles a component with the real theme, screenshots it
+in a headless browser, and hands the image back. Use it to see a component instead
+of inferring how it looks from its class list.
+
+## When it earns its cost
+
+Reach for it when appearance is the question: a new component, a changed size or
+tone ladder, an edit to `styles/tokens.css`, or a review that asks whether a
+surface is correct. Skip it for logic, state, and data changes that do not move a
+pixel.
+
+## The three tools
+
+| Tool                     | Use                                                                                                         |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `list-shared-components` | Every component carrying the `style-system` tag. Takes no `--app-path`.                                     |
+| `get-css-classes`        | The tokens the theme actually generates, read from `styles/tokens.css`.                                     |
+| `get-ui-component`       | Compiles one story and returns a screenshot. `--component-name X --app-path <pkg> --story-name Playground`. |
+
+Read `get-css-classes` before inventing a class. It reports only `--color-*`,
+`--text-*`, `--font-*`, `--space-*`, `--spacing` and `--shadow-*`, so `--radius-*`
+and `--tracking-*` are absent from its output even though they generate utilities.
+
+## Configuration
+
+`style-system.config.yaml` at the workspace root holds `defaults` and three presets;
+each configured package extends one by name.
+
+- `packages/core/doompi-web-components` extends `doom-components`
+- `packages/clients/doompi-web` extends `doom-web-app`
+- every package with a `src/web/components` tree extends `doom-plugin`
+
+Resolution is `defaults` then the preset then the project file, replacing whole
+values per field. There is no upward directory walk: a project config is read only
+at the exact `--app-path` on the command line. `themePath` is workspace-root
+relative; `cssFiles` entries are app-relative and must not contain `..`.
+
+Keep stories inside a configured package. A story elsewhere resolves to the root
+config, which is `root: true` and rejects being used as a project config.
+
+### Adding a package
+
+A package that renders stories needs three things, all cheap:
+
+1. `style-system.config.yaml` containing `extends: doom-plugin`.
+2. `styles/preview.css` importing `tailwindcss` and then
+   `@agimon-ai/doompi-web-components/styles.css`. The library's `styles.css` is a
+   package export, which is how a plugin reaches the palette without a `..` that
+   `cssFiles` forbids. Tailwind has to be imported by hand, because the renderer
+   only injects it for a project that configures no `cssFiles` at all.
+3. `react-dom` as a devDependency. Plugin packages carry `react` but usually not
+   `react-dom`, and under pnpm's strict layout the renderer then fails to resolve
+   `react-dom/client` at build time.
+
+## Stories
+
+Storybook is not installed. A story is a plain object literal that the renderer
+parses statically, preferring `Story.render`, then `meta.render`, then
+`meta.component`.
+
+```tsx
+import { Thing } from './Thing.tsx';
+
+const meta = {
+  title: 'Components/Thing',
+  component: Thing,
+  tags: ['style-system'],
+};
+
+export default meta;
+
+export const Playground = {
+  render: () => (
+    <div className="flex flex-col gap-6 bg-doom-bg p-6">
+      <span className="text-2xs uppercase tracking-widest text-doom-dim">size md</span>
+      <Thing size="md" />
+    </div>
+  ),
+};
+```
+
+Rules that make a story renderable:
+
+- Never import from `storybook` or `@storybook/*`. Plain object literals only.
+- `const meta` must be a bare declaration with `export default meta` after it.
+  Writing `export const meta` breaks the render: the renderer finds the default
+  export by looking for the bare declaration and otherwise reports the component
+  as not found in the stories index. `no-default-export` and `direct-export-only`
+  are therefore switched off for `src/components/*.stories.tsx` through an
+  `overrides` block in the library's `vibe-lint.config.yaml`. Theming rules still
+  apply to stories.
+- `tags: ['style-system']` is what `list-shared-components` looks for.
+- Relative imports carry their `.tsx` or `.ts` extension.
+- It must paint with no interaction. Radix overlays need `open` or `defaultOpen`,
+  `Tooltip` needs its provider, and portalled content needs a wrapper tall enough
+  to screenshot.
+- Show every rung a `cva` ladder declares, so a collapsed step is visible.
+- A component taking `WebPluginSlotProps` or `ToolMessageRenderProps` gets them
+  from `@agimon-ai/doompi-web-contracts/testing`, which already exports
+  `slotPropsFixture` and `toolMessagePropsFixture`. A hand-rolled stub drifts
+  silently when the contract changes; the fixture breaks at the type level.
+
+Stories live in `src/` and never ship: `files` in `package.json` publishes `dist`
+and `styles` only. `vitest.config.ts` excludes them from coverage.
+
+## The token scales
+
+Type, radius and tracking are closed sets. `no-arbitrary-style-value` in
+`@agimon-ai/vibe-lint-plugin-doom-web` fails the build on anything outside them.
+
+| Scale    | Rungs                                                                            |
+| -------- | -------------------------------------------------------------------------------- |
+| Type     | `text-2xs` 9px, `text-xs` 10px, `text-sm` 12px, `text-base` 13px, `text-lg` 15px |
+| Radius   | `rounded-xs` 2px, `rounded-sm` 3px, `rounded-md` 5px, `rounded-lg` 10px          |
+| Tracking | `tracking-wide` .08em, `tracking-wider` .14em, `tracking-widest` .18em           |
+| Leading  | stock Tailwind steps; the theme adds none                                        |
+
+Bare `rounded` is 4px, `rounded-full`, `rounded-none` and `rounded-t`/`rounded-b`
+do not read `--radius-*` and are unaffected by the scale.
+
+Adding a type step means restating its line height too. Overriding `--text-sm`
+alone leaves Tailwind's default `--text-sm--line-height` in place, pairing a new
+size with a stale ratio.
+
+Colours are `--color-doom-*`. `text-doom-muted` is **not** one of them: the quiet
+foreground is `text-doom-dim`. A class naming a token that does not exist compiles
+to nothing and silently inherits, so confirm the name in `get-css-classes`.
+
+## Verifying a change
+
+1. `pnpm vibe-lint check --rules-only <paths>` before editing governed files.
+2. Render the affected components and look at the screenshots.
+3. `pnpm lint:vibe --preflight-only`.
+4. `pnpm exec nx run-many -t lint typecheck build test -p <project>`.
+
+Run Nx at `--parallel=3` or lower. Higher parallelism makes lint and typecheck
+contend on shared build artifacts and report failures that vanish when rerun.
+
+To confirm a token really compiles, build the CSS directly. The Tailwind v4 CLI has
+no `--content` flag; point at sources with `@source "<absolute path>"` inside the
+input CSS.
+
+## Known quirks
+
+- `get-css-classes` lists `--text-*--line-height` entries as though they were
+  classes. Cosmetic; leave them.
+- The renderer writes scratch Vite builds into `.tmp/` inside the package and never
+  cleans them. Already git-ignored.
+- The generated wrapper appends `@source` lines for `apps/` and
+  `packages/frontend`, which this repository does not have. Tailwind ignores a
+  missing source silently.
+- The renderer serves the built page from `file://`, so a Web Worker cannot start:
+  the browser blocks it as an origin `null` script. This bit `PdfPreview`, whose
+  pdfjs import spun up a worker at module scope and so crashed every story in
+  every package that imports the library barrel. The import is now lazy, which
+  fixes the crash. A story that genuinely needs a worker to paint, such as the
+  PDF canvas itself, still cannot: expect the chrome and the error state instead.
+- A package renders against the library's built `dist`, not its sources. After
+  changing a component, run `nx run @agimon-ai/doompi-web-components:build`
+  before rendering a story from any other package.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@agimon-ai/doompi-web':
         specifier: workspace:*
         version: link:packages/clients/doompi-web
+      '@agimon-ai/style-system':
+        specifier: 0.1.1
+        version: 0.1.1(@types/node@26.4.1)(@types/react@19.2.18)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)(zod@4.5.4)
       '@agimon-ai/vibe-lint':
         specifier: 0.0.1-alpha.29
         version: 0.0.1-alpha.29(@earendil-works/pi-coding-agent@0.85.1(zod@4.5.4))
@@ -106,7 +109,7 @@ importers:
         version: 7.0.2001
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -162,9 +165,12 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -195,7 +201,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.22.14
-        version: 0.22.14(typescript@7.0.2)
+        version: 0.22.14(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -226,7 +232,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -279,9 +285,12 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.22.14
-        version: 0.22.14(typescript@7.0.2)
+        version: 0.22.14(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -337,9 +346,12 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -410,6 +422,9 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -445,7 +460,7 @@ importers:
         version: 11.16.0
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -503,7 +518,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -645,7 +660,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -767,7 +782,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -804,7 +819,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -838,7 +853,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -890,7 +905,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -921,7 +936,7 @@ importers:
         version: 4.1.11(vitest@4.1.11)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -939,7 +954,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -985,7 +1000,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1016,7 +1031,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1065,7 +1080,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1114,7 +1129,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1139,7 +1154,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1195,9 +1210,12 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1303,7 +1321,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1336,7 +1354,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1354,7 +1372,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1447,9 +1465,12 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1528,7 +1549,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1587,9 +1608,12 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1629,7 +1653,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1691,9 +1715,12 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1764,9 +1791,12 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1827,7 +1857,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1886,9 +1916,12 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -1959,9 +1992,12 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -2081,7 +2117,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -2131,9 +2167,12 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -2191,7 +2230,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -2225,7 +2264,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -2277,7 +2316,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -2403,9 +2442,12 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -2481,7 +2523,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@7.0.2)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -2506,7 +2548,7 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@6.0.3)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@6.0.3)
       vitest:
         specifier: 5.0.0
         version: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -2528,12 +2570,15 @@ importers:
         version: 5.0.0(vitest@5.0.0)
       tsdown:
         specifier: 0.23.0
-        version: 0.23.0(typescript@6.0.3)
+        version: 0.23.0(oxc-resolver@11.24.2)(typescript@6.0.3)
       vitest:
         specifier: 5.0.0
         version: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
   '@agiflowai/aicode-utils@1.3.0':
     resolution: {integrity: sha512-dzM6sU2TrqxIGiGt2aN2M3+yMVrK/3dzmBRi8Xi4HSaNxbvyYPinFa9SbT2LGEhu5GQhTizurF1gq1APizvtSA==}
@@ -2555,6 +2600,9 @@ packages:
   '@agimon-ai/foundation-exec@0.26.19':
     resolution: {integrity: sha512-YPLWySHc3B2l21J6x5XyNkF7AZYFjQQa9BxYKoXk3J38iV8O4vmzbVGjJwPFjIcCCvQbqSWttWN9JcuuiLprzA==}
 
+  '@agimon-ai/foundation-exec@0.26.23':
+    resolution: {integrity: sha512-b5qbUsyS2T2CKo7M1IaFQuuDXCTG/EQqF1TMEUHT8GYOjW88UYNqT5fj88HlyDYIpHXIjc5TAqapMUdgnw2OYA==}
+
   '@agimon-ai/foundation-port-registry@0.29.19':
     resolution: {integrity: sha512-ulvRK9ybEOeKuiAdneELiL4sao/trET5ZoXPbcG3iN36VGVMvhkPRIJiRYf7nFbyOYeHsb659xw7U5+oOIYuRw==}
     hasBin: true
@@ -2567,6 +2615,12 @@ packages:
     peerDependencies:
       zod: ^4.4.3
 
+  '@agimon-ai/foundation-port-registry@0.29.23':
+    resolution: {integrity: sha512-eh+LmPpCQHpEQqb4g5dNEs8fxRzYYRrmZ2xmccsJjbEaE8D0Z0gMwTHSRUMlnbc0l0xorlbDy6lGbiij29ixFQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^4.4.3
+
   '@agimon-ai/foundation-process-registry@0.29.19':
     resolution: {integrity: sha512-GS+T2TWkjlxifVwUUmhOqHbMg3BRHECdlivOqvnqT1N5L7nrvezX1F+gvMjTKQ3A5YfdMEXVGeomCWh56U6YaA==}
     hasBin: true
@@ -2575,6 +2629,12 @@ packages:
 
   '@agimon-ai/foundation-process-registry@0.29.22':
     resolution: {integrity: sha512-Uz+eq8To2w5WVVr2qpjRB/v1PkuJBX6MNJFsWabeDmDCPHf2/PLUUOnW8hiV9mxAekgJUcItaTIyM+TrcVGxLA==}
+    hasBin: true
+    peerDependencies:
+      zod: ^4.4.3
+
+  '@agimon-ai/foundation-process-registry@0.29.23':
+    resolution: {integrity: sha512-0VqAM1Fgh1DkvzRdvc0VQpp+eC2mYXKcVl2c3PvH5QCjxgtN1rDGm1kHLc+LSl5Csj76zt5CkiOeQIZIJib8Ng==}
     hasBin: true
     peerDependencies:
       zod: ^4.4.3
@@ -2611,6 +2671,12 @@ packages:
 
   '@agimon-ai/mcp-proxy@0.31.22':
     resolution: {integrity: sha512-6zqiFv3B8VolUO2uzb3TKKXiEZc3h5jYEO9EP9g4TWrXcZmlD8+Kiik7W9QcJ9a/eDA69McEtxm40AedIvMDfA==}
+    hasBin: true
+    peerDependencies:
+      zod: ^4.4.3
+
+  '@agimon-ai/style-system@0.1.1':
+    resolution: {integrity: sha512-6MHpcGVNgBaJjNQ5vjR7nwBWwFyebHryfMIEkSHjMV8GdbUE00oMnl1DJBK7YgmRe2uoyXI0qVd2kX2TFlC4Ig==}
     hasBin: true
     peerDependencies:
       zod: ^4.4.3
@@ -3500,14 +3566,35 @@ packages:
     resolution: {integrity: sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==}
     engines: {node: '>=22.12.0'}
 
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
   '@emnapi/core@1.4.5':
     resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
+
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/runtime@1.4.5':
     resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
 
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
   '@emnapi/wasi-threads@1.0.4':
     resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -3728,6 +3815,159 @@ packages:
 
   '@iconify/utils@3.1.5':
     resolution: {integrity: sha512-nT+AWyh5caHY6xa0PdLXpUooIz6l7qsT+adqsCTYBfbdn5Q18VrWs2fvuTa7KEoJnPBfEPqWkmAIht0EHtCi2A==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@inquirer/ansi@2.0.7':
     resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
@@ -4199,6 +4439,13 @@ packages:
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
 
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
+
   '@nx/devkit@23.2.0':
     resolution: {integrity: sha512-srj04UsYqq2nG7Z9DxM00D8XpSpmSM7XQafCkD4FIOE2NPMCu0QvypJLe8S7a1/YAW9rqlnYrdadaQte687eAw==}
     peerDependencies:
@@ -4350,8 +4597,241 @@ packages:
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
 
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    resolution: {integrity: sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    resolution: {integrity: sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    resolution: {integrity: sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    resolution: {integrity: sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    resolution: {integrity: sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    resolution: {integrity: sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    resolution: {integrity: sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    resolution: {integrity: sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    resolution: {integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    resolution: {integrity: sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    resolution: {integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
   '@oxc-project/types@0.148.0':
     resolution: {integrity: sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    resolution: {integrity: sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    resolution: {integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    resolution: {integrity: sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    resolution: {integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    resolution: {integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    resolution: {integrity: sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    resolution: {integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    resolution: {integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
+    cpu: [x64]
+    os: [win32]
 
   '@oxfmt/binding-android-arm-eabi@0.66.0':
     resolution: {integrity: sha512-2Me9eoptv6ERdEuI2P8AOlYdHHraXebJaM6SC0kc2Dfb+mLrep2db+fedBPKaYn673h/vBgvP4tkOdAbaudX6w==}
@@ -5414,6 +5894,9 @@ packages:
   '@radix-ui/rect@1.1.3':
     resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
 
+  '@react-native/normalize-colors@0.74.89':
+    resolution: {integrity: sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg==}
+
   '@rmux/sdk@0.6.5':
     resolution: {integrity: sha512-ZYhQmZueNo5VOCIcBp97kUFwbgVJ5KJa3CBQuv81NhSWqRWuRCnHECI9j99UOfUWNSmR17ZreQuFx0rEQHOFIg==}
     engines: {node: '>=20'}
@@ -5588,6 +6071,14 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@2.1.0':
+    resolution: {integrity: sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tailwindcss/node@4.3.3':
     resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
 
@@ -5715,6 +6206,20 @@ packages:
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/user-event@14.6.7':
+    resolution: {integrity: sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tursodatabase/database-common@0.7.2':
     resolution: {integrity: sha512-c4uWaA5m7nyDemUrjvX6lQQ89cBxv1jCv7nmwq5JoagyXgbMxDeBfLcY7N5kn0oEcnD0Y+cf09S0wKEXKFKbfg==}
 
@@ -5743,8 +6248,14 @@ packages:
   '@tursodatabase/database@0.7.2':
     resolution: {integrity: sha512-B84QicyDYnKt97qxgb7861cQQC26kuv/LkUlCnpxGs4tuGT9zgS2z/Mt+BkG/wOo1fB4rsSycOgGCbi0xU0YOQ==}
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -6069,6 +6580,19 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vitejs/plugin-react@6.0.3':
+    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: 8.2.2
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
   '@vitejs/plugin-react@6.1.1':
     resolution: {integrity: sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6103,6 +6627,9 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/expect@4.1.11':
     resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
@@ -6136,6 +6663,9 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.1.11':
     resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
 
@@ -6145,11 +6675,17 @@ packages:
   '@vitest/snapshot@4.1.11':
     resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/spy@4.1.11':
     resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
   '@vitest/spy@5.0.0':
     resolution: {integrity: sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
@@ -6216,6 +6752,9 @@ packages:
 
   '@vscode/ripgrep@1.18.0':
     resolution: {integrity: sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==}
+
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
   '@xterm/headless@6.0.0':
     resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
@@ -6551,6 +7090,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -6573,6 +7116,16 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
@@ -6583,6 +7136,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-types@0.16.3:
+    resolution: {integrity: sha512-FvWoWYfSCM6kRxCSH+MGLHIKKGRL6A6AW7Zek2O32REPQRdg131428uRTKMBYAeRd3XXAaHDS60Wpri7CdKDrA==}
+    engines: {node: '>=4'}
 
   ast-v8-to-istanbul@1.0.5:
     resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
@@ -6670,6 +7227,10 @@ packages:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   browserslist@4.28.8:
     resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -6718,6 +7279,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -6744,6 +7309,10 @@ packages:
 
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -6898,9 +7467,18 @@ packages:
   crelt@1.0.7:
     resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
 
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-in-js-utils@3.1.0:
+    resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -7086,6 +7664,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   default-browser-id@5.0.0:
     resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
     engines: {node: '>=18'}
@@ -7145,6 +7727,12 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dompurify@3.4.14:
     resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
@@ -7437,6 +8025,12 @@ packages:
   fastdom@1.0.12:
     resolution: {integrity: sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==}
 
+  fbjs-css-vars@1.0.2:
+    resolution: {integrity: sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==}
+
+  fbjs@3.0.5:
+    resolution: {integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -7457,6 +8051,10 @@ packages:
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -7553,6 +8151,10 @@ packages:
   get-tsconfig@5.0.0-beta.6:
     resolution: {integrity: sha512-X6fBC0pmImC70gvX2zm56go9hx0MyoGVdG0tUCkg/D+Xnh5TJsOZ7iDbOdI3PvmtrDxnu1YdDufpK2QJX1Meqw==}
     engines: {node: '>=20.20.0'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   global-directory@5.0.0:
     resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
@@ -7677,6 +8279,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  hyphenate-style-name@1.1.0:
+    resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -7707,6 +8312,10 @@ packages:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -7716,6 +8325,9 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  inline-style-prefixer@7.0.1:
+    resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
@@ -7786,6 +8398,10 @@ packages:
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -8111,6 +8727,13 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -8122,6 +8745,10 @@ packages:
     resolution: {integrity: sha512-MaG+8WnOXkDWz9XeElj7TnQ890tTZUB0a36i03aRRCKGWE6e7jJpmdCvtxxuxcjjdqyN6m4sL6qlHVuSUDtYgg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -8201,6 +8828,9 @@ packages:
   media-typer@1.1.1:
     resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
     engines: {node: '>= 0.8'}
+
+  memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -8293,6 +8923,10 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -8317,6 +8951,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -8330,6 +8968,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -8351,6 +8993,15 @@ packages:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -8439,6 +9090,9 @@ packages:
       - validate-npm-package-name
       - which
 
+  nullthrows@1.1.1:
+    resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
   nx@23.2.0:
     resolution: {integrity: sha512-EWscwgKDr40bpsy2Dpijx0+wdkQjF8Z5Gvo91qLh3Ot2qkoYCznAzrqT2hXkkc1USC1TvX64t5IgsQq0Wtg1nA==}
     hasBin: true
@@ -8492,6 +9146,10 @@ packages:
     resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
     engines: {node: '>=18'}
 
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
   open@11.0.2:
     resolution: {integrity: sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==}
     engines: {node: '>=20'}
@@ -8514,6 +9172,13 @@ packages:
   ora@9.3.0:
     resolution: {integrity: sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==}
     engines: {node: '>=20'}
+
+  oxc-parser@0.127.0:
+    resolution: {integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.24.2:
+    resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
   oxfmt@0.66.0:
     resolution: {integrity: sha512-FfvqR8RFtV6JJpRrpkfqyVCQ7HDvZ/VriWFx7veftCgL1B5ZO9qNr+1rvPieycMQnNfVG0PWyJQiy7p0hq1I5w==}
@@ -8588,6 +9253,10 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
@@ -8597,6 +9266,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pdfjs-dist@6.3.289:
     resolution: {integrity: sha512-ZHjSVpDa3D6izMq8/04lvkhkATUmL9px6ChPaXc1k6nU2Mrhlg1/7F0bdUqCwUjw3NsPTfPZsMDUU6ZIcRaeQw==}
@@ -8612,6 +9285,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -8647,8 +9324,18 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  playwright-core@1.63.0:
+    resolution: {integrity: sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   playwright@1.62.1:
     resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.63.0:
+    resolution: {integrity: sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -8657,6 +9344,13 @@ packages:
 
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
@@ -8670,6 +9364,10 @@ packages:
     resolution: {integrity: sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==}
     engines: {node: '>=20'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -8680,6 +9378,9 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  promise@7.3.1:
+    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
 
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
@@ -8747,16 +9448,30 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
       react: ^19.2.8
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
+
+  react-native-web@0.21.2:
+    resolution: {integrity: sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -8788,6 +9503,10 @@ packages:
       '@types/react':
         optional: true
 
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
@@ -8802,6 +9521,14 @@ packages:
 
   real-require@1.0.0:
     resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
+
+  recast@0.23.21:
+    resolution: {integrity: sha512-mFAyJq9vUbSTARLZUvAEf1z3YxlvAwswbmxMx2mPA/MSm4KmpwvwvhsH/NIrZhyOuwD60Lzyw2qh83uCbgTPYw==}
+    engines: {node: '>= 4'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
@@ -9005,8 +9732,15 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -9151,6 +9885,21 @@ packages:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
 
+  storybook@10.5.2:
+    resolution: {integrity: sha512-zkYxVZoDMj8njzZc3EH5UyY7885wpi9a1mmWVwFiNHSo+i5r2Go84E2OI1cdOctRymLkNvgs1j5jqAKA0ftBqg==}
+    hasBin: true
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      prettier: ^2 || ^3
+      vite-plus: ^0.1.15 || ^0.2.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      prettier:
+        optional: true
+      vite-plus:
+        optional: true
+
   strictdom@1.0.1:
     resolution: {integrity: sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==}
 
@@ -9196,6 +9945,10 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
@@ -9208,6 +9961,9 @@ packages:
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  styleq@0.1.3:
+    resolution: {integrity: sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==}
 
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
@@ -9242,6 +9998,9 @@ packages:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
     engines: {node: '>=20'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -9265,17 +10024,32 @@ packages:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.1.1:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.6:
+    resolution: {integrity: sha512-u8KszXvGfU68hVcZpRHKG28T0krMuv2G5nDhiHaMLen/gIuFEgIJhaJuO69qjnXg5paSrbPMFfx3brNuN8eVSg==}
     engines: {node: '>=14.0.0'}
 
   tmp@0.2.7:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -9403,6 +10177,10 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
+  ua-parser-js@1.0.41:
+    resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
+    hasBin: true
+
   ulidx@2.4.1:
     resolution: {integrity: sha512-xY7c8LPyzvhvew0Fn+Ek3wBC9STZAuDI/Y5andCKi9AX6/jvfaX45PhsDX8oxgPL0YFp0Jhr8qWMbS/p9375Xg==}
     engines: {node: '>=16'}
@@ -9521,6 +10299,16 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite-plugin-singlefile@2.3.3:
+    resolution: {integrity: sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==}
+    engines: {node: '>18.0.0'}
+    peerDependencies:
+      rollup: ^4.59.0
+      vite: 8.2.2
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   vite@8.2.2:
     resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
@@ -9662,6 +10450,12 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -9699,6 +10493,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
 
   wsl-utils@1.0.0:
     resolution: {integrity: sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==}
@@ -9795,6 +10593,8 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.5.0': {}
+
   '@agiflowai/aicode-utils@1.3.0':
     dependencies:
       chalk: 5.6.2
@@ -9863,6 +10663,12 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  '@agimon-ai/foundation-exec@0.26.23(zod@4.5.4)':
+    dependencies:
+      '@agimon-ai/foundation-process-registry': 0.29.23(zod@4.5.4)
+    transitivePeerDependencies:
+      - zod
+
   '@agimon-ai/foundation-port-registry@0.29.19(zod@4.4.3)':
     dependencies:
       '@tursodatabase/database': 0.7.2
@@ -9874,6 +10680,11 @@ snapshots:
       zod: 4.5.4
 
   '@agimon-ai/foundation-port-registry@0.29.22(zod@4.5.4)':
+    dependencies:
+      '@tursodatabase/database': 0.7.2
+      zod: 4.5.4
+
+  '@agimon-ai/foundation-port-registry@0.29.23(zod@4.5.4)':
     dependencies:
       '@tursodatabase/database': 0.7.2
       zod: 4.5.4
@@ -9893,6 +10704,12 @@ snapshots:
   '@agimon-ai/foundation-process-registry@0.29.22(zod@4.5.4)':
     dependencies:
       '@agimon-ai/foundation-port-registry': 0.29.22(zod@4.5.4)
+      '@tursodatabase/database': 0.7.2
+      zod: 4.5.4
+
+  '@agimon-ai/foundation-process-registry@0.29.23(zod@4.5.4)':
+    dependencies:
+      '@agimon-ai/foundation-port-registry': 0.29.23(zod@4.5.4)
       '@tursodatabase/database': 0.7.2
       zod: 4.5.4
 
@@ -10208,6 +11025,55 @@ snapshots:
       - sqlite3
       - supports-color
       - unstorage
+
+  '@agimon-ai/style-system@0.1.1(@types/node@26.4.1)(@types/react@19.2.18)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)(zod@4.5.4)':
+    dependencies:
+      '@agimon-ai/foundation-exec': 0.26.23(zod@4.5.4)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.5.4)
+      '@tailwindcss/vite': 4.3.3(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitejs/plugin-react': 6.0.3(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      chalk: 5.6.2
+      commander: 14.0.3
+      glob: 13.0.6
+      inversify: 8.2.1(reflect-metadata@0.2.2)
+      js-yaml: 5.3.0
+      pino: 10.3.1
+      playwright: 1.63.0
+      postcss: 8.5.19
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-native-web: 0.21.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      reflect-metadata: 0.2.2
+      sharp: 0.34.5
+      storybook: 10.5.2(@types/react@19.2.18)(react@19.2.7)
+      tailwindcss: 4.3.3
+      vite: 8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite-plugin-singlefile: 2.3.3(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      zod: 4.5.4
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@rolldown/plugin-babel'
+      - '@types/node'
+      - '@types/react'
+      - '@vitejs/devtools'
+      - babel-plugin-react-compiler
+      - bufferutil
+      - encoding
+      - esbuild
+      - jiti
+      - less
+      - prettier
+      - rollup
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite-plus
+      - yaml
 
   '@agimon-ai/vibe-lint@0.0.1-alpha.29(@earendil-works/pi-coding-agent@0.85.1(zod@4.5.4))':
     dependencies:
@@ -11684,18 +12550,55 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.4.5':
     dependencies:
       '@emnapi/wasi-threads': 1.0.4
       tslib: 2.8.1
 
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.4.5':
     dependencies:
       tslib: 2.8.1
 
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.0.4':
     dependencies:
       tslib: 2.8.1
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -11845,6 +12748,102 @@ snapshots:
       '@antfu/install-pkg': 2.0.1
       '@iconify/types': 2.0.0
       import-meta-resolve: 4.2.0
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@inquirer/ansi@2.0.7': {}
 
@@ -12326,6 +13325,20 @@ snapshots:
       '@emnapi/runtime': 1.4.5
       '@tybys/wasm-util': 0.9.0
 
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nx/devkit@23.2.0(nx@23.2.0)':
     dependencies:
       ejs: 5.0.1
@@ -12502,7 +13515,134 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
   '@oxc-project/types@0.148.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    optional: true
 
   '@oxfmt/binding-android-arm-eabi@0.66.0':
     optional: true
@@ -13529,6 +14669,8 @@ snapshots:
 
   '@radix-ui/rect@1.1.3': {}
 
+  '@react-native/normalize-colors@0.74.89': {}
+
   '@rmux/sdk@0.6.5':
     dependencies:
       '@types/node': 24.13.3
@@ -13664,6 +14806,12 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@2.1.0(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+
   '@tailwindcss/node@4.3.3':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -13768,6 +14916,30 @@ snapshots:
 
   '@tanstack/store@0.9.3': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/user-event@14.6.7(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tursodatabase/database-common@0.7.2': {}
 
   '@tursodatabase/database-darwin-arm64@0.7.2':
@@ -13791,9 +14963,16 @@ snapshots:
       '@tursodatabase/database-linux-x64-gnu': 0.7.2
       '@tursodatabase/database-win32-x64-msvc': 0.7.2
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@tybys/wasm-util@0.9.0':
     dependencies:
       tslib: 2.8.1
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -14100,6 +15279,11 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vitejs/plugin-react@6.0.3(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+
   '@vitejs/plugin-react@6.1.1(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -14130,6 +15314,14 @@ snapshots:
       std-env: 4.2.0
       tinyrainbow: 3.1.1
       vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -14181,6 +15373,10 @@ snapshots:
     optionalDependencies:
       vite: 8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
 
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.1.11':
     dependencies:
       tinyrainbow: 3.1.1
@@ -14197,9 +15393,19 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.6
+
   '@vitest/spy@4.1.11': {}
 
   '@vitest/spy@5.0.0': {}
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.1.11':
     dependencies:
@@ -14257,6 +15463,8 @@ snapshots:
       '@vscode/ripgrep-win32-arm64': 1.18.0
       '@vscode/ripgrep-win32-ia32': 1.18.0
       '@vscode/ripgrep-win32-x64': 1.18.0
+
+  '@webcontainer/env@1.1.1': {}
 
   '@xterm/headless@6.0.0': {}
 
@@ -14465,6 +15673,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   ansis@4.3.1: {}
@@ -14481,6 +15691,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  asap@2.0.6: {}
+
   asn1.js@5.4.1:
     dependencies:
       bn.js: 4.12.5
@@ -14495,6 +15713,10 @@ snapshots:
       tslib: 2.8.1
 
   assertion-error@2.0.1: {}
+
+  ast-types@0.16.3:
+    dependencies:
+      tslib: 2.8.1
 
   ast-v8-to-istanbul@1.0.5:
     dependencies:
@@ -14608,6 +15830,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.3
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   browserslist@4.28.8:
     dependencies:
       baseline-browser-mapping: 2.11.20
@@ -14651,6 +15877,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -14669,6 +15903,8 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   chardet@2.2.0: {}
+
+  check-error@2.1.3: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -14801,11 +16037,23 @@ snapshots:
 
   crelt@1.0.7: {}
 
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-in-js-utils@3.1.0:
+    dependencies:
+      hyphenate-style-name: 1.1.0
+
+  css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
 
@@ -15011,6 +16259,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
   default-browser-id@5.0.0: {}
 
   default-browser-id@5.0.1: {}
@@ -15057,6 +16307,10 @@ snapshots:
 
   diff@8.0.4: {}
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dompurify@3.4.14:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -15071,7 +16325,9 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  dts-resolver@3.0.0: {}
+  dts-resolver@3.0.0(oxc-resolver@11.24.2):
+    optionalDependencies:
+      oxc-resolver: 11.24.2
 
   dunder-proto@1.0.1:
     dependencies:
@@ -15288,6 +16544,20 @@ snapshots:
     dependencies:
       strictdom: 1.0.1
 
+  fbjs-css-vars@1.0.2: {}
+
+  fbjs@3.0.5:
+    dependencies:
+      cross-fetch: 3.2.0
+      fbjs-css-vars: 1.0.2
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      promise: 7.3.1
+      setimmediate: 1.0.5
+      ua-parser-js: 1.0.41
+    transitivePeerDependencies:
+      - encoding
+
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
       picomatch: 4.0.7
@@ -15304,6 +16574,10 @@ snapshots:
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   finalhandler@2.1.1:
     dependencies:
@@ -15404,6 +16678,12 @@ snapshots:
   get-tsconfig@5.0.0-beta.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.6
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   global-directory@5.0.0:
     dependencies:
@@ -15534,6 +16814,8 @@ snapshots:
 
   husky@9.1.7: {}
 
+  hyphenate-style-name@1.1.0: {}
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -15557,11 +16839,17 @@ snapshots:
 
   import-without-cache@0.4.0: {}
 
+  indent-string@4.0.0: {}
+
   inherits@2.0.4: {}
 
   ini@6.0.0: {}
 
   inline-style-parser@0.2.7: {}
+
+  inline-style-prefixer@7.0.1:
+    dependencies:
+      css-in-js-utils: 3.1.0
 
   internmap@1.0.1: {}
 
@@ -15619,6 +16907,8 @@ snapshots:
   is-interactive@1.0.0: {}
 
   is-interactive@2.0.0: {}
+
+  is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -15862,6 +17152,12 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
+
   lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
@@ -15871,6 +17167,8 @@ snapshots:
   lucide-react@1.40.0(react@19.2.8):
     dependencies:
       react: 19.2.8
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -16052,6 +17350,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   media-typer@1.1.1: {}
+
+  memoize-one@6.0.0: {}
 
   merge-descriptors@2.0.0: {}
 
@@ -16271,6 +17571,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
   mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
@@ -16287,6 +17592,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  min-indent@1.0.1: {}
+
   minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
@@ -16299,6 +17606,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
   ms@2.1.3: {}
 
   mute-stream@3.0.0: {}
@@ -16308,6 +17617,10 @@ snapshots:
   negotiator@1.0.0: {}
 
   node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -16327,6 +17640,8 @@ snapshots:
       unicorn-magic: 0.3.0
 
   npm@11.16.0: {}
+
+  nullthrows@1.1.1: {}
 
   nx@23.2.0:
     dependencies:
@@ -16508,6 +17823,13 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.1
 
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.1
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
   open@11.0.2:
     dependencies:
       default-browser: 5.5.1
@@ -16544,6 +17866,53 @@ snapshots:
       log-symbols: 7.0.1
       stdin-discarder: 0.3.2
       string-width: 8.2.2
+
+  oxc-parser@0.127.0:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.127.0
+      '@oxc-parser/binding-android-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-x64': 0.127.0
+      '@oxc-parser/binding-freebsd-x64': 0.127.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.127.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.127.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-musl': 0.127.0
+      '@oxc-parser/binding-openharmony-arm64': 0.127.0
+      '@oxc-parser/binding-wasm32-wasi': 0.127.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.127.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.127.0
+
+  oxc-resolver@11.24.2:
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.24.2
+      '@oxc-resolver/binding-android-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-x64': 11.24.2
+      '@oxc-resolver/binding-freebsd-x64': 11.24.2
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-musl': 11.24.2
+      '@oxc-resolver/binding-openharmony-arm64': 11.24.2
+      '@oxc-resolver/binding-wasm32-wasi': 11.24.2
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
+      '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
   oxfmt@0.66.0:
     dependencies:
@@ -16643,11 +18012,18 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
+
   path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pdfjs-dist@6.3.289:
     optionalDependencies:
@@ -16660,6 +18036,8 @@ snapshots:
       '@earendil-works/pi-coding-agent': 0.85.1(@modelcontextprotocol/sdk@1.30.0(zod@4.5.4))(ws@8.21.3)(zod@4.5.4)
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -16707,11 +18085,17 @@ snapshots:
 
   playwright-core@1.62.1: {}
 
+  playwright-core@1.63.0: {}
+
   playwright@1.62.1:
     dependencies:
       playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  playwright@1.63.0:
+    dependencies:
+      playwright-core: 1.63.0
 
   points-on-curve@0.2.0: {}
 
@@ -16719,6 +18103,14 @@ snapshots:
     dependencies:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.19:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.26:
     dependencies:
@@ -16730,6 +18122,12 @@ snapshots:
 
   powershell-utils@0.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
@@ -16737,6 +18135,10 @@ snapshots:
   process-warning@5.1.0: {}
 
   progress@2.0.3: {}
+
+  promise@7.3.1:
+    dependencies:
+      asap: 2.0.6
 
   proper-lockfile@4.1.2:
     dependencies:
@@ -16865,10 +18267,17 @@ snapshots:
       iconv-lite: 0.7.3
       unpipe: 1.0.0
 
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
   react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-markdown@10.1.0(@types/react@19.2.18)(react@19.2.8):
     dependencies:
@@ -16887,6 +18296,21 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  react-native-web@0.21.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@react-native/normalize-colors': 0.74.89
+      fbjs: 3.0.5
+      inline-style-prefixer: 7.0.1
+      memoize-one: 6.0.0
+      nullthrows: 1.1.1
+      postcss-value-parser: 4.2.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      styleq: 0.1.3
+    transitivePeerDependencies:
+      - encoding
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.18)(react@19.2.8):
     dependencies:
@@ -16915,6 +18339,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
+  react@19.2.7: {}
+
   react@19.2.8: {}
 
   readable-stream@3.6.2:
@@ -16926,6 +18352,19 @@ snapshots:
   real-require@0.2.0: {}
 
   real-require@1.0.0: {}
+
+  recast@0.23.21:
+    dependencies:
+      ast-types: 0.16.3
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect-metadata@0.2.2: {}
 
@@ -17019,9 +18458,9 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rolldown-plugin-dts@0.27.14(rolldown@1.2.7)(typescript@7.0.2):
+  rolldown-plugin-dts@0.27.14(oxc-resolver@11.24.2)(rolldown@1.2.7)(typescript@7.0.2):
     dependencies:
-      dts-resolver: 3.0.0
+      dts-resolver: 3.0.0(oxc-resolver@11.24.2)
       get-tsconfig: 5.0.0-beta.5
       obug: 2.1.4
       rolldown: 1.2.7
@@ -17033,9 +18472,9 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown-plugin-dts@0.28.5(rolldown@1.2.7)(typescript@6.0.3):
+  rolldown-plugin-dts@0.28.5(oxc-resolver@11.24.2)(rolldown@1.2.7)(typescript@6.0.3):
     dependencies:
-      dts-resolver: 3.0.0
+      dts-resolver: 3.0.0(oxc-resolver@11.24.2)
       get-tsconfig: 5.0.0-beta.6
       obug: 2.1.4
       rolldown: 1.2.7
@@ -17047,9 +18486,9 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown-plugin-dts@0.28.5(rolldown@1.2.7)(typescript@7.0.2):
+  rolldown-plugin-dts@0.28.5(oxc-resolver@11.24.2)(rolldown@1.2.7)(typescript@7.0.2):
     dependencies:
-      dts-resolver: 3.0.0
+      dts-resolver: 3.0.0(oxc-resolver@11.24.2)
       get-tsconfig: 5.0.0-beta.6
       obug: 2.1.4
       rolldown: 1.2.7
@@ -17163,7 +18602,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  setimmediate@1.0.5: {}
+
   setprototypeof@1.2.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -17291,6 +18763,32 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
+  storybook@10.5.2(@types/react@19.2.18)(react@19.2.7):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.1.0(react@19.2.7)
+      '@testing-library/dom': 10.4.1
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.7(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.28.1
+      jsonc-parser: 3.3.1
+      open: 10.2.0
+      oxc-parser: 0.127.0
+      oxc-resolver: 11.24.2
+      recast: 0.23.21
+      semver: 7.8.5
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      ws: 8.21.3
+    optionalDependencies:
+      '@types/react': 19.2.18
+    transitivePeerDependencies:
+      - bufferutil
+      - react
+      - utf-8-validate
+
   strictdom@1.0.1: {}
 
   string-argv@0.3.2: {}
@@ -17335,6 +18833,10 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@5.0.3: {}
 
   style-mod@4.1.3: {}
@@ -17346,6 +18848,8 @@ snapshots:
   style-to-object@1.0.14:
     dependencies:
       inline-style-parser: 0.2.7
+
+  styleq@0.1.3: {}
 
   stylis@4.4.0: {}
 
@@ -17379,6 +18883,8 @@ snapshots:
     dependencies:
       real-require: 1.0.0
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinybench@6.1.4: {}
@@ -17394,11 +18900,21 @@ snapshots:
 
   tinypool@2.1.0: {}
 
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.1.1: {}
+
+  tinyspy@4.0.6: {}
 
   tmp@0.2.7: {}
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   toidentifier@1.0.1: {}
+
+  tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
 
@@ -17418,7 +18934,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.22.14(typescript@7.0.2):
+  tsdown@0.22.14(oxc-resolver@11.24.2)(typescript@7.0.2):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -17429,7 +18945,7 @@ snapshots:
       obug: 2.1.4
       picomatch: 4.0.7
       rolldown: 1.2.7
-      rolldown-plugin-dts: 0.27.14(rolldown@1.2.7)(typescript@7.0.2)
+      rolldown-plugin-dts: 0.27.14(oxc-resolver@11.24.2)(rolldown@1.2.7)(typescript@7.0.2)
       tinyexec: 1.3.1
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
@@ -17443,7 +18959,7 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
-  tsdown@0.23.0(typescript@6.0.3):
+  tsdown@0.23.0(oxc-resolver@11.24.2)(typescript@6.0.3):
     dependencies:
       cac: 7.0.0
       defu: 6.1.7
@@ -17453,7 +18969,7 @@ snapshots:
       obug: 2.1.4
       picomatch: 4.0.7
       rolldown: 1.2.7
-      rolldown-plugin-dts: 0.28.5(rolldown@1.2.7)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.28.5(oxc-resolver@11.24.2)(rolldown@1.2.7)(typescript@6.0.3)
       tinyexec: 1.3.1
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
@@ -17467,7 +18983,7 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
-  tsdown@0.23.0(typescript@7.0.2):
+  tsdown@0.23.0(oxc-resolver@11.24.2)(typescript@7.0.2):
     dependencies:
       cac: 7.0.0
       defu: 6.1.7
@@ -17477,7 +18993,7 @@ snapshots:
       obug: 2.1.4
       picomatch: 4.0.7
       rolldown: 1.2.7
-      rolldown-plugin-dts: 0.28.5(rolldown@1.2.7)(typescript@7.0.2)
+      rolldown-plugin-dts: 0.28.5(oxc-resolver@11.24.2)(rolldown@1.2.7)(typescript@7.0.2)
       tinyexec: 1.3.1
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
@@ -17535,6 +19051,8 @@ snapshots:
       '@typescript/typescript-sunos-x64': 7.0.2
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
+
+  ua-parser-js@1.0.41: {}
 
   ulidx@2.4.1:
     dependencies:
@@ -17623,6 +19141,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   use-sync-external-store@1.6.0(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -17646,6 +19168,11 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  vite-plugin-singlefile@2.3.3(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+    dependencies:
+      micromatch: 4.0.8
+      vite: 8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
 
   vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
@@ -17805,6 +19332,13 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -17833,6 +19367,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.3: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
 
   wsl-utils@1.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   js-yaml@5.0.0 - 5.2.1: ^5.2.2
   liquidjs@10.0.0 - 10.27.0: ^10.27.1
   protobufjs@8.0.0 - 8.7.1: ^8.7.2
+  sharp@0.34.5: 0.35.4
 
 importers:
 
@@ -3820,152 +3821,161 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-arm64@0.35.4':
+    resolution: {integrity: sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-x64@0.35.4':
+    resolution: {integrity: sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    resolution: {integrity: sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
+    resolution: {integrity: sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    resolution: {integrity: sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+  '@img/sharp-libvips-linux-arm64@1.3.3':
+    resolution: {integrity: sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    resolution: {integrity: sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
+    resolution: {integrity: sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    resolution: {integrity: sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+  '@img/sharp-libvips-linux-s390x@1.3.3':
+    resolution: {integrity: sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    resolution: {integrity: sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    resolution: {integrity: sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
+    resolution: {integrity: sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm64@0.35.4':
+    resolution: {integrity: sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm@0.35.4':
+    resolution: {integrity: sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-ppc64@0.35.4':
+    resolution: {integrity: sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-riscv64@0.35.4':
+    resolution: {integrity: sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-s390x@0.35.4':
+    resolution: {integrity: sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-x64@0.35.4':
+    resolution: {integrity: sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    resolution: {integrity: sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    resolution: {integrity: sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-wasm32@0.35.4':
+    resolution: {integrity: sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    resolution: {integrity: sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==}
+    engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-arm64@0.35.4':
+    resolution: {integrity: sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-ia32@0.35.4':
+    resolution: {integrity: sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==}
+    engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-x64@0.35.4':
+    resolution: {integrity: sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -9738,9 +9748,14 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  sharp@0.35.4:
+    resolution: {integrity: sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -11044,7 +11059,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       react-native-web: 0.21.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       reflect-metadata: 0.2.2
-      sharp: 0.34.5
+      sharp: 0.35.4(@types/node@26.4.1)
       storybook: 10.5.2(@types/react@19.2.18)(react@19.2.7)
       tailwindcss: 4.3.3
       vite: 8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -12751,98 +12766,108 @@ snapshots:
 
   '@img/colour@1.1.0': {}
 
-  '@img/sharp-darwin-arm64@0.34.5':
+  '@img/sharp-darwin-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.5':
+  '@img/sharp-darwin-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.3.3
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.4
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
+  '@img/sharp-libvips-darwin-x64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
+  '@img/sharp-libvips-linux-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
+  '@img/sharp-libvips-linux-arm@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
+  '@img/sharp-libvips-linux-s390x@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+  '@img/sharp-libvips-linux-x64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-linux-arm64@0.34.5':
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-arm@0.34.5':
+  '@img/sharp-linux-arm@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.3.3
     optional: true
 
-  '@img/sharp-linux-ppc64@0.34.5':
+  '@img/sharp-linux-ppc64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-riscv64@0.34.5':
+  '@img/sharp-linux-riscv64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-s390x@0.34.5':
+  '@img/sharp-linux-s390x@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.3.3
     optional: true
 
-  '@img/sharp-linux-x64@0.34.5':
+  '@img/sharp-linux-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.3.3
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
+  '@img/sharp-linuxmusl-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
+  '@img/sharp-linuxmusl-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
     optional: true
 
-  '@img/sharp-wasm32@0.34.5':
+  '@img/sharp-wasm32@0.35.4':
     dependencies:
       '@emnapi/runtime': 1.11.3
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.5':
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.4
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.5':
+  '@img/sharp-win32-arm64@0.35.4':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.5':
+  '@img/sharp-win32-ia32@0.35.4':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.4':
     optional: true
 
   '@inquirer/ansi@2.0.7': {}
@@ -18606,36 +18631,38 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sharp@0.34.5:
+  sharp@0.35.4(@types/node@26.4.1):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      '@img/sharp-darwin-arm64': 0.35.4
+      '@img/sharp-darwin-x64': 0.35.4
+      '@img/sharp-freebsd-wasm32': 0.35.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+      '@img/sharp-libvips-linux-arm': 1.3.3
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+      '@img/sharp-libvips-linux-x64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+      '@img/sharp-linux-arm': 0.35.4
+      '@img/sharp-linux-arm64': 0.35.4
+      '@img/sharp-linux-ppc64': 0.35.4
+      '@img/sharp-linux-riscv64': 0.35.4
+      '@img/sharp-linux-s390x': 0.35.4
+      '@img/sharp-linux-x64': 0.35.4
+      '@img/sharp-linuxmusl-arm64': 0.35.4
+      '@img/sharp-linuxmusl-x64': 0.35.4
+      '@img/sharp-webcontainers-wasm32': 0.35.4
+      '@img/sharp-win32-arm64': 0.35.4
+      '@img/sharp-win32-ia32': 0.35.4
+      '@img/sharp-win32-x64': 0.35.4
+      '@types/node': 26.4.1
 
   shebang-command@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,9 @@ allowBuilds:
   esbuild: true
   nx: true
   protobufjs: true
+  # Prebuilt @img/sharp-* binaries cover every platform we ship; the install
+  # script is only a compile-from-source fallback.
+  sharp: false
 
 onlyBuiltDependencies:
   - better-sqlite3
@@ -43,12 +46,13 @@ onlyBuiltDependencies:
 
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
-  - "@agimon-ai/foundation-exec@0.26.16||0.26.19"
-  - "@agimon-ai/foundation-port-registry@0.29.16||0.29.19||0.29.20||0.29.22"
-  - "@agimon-ai/foundation-process-registry@0.29.16||0.29.19||0.29.20||0.29.22"
+  - "@agimon-ai/foundation-exec@0.26.16||0.26.19||0.26.23"
+  - "@agimon-ai/foundation-port-registry@0.29.16||0.29.19||0.29.20||0.29.22||0.29.23"
+  - "@agimon-ai/foundation-process-registry@0.29.16||0.29.19||0.29.20||0.29.22||0.29.23"
   - "@agimon-ai/foundation-validator@0.26.16||0.26.19||0.26.20||0.26.22"
   - "@agimon-ai/log-sink-mcp@0.29.16||0.29.19||0.29.20||0.29.22"
   - "@agimon-ai/mcp-proxy@0.31.16||0.31.19||0.31.20||0.31.22"
+  - "@agimon-ai/style-system@0.1.1"
   - "@agimon-ai/vibe-lint@0.0.1-alpha.26||0.0.1-alpha.29"
   - "@agimon-ai/workflow-mcp@0.23.16||0.23.19"
   - "@earendil-works/chord@0.85.0||0.85.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ overrides:
   "js-yaml@5.0.0 - 5.2.1": "^5.2.2"
   "liquidjs@10.0.0 - 10.27.0": "^10.27.1"
   "protobufjs@8.0.0 - 8.7.1": "^8.7.2"
+  "sharp@0.34.5": 0.35.4
 
 # Oxlint resolves its type-aware backend from the workspace root.
 publicHoistPattern:

--- a/scripts/style-system-token-codemod.mjs
+++ b/scripts/style-system-token-codemod.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * One-shot codemod replacing ad-hoc Tailwind values with the design tokens
+ * declared in `packages/core/doompi-web-components/styles/tokens.css`.
+ *
+ * Every replacement happens in a SINGLE pass over each file. That is the whole
+ * point of the alternation below: `text-xs` maps to `text-sm` while `text-sm`
+ * itself maps to `text-base`, so running the rules one after another would
+ * apply a rule to output an earlier rule had just produced.
+ *
+ * Components whose `cva` size ladder needs a rung-by-rung decision are excluded
+ * and were converted by hand; a nearest-value mapping collapses two of their
+ * rungs onto the same token.
+ *
+ * Usage: node scripts/style-system-token-codemod.mjs [--dry]
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+/** Size ladders converted by hand, where nearest-value mapping collapses rungs. */
+const LADDER_FILES = new Set([
+  'packages/core/doompi-web-components/src/components/Badge.tsx',
+  'packages/core/doompi-web-components/src/components/Button.tsx',
+  'packages/core/doompi-web-components/src/components/Input.tsx',
+  'packages/core/doompi-web-components/src/components/StatusBadge.tsx',
+]);
+
+/**
+ * Ordered so the regex alternation prefers the longest source first; `text-[8px]`
+ * must win over any shorter prefix that could also match at the same position.
+ */
+const MAPPING = new Map([
+  // Font size: nine ad-hoc sizes collapse onto the five-step scale.
+  ['text-[8px]', 'text-2xs'],
+  ['text-[9px]', 'text-2xs'],
+  ['text-[10px]', 'text-xs'],
+  ['text-[11px]', 'text-sm'],
+  ['text-[12px]', 'text-sm'],
+  ['text-[13px]', 'text-base'],
+  ['text-[14px]', 'text-base'],
+  ['text-[15px]', 'text-lg'],
+  ['text-[16px]', 'text-lg'],
+  // Named steps keep their RENDERED size rather than their name: the scale
+  // redefines every step downward, so `text-xs` (was 12px) becomes `text-sm`.
+  ['text-xs', 'text-sm'],
+  ['text-sm', 'text-base'],
+  ['text-base', 'text-lg'],
+  // Radius.
+  ['rounded-[1px]', 'rounded-xs'],
+  ['rounded-[2px]', 'rounded-xs'],
+  ['rounded-[3px]', 'rounded-sm'],
+  ['rounded-[5px]', 'rounded-md'],
+  ['rounded-[10px]', 'rounded-lg'],
+  // Letter spacing.
+  ['tracking-[0.08em]', 'tracking-wide'],
+  ['tracking-[0.14em]', 'tracking-wider'],
+  ['tracking-[0.16em]', 'tracking-wider'],
+  ['tracking-[0.18em]', 'tracking-widest'],
+  ['tracking-[0.25em]', 'tracking-widest'],
+  // Line height maps onto Tailwind's stock steps, so no token is redefined.
+  ['leading-[1.5]', 'leading-normal'],
+  ['leading-[1.6]', 'leading-relaxed'],
+  ['leading-[15px]', 'leading-tight'],
+  ['leading-[17px]', 'leading-snug'],
+]);
+
+const escape = (value) => value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+
+/**
+ * A utility is a whole class token: it may follow a variant colon or a quote but
+ * never another word character or hyphen, which is what keeps `text-2xs` from
+ * matching the `text-xs` rule.
+ */
+const PATTERN = new RegExp(String.raw`(?<![\w-])(${[...MAPPING.keys()].map(escape).join('|')})(?![\w-])`, 'g');
+
+const dryRun = process.argv.includes('--dry');
+const files = execFileSync('git', ['ls-files', '*.tsx', '*.ts'], { encoding: 'utf8' })
+  .split('\n')
+  .filter((file) => file.length > 0 && !LADDER_FILES.has(file));
+
+const totals = new Map();
+let changedFiles = 0;
+
+for (const file of files) {
+  const before = readFileSync(file, 'utf8');
+  const after = before.replaceAll(PATTERN, (_match, token) => {
+    totals.set(token, (totals.get(token) ?? 0) + 1);
+    return MAPPING.get(token);
+  });
+  if (after === before) continue;
+  changedFiles += 1;
+  if (!dryRun) writeFileSync(file, after);
+}
+
+for (const [token, count] of [...totals.entries()].sort((a, b) => b[1] - a[1])) {
+  console.log(`${String(count).padStart(4)}  ${token}  ->  ${MAPPING.get(token)}`);
+}
+const replaced = [...totals.values()].reduce((sum, count) => sum + count, 0);
+console.log(`\n${replaced} replacements across ${changedFiles} files${dryRun ? ' (dry run)' : ''}`);

--- a/scripts/sync-registry-versions.mjs
+++ b/scripts/sync-registry-versions.mjs
@@ -1,0 +1,127 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import process from 'node:process';
+
+// The release cut bumps from whatever `package.json` holds on disk. That is only
+// safe while every previous cut was published and tagged, and this pipeline has
+// already proved it can lose a publish: a merge commit without the release title
+// skips `Release publish` entirely, so main carries a version the registry never
+// received, and the run after it bumps past a number that is still free.
+//
+// This raises each selected package to the highest alpha already published on its
+// own base version, so the bump that follows always lands above the registry and
+// can never collide with a version npm has served. A package on disk that is
+// already ahead of the registry is left alone: it is a legitimately unpublished
+// version, not drift.
+
+const REGISTRY = 'https://registry.npmjs.org';
+const ALPHA_VERSION = /^(\d+)\.(\d+)\.(\d+)-alpha\.(\d+)$/u;
+
+const [selection] = process.argv.slice(2);
+const selected = selection ? new Set(selection.split(',').filter(Boolean)) : undefined;
+
+const manifestPaths = execFileSync('node', ['scripts/list-packages.mjs', '--paths'], {
+  encoding: 'utf8',
+})
+  .split('\n')
+  .filter(Boolean);
+
+const raised = await Promise.all(manifestPaths.map(raiseToRegistryFloor));
+const changed = raised.filter(Boolean);
+
+if (changed.length === 0) {
+  console.log('Every selected package is at or above its registry version.');
+} else {
+  for (const line of changed) {
+    console.log(line);
+  }
+  console.log(`Raised ${changed.length} package version(s) to the registry floor.`);
+}
+
+async function raiseToRegistryFloor(manifestPath) {
+  const raw = fs.readFileSync(manifestPath, 'utf8');
+  const manifest = JSON.parse(raw);
+  if (selected && !selected.has(manifest.name)) {
+    return undefined;
+  }
+
+  const onDisk = parseAlphaVersion(manifest.version, `${manifest.name} in ${manifestPath}`);
+  const published = await publishedVersions(manifest.name);
+  const base = `${onDisk.base.join('.')}`;
+
+  const ahead = published.find((version) => compareBase(version.base, onDisk.base) > 0);
+  if (ahead) {
+    throw new Error(
+      `${manifest.name} is at ${manifest.version} on disk but ${ahead.raw} is already published. ` +
+        'The base version moved outside this pipeline, so the release cut cannot pick the next alpha safely.',
+    );
+  }
+
+  const highest = published
+    .filter((version) => compareBase(version.base, onDisk.base) === 0)
+    .reduce((max, version) => (version.counter > max ? version.counter : max), -1);
+  if (highest <= onDisk.counter) {
+    return undefined;
+  }
+
+  const next = `${base}-alpha.${highest}`;
+  fs.writeFileSync(manifestPath, replaceVersion(raw, manifest.version, next, manifestPath));
+  return `${manifest.name}: ${manifest.version} -> ${next} (highest published)`;
+}
+
+async function publishedVersions(name) {
+  // The abbreviated packument is the smaller read and still carries every version
+  // key, which is what the floor is derived from.
+  const response = await fetch(`${REGISTRY}/${name.replace('/', '%2F')}`, {
+    headers: { accept: 'application/vnd.npm.install-v1+json' },
+  });
+  if (response.status === 404) {
+    return [];
+  }
+  if (!response.ok) {
+    throw new Error(`Reading ${name} from the registry failed with HTTP ${response.status}.`);
+  }
+
+  const packument = await response.json();
+  return Object.keys(packument.versions ?? {})
+    .map((version) => {
+      const match = ALPHA_VERSION.exec(version);
+      return match
+        ? { raw: version, base: [Number(match[1]), Number(match[2]), Number(match[3])], counter: Number(match[4]) }
+        : undefined;
+    })
+    .filter(Boolean);
+}
+
+function parseAlphaVersion(version, subject) {
+  const match = ALPHA_VERSION.exec(version ?? '');
+  if (!match) {
+    throw new Error(
+      `${subject} is at ${version}, which is not an <major>.<minor>.<patch>-alpha.<counter> release version.`,
+    );
+  }
+  return { base: [Number(match[1]), Number(match[2]), Number(match[3])], counter: Number(match[4]) };
+}
+
+function compareBase(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) {
+      return left[index] - right[index];
+    }
+  }
+  return 0;
+}
+
+function replaceVersion(raw, current, next, manifestPath) {
+  // A surgical replacement of the top-level key keeps the file byte-identical
+  // everywhere else, so `pnpm fmt:check` stays happy.
+  const pattern = new RegExp(`(\\n  "version": ")${escapeForRegExp(current)}(")`, 'u');
+  if (!pattern.test(raw)) {
+    throw new Error(`${manifestPath} has no top-level "version": "${current}" to rewrite.`);
+  }
+  return raw.replace(pattern, `$1${next}$2`);
+}
+
+function escapeForRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}

--- a/scripts/sync-registry-versions.mjs
+++ b/scripts/sync-registry-versions.mjs
@@ -72,7 +72,7 @@ async function raiseToRegistryFloor(manifestPath) {
 async function publishedVersions(name) {
   // The abbreviated packument is the smaller read and still carries every version
   // key, which is what the floor is derived from.
-  const response = await fetch(`${REGISTRY}/${name.replace('/', '%2F')}`, {
+  const response = await fetch(`${REGISTRY}/${name.replaceAll('/', '%2F')}`, {
     headers: { accept: 'application/vnd.npm.install-v1+json' },
   });
   if (response.status === 404) {

--- a/style-system.config.yaml
+++ b/style-system.config.yaml
@@ -1,0 +1,50 @@
+# Workspace-root style-system configuration.
+#
+# Resolution order for a project is: `defaults` -> preset chain -> project config,
+# with whole-value replacement per field. Project configs are read only at the exact
+# `--app-path` given on the command line; there is no upward directory walk.
+#
+# `themePath` is workspace-root relative. `cssFiles` entries are app-relative and
+# must not contain `..`.
+root: true
+
+sharedComponentTags:
+  - style-system
+
+defaults:
+  # doompi-web-components is shadcn-on-Radix.
+  type: shadcn
+  # styles/tokens.css hardcodes `color-scheme: dark`. The light palette is swapped
+  # at runtime from JSON, so it is not discoverable from CSS.
+  colorScheme: dark
+
+presets:
+  # Shared component library rendered in isolation.
+  doom-components:
+    themePath: packages/core/doompi-web-components/styles/tokens.css
+    cssFiles:
+      - styles/preview.css
+    viewport:
+      width: 1280
+      height: 800
+
+  # The web client, which composes the library plus runtime-mounted plugin trees.
+  doom-web-app:
+    themePath: packages/core/doompi-web-components/styles/tokens.css
+    cssFiles:
+      - src/web/styles/app.css
+    viewport:
+      width: 1440
+      height: 900
+
+  # A plugin's own web tree. Its components consume the library as a package
+  # rather than by path, so the preview stylesheet imports the library's
+  # published `styles.css` instead of reaching across the workspace with `..`,
+  # which `cssFiles` forbids.
+  doom-plugin:
+    themePath: packages/core/doompi-web-components/styles/tokens.css
+    cssFiles:
+      - styles/preview.css
+    viewport:
+      width: 1280
+      height: 800


### PR DESCRIPTION
## Summary

- keep cockpit cost and context chips live during active turns
- preserve persona avatars when transcript protocol state is rebuilt
- register the pending thread subscription and improve release version reconciliation
- wire the shared style system across web packages

## Testing

- not run as part of PR creation