### PR TITLE
fix: tighten workflow dispatch and runtime caching

### DIFF
--- a/packages/clients/doompi-web/docs/bundle.md
+++ b/packages/clients/doompi-web/docs/bundle.md
@@ -116,9 +116,15 @@ The normal listener serves the shell built into `@agimon-ai/doompi-web`. `--asse
 
 The hub copies the selected `plugins/` output into its immutable publication store and signs a manifest containing each path, content type, byte length, and SHA-256 digest. It exposes raw publication bytes under composition- and revision-specific routes.
 
-The browser does not execute those raw URLs directly. Its service worker verifies the signature and every asset, commits the complete composition to Cache Storage, and exposes a verified local route. Only then does the shell load `composition.js` and its styles. Switching sessions activates the verified composition assigned to that session and disposes the previous session's plugin UI.
+The shell build also emits `bundle-asset-policy.json`. Vite derives it from original module ownership and emitted resource references, not hashed filenames. Only output exclusively owned by the known PDF or Mermaid graph, including the PDF worker resource, is optional. Shared and unclassified output stays in the required core. The signer includes this compact policy as a regular manifest v2 asset, so no manifest migration is needed.
 
-A failed verification or download leaves the previous verified revision in place. Assets from two revisions are not mixed.
+For the shell, the service worker first verifies the policy bytes. Missing or unsupported policy data falls back to eager activation. It revalidates matching bytes from the previous cache, fetches only missing or changed core assets with a four-request pool, and atomically commits a unique staging cache after all core checks pass. Reusable optional bytes are retained when possible, while the previous complete cache remains available for rollback and legacy offline use.
+
+An uncached optional shell asset is fetched only when requested. The worker resolves the exact path in the captured signed manifest, deduplicates concurrent misses, fetches revision-specific bytes, verifies them, and caches them before responding. It never serves an unlisted or unverified fallback. If that revision has already been superseded, one verified refresh uses the existing update notification and page reload path. Offline misses keep the feature's existing fallback or error state until reconnect and reload.
+
+Plugin composition delivery is unchanged. The browser does not execute plugin raw URLs directly. Its service worker verifies the signature and every plugin asset, commits the complete composition to Cache Storage, and exposes a verified local route. Only then does the shell load `composition.js` and its styles. Switching sessions activates the verified composition assigned to that session and disposes the previous session's plugin UI.
+
+A failed verification, download, or required cache write leaves the previous verified revision in place. Assets from two revisions are not mixed. Session data and private file bytes never enter these caches.
 
 ### Hub channels
 

--- a/packages/clients/doompi-web/docs/security.md
+++ b/packages/clients/doompi-web/docs/security.md
@@ -166,7 +166,11 @@ A browser plugin that calls `fetch` directly sends plaintext through the relay. 
 
 Payload encryption is insufficient if the provider can replace the JavaScript that performs encryption. DoomPi Web therefore signs the shell and each session plugin publication.
 
-The QR pins the host ECDSA public key and a minimum revision. A signed manifest records the revision, path, content type, byte length, and SHA-256 digest for every asset. The service worker downloads assets into a staging cache, verifies every byte, and commits the complete revision only after all checks pass. A failed update leaves the previous verified revision active.
+The QR pins the host ECDSA public key and a minimum revision. A signed manifest records the revision, path, content type, byte length, and SHA-256 digest for every asset. The service worker verifies an authenticated build policy, revalidates reusable cached bytes, and downloads the required core into a unique staging cache with bounded concurrency. It commits the core revision only after every required byte passes verification. A failed update leaves the previous verified revision active.
+
+The build policy remains an ordinary signed manifest v2 asset. It can defer only output proven by Vite's module and resource graph to belong to the PDF or Mermaid feature. Missing, unsupported, or inconsistent policy data makes every asset eager. Each deferred asset is fetched from its revision-specific raw path on first use, verified against the captured signed manifest, and only then cached and served. Concurrent requests for the same asset share one verified fetch. An unavailable obsolete revision triggers at most one normal verified refresh, then the existing bundle-update message reloads open pages.
+
+Legacy complete caches remain available offline after an upgrade. Until a successful online activation stores the signed manifest and policy metadata, that legacy state is cache-only and cannot fetch a missing asset. Session data, private file contents, and plugin caches are outside this policy.
 
 The public routes are revision-specific:
 

--- a/packages/clients/doompi-web/src/adapters/bundleAssetPolicy.ts
+++ b/packages/clients/doompi-web/src/adapters/bundleAssetPolicy.ts
@@ -1,0 +1,152 @@
+import type { Plugin } from 'vite';
+import {
+  BUNDLE_ASSET_POLICY_PATH,
+  BUNDLE_ASSET_POLICY_VERSION,
+  type BundleAssetPolicy,
+} from '../types/bundleAssetPolicy.ts';
+
+const OPTIONAL_PACKAGES = ['/node_modules/mermaid/', '/node_modules/pdfjs-dist/'] as const;
+
+interface PolicyOutput {
+  type: 'asset' | 'chunk';
+  isEntry?: boolean;
+  facadeModuleId?: string | null;
+  modules?: Record<string, unknown>;
+  imports?: string[];
+  dynamicImports?: string[];
+  referencedFiles?: string[];
+  code?: string;
+  source?: string | Uint8Array;
+  viteMetadata?: { importedAssets?: Set<string> };
+}
+
+function packageOwner(output: PolicyOutput, owned: ReadonlyMap<string, ReadonlySet<string>>): string | undefined {
+  const ids = Object.keys(output.modules ?? {});
+  return OPTIONAL_PACKAGES.find(
+    (dependency) =>
+      ids.some((id) => id.replaceAll('\\', '/').includes(dependency)) &&
+      ids.every((id) => owned.get(dependency)?.has(id)),
+  );
+}
+
+function references(output: PolicyOutput): string[] {
+  if (output.type === 'asset') return [];
+  return [
+    ...(output.imports ?? []),
+    ...(output.dynamicImports ?? []),
+    ...(output.referencedFiles ?? []),
+    ...(output.viteMetadata?.importedAssets ?? []),
+  ];
+}
+
+/** Classifies only output owned exclusively by a known optional dependency graph. */
+export function classifyOptionalBundleAssets(
+  bundle: Readonly<Record<string, PolicyOutput>>,
+  moduleDependencies?: (id: string) => readonly string[] | undefined,
+): string[] {
+  const outputs = new Map(Object.entries(bundle));
+  const owned = new Map<string, Set<string>>();
+  for (const dependency of OPTIONAL_PACKAGES) {
+    const modules = new Set<string>();
+    const visit = (id: string): void => {
+      // Application and unresolved virtual modules never inherit optional ownership.
+      if (modules.has(id) || !id.replaceAll('\\', '/').includes('/node_modules/')) return;
+      modules.add(id);
+      for (const imported of moduleDependencies?.(id) ?? []) visit(imported);
+    };
+    for (const output of outputs.values()) {
+      for (const id of Object.keys(output.modules ?? {})) {
+        if (id.replaceAll('\\', '/').includes(dependency)) visit(id);
+      }
+    }
+    owned.set(dependency, modules);
+  }
+  const graphReferences = (output: PolicyOutput): string[] => {
+    const source =
+      output.code ??
+      (typeof output.source === 'string'
+        ? output.source
+        : output.source === undefined
+          ? ''
+          : new TextDecoder().decode(output.source));
+    return [
+      ...references(output),
+      ...[...outputs]
+        .filter(([fileName, candidate]) => candidate.type === 'asset' && source.includes(fileName))
+        .map(([fileName]) => fileName),
+    ];
+  };
+  const optionalRoots = new Map<string, string>();
+  for (const [fileName, output] of outputs) {
+    if (output.type !== 'chunk') continue;
+    const owner = packageOwner(output, owned);
+    const facade = output.facadeModuleId?.replaceAll('\\', '/');
+    if (
+      owner !== undefined &&
+      (!output.isEntry || OPTIONAL_PACKAGES.some((dependency) => facade?.includes(dependency)))
+    ) {
+      optionalRoots.set(fileName, owner);
+    }
+  }
+
+  const eager = new Set<string>();
+  const visitEager = (fileName: string): void => {
+    if (eager.has(fileName)) return;
+    eager.add(fileName);
+    const output = outputs.get(fileName);
+    if (output === undefined) return;
+    for (const reference of graphReferences(output)) {
+      const deferredRoot = optionalRoots.has(reference) && output.dynamicImports?.includes(reference);
+      if (!deferredRoot) visitEager(reference);
+    }
+  };
+  for (const [fileName, output] of outputs) {
+    if (fileName === 'index.html' || (output.type === 'chunk' && output.isEntry && !optionalRoots.has(fileName)))
+      visitEager(fileName);
+  }
+
+  const optional = new Set<string>();
+  const visitOptional = (fileName: string, owner: string): void => {
+    if (eager.has(fileName) || optional.has(fileName)) return;
+    const output = outputs.get(fileName);
+    if (output === undefined) return;
+    if (output.type === 'chunk') {
+      const ids = Object.keys(output.modules ?? {});
+      if (ids.length === 0 || !ids.every((id) => owned.get(owner)?.has(id))) {
+        visitEager(fileName);
+        return;
+      }
+    }
+    optional.add(fileName);
+    for (const reference of graphReferences(output)) {
+      const referencedRootOwner = optionalRoots.get(reference);
+      if (referencedRootOwner === undefined || referencedRootOwner === owner) visitOptional(reference, owner);
+    }
+  };
+  for (const [fileName, owner] of optionalRoots) visitOptional(fileName, owner);
+  return [...optional]
+    .filter((fileName) => !eager.has(fileName) && !fileName.endsWith('.map'))
+    .map((fileName) => `/${fileName}`)
+    .sort();
+}
+
+/** Emits an authenticated v1 policy derived from Rollup's module and resource graph. */
+export function bundleAssetPolicyPlugin(): Plugin {
+  return {
+    name: 'doompi-bundle-asset-policy',
+    generateBundle(_options, bundle) {
+      const policy: BundleAssetPolicy = {
+        version: BUNDLE_ASSET_POLICY_VERSION,
+        optional: classifyOptionalBundleAssets(bundle, (id) => {
+          const info = this.getModuleInfo(id);
+          return info === null ? undefined : [...info.importedIds, ...info.dynamicallyImportedIds];
+        }),
+      };
+      this.emitFile({
+        type: 'asset',
+        fileName: BUNDLE_ASSET_POLICY_PATH.slice(1),
+        source: `${JSON.stringify(policy)}\n`,
+      });
+    },
+  };
+}

--- a/packages/clients/doompi-web/src/adapters/webBundler.ts
+++ b/packages/clients/doompi-web/src/adapters/webBundler.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { PLUGIN_ROOTS_FILE } from '../services/webDevRoots.ts';
+import { bundleAssetPolicyPlugin } from './bundleAssetPolicy.ts';
 import { SERVER_REGISTRY_FILE, webHostPackageRoot, writeSyncWebPluginModules } from './webPluginGenerate.ts';
 import { scanWebPlugins } from './webPluginScan.ts';
 import {
@@ -84,7 +85,7 @@ export async function bundleCockpitWeb(options: BundleCockpitWebOptions): Promis
     envDir: false,
     logLevel: 'warn',
     root: clientRoot,
-    plugins: [webPluginOverridePlugin(clientRoot, generated), react(), tailwindcss()],
+    plugins: [webPluginOverridePlugin(clientRoot, generated), react(), tailwindcss(), bundleAssetPolicyPlugin()],
     resolve: {
       dedupe: [...DEDUPED_RUNTIMES],
       alias: [...webPluginRuntimeAliases(clientRoot), webPluginCssAlias(generated)],

--- a/packages/clients/doompi-web/src/pwa/bundleCache.ts
+++ b/packages/clients/doompi-web/src/pwa/bundleCache.ts
@@ -1,3 +1,5 @@
+import type { BundleManifest, SignedBundleManifest } from '@agimon-ai/doompi-web-security/browser';
+
 export const PWA_DATABASE = 'doompi-pwa';
 export const PWA_DATABASE_VERSION = 1;
 export const PWA_STATE_STORE = 'state';
@@ -9,6 +11,12 @@ export interface ActiveBundleState {
   manifestDigest: string;
   revision: number;
   cacheName: string;
+  /** Absent on v1 state written before lazy verified assets existed. */
+  manifest?: BundleManifest;
+  /** Reverified after worker restarts before metadata can authorize asset delivery. */
+  signedManifest?: SignedBundleManifest;
+  /** Absent means the legacy cache is usable offline, but cannot fetch misses. */
+  optionalAssetPaths?: string[];
 }
 
 export interface VerifiedPluginCompositionState {

--- a/packages/clients/doompi-web/src/pwa/serviceWorker.ts
+++ b/packages/clients/doompi-web/src/pwa/serviceWorker.ts
@@ -2,7 +2,10 @@
 
 import {
   BUNDLE_MANIFEST_ROUTE,
+  type BundleAsset,
+  type BundleManifest,
   canonicalManifest,
+  type SignedBundleManifest,
   verifyBundleAsset,
   verifySignedBundleManifest,
 } from '@agimon-ai/doompi-web-security/browser';
@@ -18,6 +21,7 @@ import {
   type ActiveBundleState,
   type VerifiedPluginCompositionState,
 } from './bundleCache.ts';
+import { BUNDLE_ASSET_POLICY_PATH, parseBundleAssetPolicy } from '../types/bundleAssetPolicy.ts';
 import { RAW_BUNDLE_PREFIX, trustedNetworkPath } from './networkPaths.ts';
 
 const worker = self as unknown as ServiceWorkerGlobalScope;
@@ -33,6 +37,7 @@ const RESET_MESSAGE = 'doompi:reset-bundle-trust';
 const PLUGIN_FETCH_MESSAGE = 'doompi:plugin-fetch';
 const PLUGIN_FETCH_RESULT_MESSAGE = 'doompi:plugin-fetch-result';
 const PLUGIN_FETCH_TIMEOUT_MS = 120_000;
+const ASSET_FETCH_CONCURRENCY = 4;
 
 interface ActivateBundleMessage {
   type: typeof ACTIVATE_MESSAGE;
@@ -190,12 +195,204 @@ async function manifestDigest(manifest: Parameters<typeof canonicalManifest>[0])
   return hex(await crypto.subtle.digest('SHA-256', bytes));
 }
 
+function assetResponse(asset: BundleAsset, bytes: ArrayBuffer): Response {
+  return new Response(bytes, {
+    status: 200,
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Length': String(asset.byteLength),
+      'Content-Type': asset.contentType,
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}
+
+const optionalFetches = new Map<string, Promise<Response>>();
+const assetControllers = new Set<AbortController>();
+const assetWaiters: Array<() => void> = [];
+let activeAssetFetches = 0;
+let trustEpoch = 0;
+let trustOperation: Promise<unknown> = Promise.resolve();
+
+function queueTrustOperation<T>(operation: (epoch: number) => Promise<T>): Promise<T> {
+  const epoch = trustEpoch;
+  const queued = trustOperation.then(
+    async () => await operation(epoch),
+    async () => await operation(epoch),
+  );
+  trustOperation = queued;
+  return queued;
+}
+
+async function fetchRawAsset(manifest: BundleManifest, asset: BundleAsset): Promise<ArrayBuffer> {
+  const epoch = trustEpoch;
+  if (activeAssetFetches >= ASSET_FETCH_CONCURRENCY) {
+    await new Promise<void>((resolve) => assetWaiters.push(resolve));
+  } else activeAssetFetches += 1;
+  const controller = new AbortController();
+  assetControllers.add(controller);
+  try {
+    if (epoch !== trustEpoch) throw new Error('Bundle trust changed before the asset download.');
+    const source = `${RAW_BUNDLE_PREFIX}${String(manifest.revision)}${asset.path}`;
+    const response = await fetch(source, {
+      credentials: 'include',
+      cache: 'no-store',
+      redirect: 'error',
+      signal: controller.signal,
+    });
+    const responseUrl = new URL(response.url);
+    if (
+      !response.ok ||
+      response.redirected ||
+      responseUrl.origin !== worker.location.origin ||
+      responseUrl.pathname !== source
+    ) {
+      throw new Error(`The raw bundle asset ${asset.path} was unavailable.`);
+    }
+    const bytes = await response.arrayBuffer();
+    const result = await verifyBundleAsset(manifest, asset.path, bytes);
+    if (!result.ok) throw new Error(`The raw bundle asset ${asset.path} failed ${result.failure.code}.`);
+    return bytes;
+  } finally {
+    assetControllers.delete(controller);
+    const next = assetWaiters.shift();
+    if (next === undefined) activeAssetFetches -= 1;
+    else next();
+  }
+}
+
+async function verifiedCachedBytes(
+  cache: Cache | undefined,
+  manifest: BundleManifest,
+  asset: BundleAsset,
+): Promise<ArrayBuffer | undefined> {
+  const cached = await cache?.match(asset.path);
+  if (cached === undefined || cached.status !== 200) return undefined;
+  const bytes = await cached.arrayBuffer();
+  return (await verifyBundleAsset(manifest, asset.path, bytes)).ok ? bytes : undefined;
+}
+
+async function runBounded<T>(values: readonly T[], operation: (value: T) => Promise<void>): Promise<void> {
+  let index = 0;
+  let failed = false;
+  const results = await Promise.allSettled(
+    Array.from({ length: Math.min(ASSET_FETCH_CONCURRENCY, values.length) }, async () => {
+      while (!failed && index < values.length) {
+        const value = values[index++];
+        try {
+          if (value !== undefined) await operation(value);
+        } catch (error) {
+          failed = true;
+          throw error;
+        }
+      }
+    }),
+  );
+  const rejected = results.find((result) => result.status === 'rejected');
+  if (rejected?.status === 'rejected') {
+    const error: unknown = rejected.reason;
+    throw error instanceof Error ? error : new Error('An asset operation failed.', { cause: error });
+  }
+}
+
+function optionalPaths(manifest: BundleManifest, bytes: ArrayBuffer): string[] {
+  try {
+    const policy = parseBundleAssetPolicy(JSON.parse(new TextDecoder().decode(bytes)) as unknown);
+    if (
+      policy !== undefined &&
+      policy.optional.every(
+        (assetPath) =>
+          assetPath !== '/index.html' &&
+          assetPath !== BUNDLE_ASSET_POLICY_PATH &&
+          manifest.assets.some((asset) => asset.path === assetPath),
+      )
+    ) {
+      return policy.optional;
+    }
+  } catch {
+    // Authenticated but unsupported policy means eager activation, never an integrity bypass.
+  }
+  return [];
+}
+
+async function verifiedStateManifest(state: ActiveBundleState): Promise<BundleManifest | undefined> {
+  const verified = await verifySignedBundleManifest(state.signedManifest, state.signerPublicKey, state.revision);
+  if (
+    !verified.ok ||
+    verified.manifest.revision !== state.revision ||
+    (await manifestDigest(verified.manifest)) !== state.manifestDigest
+  )
+    return undefined;
+  return verified.manifest;
+}
+
+async function lazyVerifiedResponse(
+  state: ActiveBundleState,
+  manifest: BundleManifest,
+  asset: BundleAsset,
+): Promise<Response> {
+  const key = `${state.cacheName}:${state.manifestDigest}:${asset.path}`;
+  const existing = optionalFetches.get(key);
+  if (existing !== undefined) return (await existing).clone();
+  const epoch = trustEpoch;
+  const fetching = (async () => {
+    const bytes = await fetchRawAsset(manifest, asset);
+    const current = await readActiveBundle();
+    if (
+      epoch !== trustEpoch ||
+      current?.cacheName !== state.cacheName ||
+      current.manifestDigest !== state.manifestDigest
+    ) {
+      throw new Error('The active bundle changed while the optional asset was downloading.');
+    }
+    const response = assetResponse(asset, bytes);
+    const cache = await caches.open(state.cacheName);
+    await cache.put(asset.path, response.clone());
+    const committed = await readActiveBundle();
+    if (
+      epoch !== trustEpoch ||
+      committed?.cacheName !== state.cacheName ||
+      committed.manifestDigest !== state.manifestDigest
+    ) {
+      if (epoch !== trustEpoch) await caches.delete(state.cacheName);
+      else await cache.delete(asset.path);
+      throw new Error('The active bundle changed while the optional asset was being cached.');
+    }
+    return response;
+  })();
+  optionalFetches.set(key, fetching);
+  try {
+    return (await fetching).clone();
+  } finally {
+    if (optionalFetches.get(key) === fetching) optionalFetches.delete(key);
+  }
+}
+
 async function verifiedResponse(state: ActiveBundleState, request: Request): Promise<Response> {
+  const unavailable = () => new Response('That verified cockpit asset is unavailable.', { status: 404 });
+  if (request.method !== 'GET')
+    return new Response('Only GET assets are supported.', { status: 405, headers: { Allow: 'GET' } });
   const cache = await caches.open(state.cacheName);
-  const url = new URL(request.url);
-  const key = request.mode === 'navigate' ? '/index.html' : url.pathname;
-  const cached = await cache.match(key);
-  return cached ?? new Response('That verified cockpit asset is unavailable.', { status: 404 });
+  const key = request.mode === 'navigate' ? '/index.html' : new URL(request.url).pathname;
+  if (state.signedManifest === undefined) {
+    // Old complete caches retain their original offline contract, but cannot authorize new downloads.
+    if (state.manifest !== undefined || state.optionalAssetPaths !== undefined) return unavailable();
+    return (await cache.match(key)) ?? unavailable();
+  }
+  const manifest = await verifiedStateManifest(state);
+  const asset = manifest?.assets.find((candidate) => candidate.path === key);
+  if (manifest === undefined || asset === undefined) return unavailable();
+  const bytes = await verifiedCachedBytes(cache, manifest, asset);
+  if (bytes !== undefined) return assetResponse(asset, bytes);
+  const policyAsset = manifest.assets.find((candidate) => candidate.path === BUNDLE_ASSET_POLICY_PATH);
+  const policyBytes = policyAsset === undefined ? undefined : await verifiedCachedBytes(cache, manifest, policyAsset);
+  if (policyBytes === undefined || !optionalPaths(manifest, policyBytes).includes(key)) return unavailable();
+  try {
+    return await lazyVerifiedResponse(state, manifest, asset);
+  } catch {
+    await revalidatePinnedBundle(state);
+    return unavailable();
+  }
 }
 
 async function fetchManifest(): Promise<unknown> {
@@ -232,7 +429,9 @@ async function prunePluginCompositions(): Promise<void> {
 async function activatePluginComposition(
   request: ActivatePluginCompositionMessage,
   fetchPlugin: (path: string) => Promise<Response>,
+  expectedEpoch: number,
 ): Promise<WorkerReply> {
+  if (expectedEpoch !== trustEpoch) return { ok: false, code: 'trust-reset', message: 'Bundle trust was reset.' };
   const host = await readActiveBundle();
   if (host === undefined) {
     return { ok: false, code: 'no-pin', message: 'No trusted cockpit signing key is pinned.' };
@@ -258,7 +457,9 @@ async function activatePluginComposition(
       return { ok: false, code: 'revision-conflict', message: 'The plugin revision was reused for different bytes.' };
     }
     if (await caches.has(previous.cacheName)) {
+      if (expectedEpoch !== trustEpoch) return { ok: false, code: 'trust-reset', message: 'Bundle trust was reset.' };
       await commitVerifiedPluginComposition({ ...previous, lastUsedAt: Date.now() });
+      if (expectedEpoch !== trustEpoch) return { ok: false, code: 'trust-reset', message: 'Bundle trust was reset.' };
       return { ok: true, revision: previous.revision };
     }
   }
@@ -296,7 +497,9 @@ async function activatePluginComposition(
       verifiedAssetBaseUrl: request.verifiedAssetBaseUrl,
       lastUsedAt: Date.now(),
     };
+    if (expectedEpoch !== trustEpoch) throw new Error('Bundle trust was reset during plugin activation.');
     await commitVerifiedPluginComposition(next);
+    if (expectedEpoch !== trustEpoch) throw new Error('Bundle trust was reset during plugin activation.');
     try {
       if (previous !== undefined && previous.cacheName !== next.cacheName) await caches.delete(previous.cacheName);
       await prunePluginCompositions();
@@ -306,6 +509,7 @@ async function activatePluginComposition(
     return { ok: true, revision: next.revision };
   } catch (error) {
     await caches.delete(cacheName);
+    if (expectedEpoch !== trustEpoch) return { ok: false, code: 'trust-reset', message: 'Bundle trust was reset.' };
     return { ok: false, code: 'asset-verification', message: error instanceof Error ? error.message : String(error) };
   }
 }
@@ -315,11 +519,12 @@ const pluginActivations = new Map<string, Promise<WorkerReply>>();
 function queuePluginActivation(
   request: ActivatePluginCompositionMessage,
   fetchPlugin: (path: string) => Promise<Response>,
+  expectedEpoch: number,
 ): Promise<WorkerReply> {
   const previous = pluginActivations.get(request.compositionId) ?? Promise.resolve({ ok: true } as WorkerReply);
   const activation = previous.then(
-    async () => await activatePluginComposition(request, fetchPlugin),
-    async () => await activatePluginComposition(request, fetchPlugin),
+    async () => await activatePluginComposition(request, fetchPlugin, expectedEpoch),
+    async () => await activatePluginComposition(request, fetchPlugin, expectedEpoch),
   );
   pluginActivations.set(request.compositionId, activation);
   void activation.then(
@@ -334,6 +539,8 @@ function queuePluginActivation(
 }
 
 async function verifiedPluginResponse(request: Request): Promise<Response> {
+  const expectedEpoch = trustEpoch;
+  const host = await readActiveBundle();
   const url = new URL(request.url);
   const [compositionId, revisionText] = url.pathname.slice(VERIFIED_PLUGIN_PREFIX.length).split('/', 2);
   if (compositionId === undefined || revisionText === undefined) {
@@ -341,19 +548,23 @@ async function verifiedPluginResponse(request: Request): Promise<Response> {
   }
   const state = await readVerifiedPluginComposition(compositionId);
   if (
+    host === undefined ||
     state === undefined ||
+    state.signerPublicKey !== host.signerPublicKey ||
     String(state.revision) !== revisionText ||
     !url.pathname.startsWith(`${state.verifiedAssetBaseUrl}/`)
   ) {
     return new Response('That verified plugin asset is unavailable.', { status: 404 });
   }
   const cache = await caches.open(state.cacheName);
-  return (
-    (await cache.match(url.pathname)) ?? new Response('That verified plugin asset is unavailable.', { status: 404 })
-  );
+  const response = await cache.match(url.pathname);
+  return expectedEpoch === trustEpoch && response !== undefined
+    ? response
+    : new Response('That verified plugin asset is unavailable.', { status: 404 });
 }
 
-async function activateBundle(publicKey: string, minimumRevision: number): Promise<WorkerReply> {
+async function activateBundle(publicKey: string, minimumRevision: number, expectedEpoch: number): Promise<WorkerReply> {
+  if (expectedEpoch !== trustEpoch) return { ok: false, code: 'trust-reset', message: 'Bundle trust was reset.' };
   const previous = await readActiveBundle();
   if (previous !== undefined && previous.signerPublicKey !== publicKey) {
     return { ok: false, code: 'signer-mismatch', message: 'The host signing key does not match the pinned key.' };
@@ -371,58 +582,106 @@ async function activateBundle(publicKey: string, minimumRevision: number): Promi
   if (!verified.ok)
     return { ok: false, code: verified.failure.code, message: 'The signed bundle manifest was refused.' };
   const digest = await manifestDigest(verified.manifest);
-  if (previous?.revision === verified.manifest.revision) {
-    if (previous.manifestDigest !== digest) {
-      return {
-        ok: false,
-        code: 'revision-conflict',
-        message: 'The host reused a revision for different bundle bytes.',
-      };
-    }
-    if (await caches.has(previous.cacheName)) return { ok: true, revision: previous.revision };
+  if (previous?.revision === verified.manifest.revision && previous.manifestDigest !== digest) {
+    return {
+      ok: false,
+      code: 'revision-conflict',
+      message: 'The host reused a revision for different bundle bytes.',
+    };
   }
 
-  const cacheName = `${CACHE_PREFIX}${String(verified.manifest.revision)}-${digest.slice(0, 16)}`;
-  await caches.delete(cacheName);
+  const cacheName = `${CACHE_PREFIX}${String(verified.manifest.revision)}-${digest.slice(0, 16)}-${crypto.randomUUID()}`;
   const staging = await caches.open(cacheName);
+  const reusable =
+    previous !== undefined && (await caches.has(previous.cacheName))
+      ? await caches.open(previous.cacheName)
+      : undefined;
   try {
-    for (const asset of verified.manifest.assets) {
-      const source = `${RAW_BUNDLE_PREFIX}${String(verified.manifest.revision)}${asset.path}`;
-      const response = await fetch(source, {
-        credentials: 'include',
-        cache: 'no-store',
-        redirect: 'error',
-      });
-      if (!response.ok || response.redirected || new URL(response.url).origin !== worker.location.origin) {
-        throw new Error(`The raw bundle asset ${asset.path} was unavailable.`);
-      }
-      const bytes = await response.arrayBuffer();
-      const assetResult = await verifyBundleAsset(verified.manifest, asset.path, bytes);
-      if (!assetResult.ok) throw new Error(`The raw bundle asset ${asset.path} failed ${assetResult.failure.code}.`);
-      await staging.put(
-        asset.path,
-        new Response(bytes, {
-          status: 200,
-          headers: {
-            'Cache-Control': 'no-store',
-            'Content-Length': String(asset.byteLength),
-            'Content-Type': asset.contentType,
-            'X-Content-Type-Options': 'nosniff',
-          },
-        }),
-      );
+    const policyAsset = verified.manifest.assets.find((asset) => asset.path === BUNDLE_ASSET_POLICY_PATH);
+    let optionalAssetPaths: string[] = [];
+    if (policyAsset !== undefined) {
+      const policyBytes =
+        (await verifiedCachedBytes(reusable, verified.manifest, policyAsset)) ??
+        (await fetchRawAsset(verified.manifest, policyAsset));
+      await staging.put(policyAsset.path, assetResponse(policyAsset, policyBytes));
+      optionalAssetPaths = optionalPaths(verified.manifest, policyBytes);
     }
 
+    const optional = new Set(optionalAssetPaths);
+    const required = verified.manifest.assets.filter(
+      (asset) => asset.path !== BUNDLE_ASSET_POLICY_PATH && !optional.has(asset.path),
+    );
+    if (
+      previous?.revision === verified.manifest.revision &&
+      reusable !== undefined &&
+      (policyAsset === undefined || (await verifiedCachedBytes(reusable, verified.manifest, policyAsset)) !== undefined)
+    ) {
+      let complete = true;
+      await runBounded(required, async (asset) => {
+        if ((await verifiedCachedBytes(reusable, verified.manifest, asset)) === undefined) complete = false;
+      });
+      if (complete) {
+        if (expectedEpoch !== trustEpoch) throw new Error('Bundle trust was reset during activation.');
+        await commitActiveBundle({
+          ...previous,
+          manifest: verified.manifest,
+          signedManifest: envelope as SignedBundleManifest,
+          optionalAssetPaths,
+        });
+        try {
+          await caches.delete(cacheName);
+        } catch {
+          /* The active cache is untouched; staging cleanup is best effort. */
+        }
+        return { ok: true, revision: previous.revision };
+      }
+    }
+    await runBounded(required, async (asset) => {
+      const bytes =
+        (await verifiedCachedBytes(reusable, verified.manifest, asset)) ??
+        (await fetchRawAsset(verified.manifest, asset));
+      await staging.put(asset.path, assetResponse(asset, bytes));
+    });
+
+    // Reusable optional bytes improve offline updates, but a failed optional copy cannot block core activation.
+    await runBounded(
+      verified.manifest.assets.filter((asset) => optional.has(asset.path)),
+      async (asset) => {
+        try {
+          const bytes = await verifiedCachedBytes(reusable, verified.manifest, asset);
+          if (bytes !== undefined) await staging.put(asset.path, assetResponse(asset, bytes));
+        } catch {
+          // The optional asset remains lazy and can be fetched on demand.
+        }
+      },
+    );
+
+    if (expectedEpoch !== trustEpoch) throw new Error('Bundle trust was reset during activation.');
     const next: ActiveBundleState = {
       signerPublicKey: publicKey,
       manifestDigest: digest,
       revision: verified.manifest.revision,
       cacheName,
+      manifest: verified.manifest,
+      signedManifest: envelope as SignedBundleManifest,
+      optionalAssetPaths,
     };
     await commitActiveBundle(next);
-    for (const held of await caches.keys()) {
-      if (held.startsWith(CACHE_PREFIX) && held !== next.cacheName && held !== previous?.cacheName)
-        await caches.delete(held);
+    try {
+      for (const held of await caches.keys()) {
+        if (held.startsWith(CACHE_PREFIX) && held !== next.cacheName && held !== previous?.cacheName) {
+          await caches.delete(held);
+        }
+      }
+    } catch {
+      // The new core is committed. A later activation retries best-effort cleanup.
+    }
+    if (previous !== undefined && next.revision > previous.revision) {
+      try {
+        await announceRevision(next.revision, expectedEpoch);
+      } catch {
+        /* A closed client cannot roll back committed assets. */
+      }
     }
     return { ok: true, revision: next.revision };
   } catch (error) {
@@ -431,29 +690,47 @@ async function activateBundle(publicKey: string, minimumRevision: number): Promi
   }
 }
 
-async function handleMessage(request: WorkerRequest, port: MessagePort): Promise<WorkerReply> {
-  if (request.type === RESET_MESSAGE) {
-    for (const held of await caches.keys()) {
-      if (held.startsWith(CACHE_PREFIX) || held.startsWith(PLUGIN_CACHE_PREFIX)) await caches.delete(held);
-    }
+async function resetBundleTrust(): Promise<WorkerReply> {
+  await clearActiveBundle();
+  try {
     for (const plugin of await listVerifiedPluginCompositions()) {
       await clearVerifiedPluginComposition(plugin.compositionId);
     }
-    await clearActiveBundle();
-    return { ok: true };
+  } catch {
+    // Durable host trust is already cleared. Plugin record cleanup is best effort.
+  }
+  try {
+    for (const held of await caches.keys()) {
+      if (held.startsWith(CACHE_PREFIX) || held.startsWith(PLUGIN_CACHE_PREFIX)) await caches.delete(held);
+    }
+  } catch {
+    // Durable host trust is already cleared. Cache cleanup is best effort.
+  }
+  return { ok: true };
+}
+
+async function handleMessage(request: WorkerRequest, port: MessagePort): Promise<WorkerReply> {
+  if (request.type === RESET_MESSAGE) {
+    trustEpoch += 1;
+    for (const controller of assetControllers) controller.abort();
+    return await queueTrustOperation(async () => await resetBundleTrust());
   }
   if (request.type === ACTIVATE_MESSAGE) {
-    return await activateBundle(request.publicKey, request.minimumRevision);
+    return await queueTrustOperation(
+      async (epoch) => await activateBundle(request.publicKey, request.minimumRevision, epoch),
+    );
   }
   if (request.type === ACTIVATE_PLUGIN_MESSAGE) {
     const fetchPlugin = request.relayThroughClient
       ? (path: string) => fetchThroughClient(port, path)
       : fetchPluginDirect;
-    return await queuePluginActivation(request, fetchPlugin);
+    return await queueTrustOperation(async (epoch) => await queuePluginActivation(request, fetchPlugin, epoch));
   }
-  const current = await readActiveBundle();
-  if (current === undefined) return { ok: false, code: 'no-pin', message: 'No host signing key is pinned.' };
-  return await activateBundle(current.signerPublicKey, current.revision);
+  return await queueTrustOperation(async (epoch) => {
+    const current = await readActiveBundle();
+    if (current === undefined) return { ok: false, code: 'no-pin', message: 'No host signing key is pinned.' };
+    return await activateBundle(current.signerPublicKey, current.revision, epoch);
+  });
 }
 
 worker.addEventListener('install', (event) => {
@@ -497,10 +774,11 @@ worker.addEventListener('message', (event) => {
  */
 let revalidation: Promise<void> | undefined;
 
-async function announceRevision(revision: number): Promise<void> {
+async function announceRevision(revision: number, epoch: number): Promise<void> {
   const windows = await worker.clients.matchAll({ type: 'window' });
   for (const client of windows) {
-    client.postMessage({ type: BUNDLE_UPDATED_MESSAGE, revision } satisfies BundleUpdatedMessage);
+    if (epoch === trustEpoch)
+      client.postMessage({ type: BUNDLE_UPDATED_MESSAGE, revision } satisfies BundleUpdatedMessage);
   }
 }
 
@@ -516,10 +794,16 @@ async function announceRevision(revision: number): Promise<void> {
 function revalidatePinnedBundle(state: ActiveBundleState): Promise<void> {
   revalidation ??= (async () => {
     try {
-      const reply = await activateBundle(state.signerPublicKey, state.revision);
-      if (reply.ok && reply.revision !== undefined && reply.revision > state.revision) {
-        await announceRevision(reply.revision);
-      }
+      await queueTrustOperation(async (epoch) => {
+        const current = await readActiveBundle();
+        if (
+          current === undefined ||
+          current.cacheName !== state.cacheName ||
+          current.signerPublicKey !== state.signerPublicKey
+        )
+          return;
+        await activateBundle(current.signerPublicKey, current.revision, epoch);
+      });
     } catch {
       // A revalidation that throws leaves the pin and the cache untouched.
     } finally {

--- a/packages/clients/doompi-web/src/types/bundleAssetPolicy.ts
+++ b/packages/clients/doompi-web/src/types/bundleAssetPolicy.ts
@@ -1,0 +1,34 @@
+export const BUNDLE_ASSET_POLICY_PATH = '/bundle-asset-policy.json';
+export const BUNDLE_ASSET_POLICY_VERSION = 1;
+
+export interface BundleAssetPolicy {
+  version: typeof BUNDLE_ASSET_POLICY_VERSION;
+  optional: string[];
+}
+
+export function parseBundleAssetPolicy(value: unknown): BundleAssetPolicy | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  const candidate = value as Record<string, unknown>;
+  if (
+    Object.keys(candidate).sort().join(',') !== 'optional,version' ||
+    candidate.version !== BUNDLE_ASSET_POLICY_VERSION ||
+    !Array.isArray(candidate.optional)
+  ) {
+    return undefined;
+  }
+  const optional = candidate.optional;
+  if (
+    optional.some(
+      (asset) =>
+        typeof asset !== 'string' ||
+        !asset.startsWith('/') ||
+        asset.includes('\\') ||
+        asset.includes('?') ||
+        asset.includes('#'),
+    ) ||
+    new Set(optional).size !== optional.length
+  ) {
+    return undefined;
+  }
+  return { version: BUNDLE_ASSET_POLICY_VERSION, optional: [...optional].sort((a, b) => a.localeCompare(b)) };
+}

--- a/packages/clients/doompi-web/src/web/app/sessionRuntime.ts
+++ b/packages/clients/doompi-web/src/web/app/sessionRuntime.ts
@@ -147,9 +147,9 @@ export function startSessionRuntime(): () => void {
   restoreComposerDrafts();
   const stopBundleWatch = watchVerifiedBundleUpdates();
   const stopFileLinkModes = bindSessionFileLinkModes();
-  // The hub-side subscription this page currently holds; it dies with the
-  // socket, which is why the snapshot handler re-subscribes.
-  let subscribed: string | null = null;
+  // The visible session and the autonomous voice owner keep hub subscriptions.
+  // Both die with the socket, which is why a fresh snapshot re-subscribes them.
+  const subscribed = new Set<string>();
   let currentVoiceOwner: string | null = null;
   let pendingVoiceTransferTarget: string | undefined;
   let pendingVoiceTransferFocus: Promise<void> | undefined;
@@ -175,13 +175,22 @@ export function startSessionRuntime(): () => void {
         completeSessionTransfer(target);
       });
     }
-    if (!force && target === subscribed) return;
-    if (subscribed !== null && subscribed !== target) {
-      disconnectCaptures(subscribed);
-      sendHubFrame(unsubscribeFrame(subscribed));
+
+    const desired = new Set<string>();
+    if (target !== null) desired.add(target);
+    if (currentVoiceOwner !== null && currentVoiceOwner in byId) desired.add(currentVoiceOwner);
+    if (force) subscribed.clear();
+    for (const sessionId of subscribed) {
+      if (desired.has(sessionId)) continue;
+      subscribed.delete(sessionId);
+      disconnectCaptures(sessionId);
+      sendHubFrame(unsubscribeFrame(sessionId));
     }
-    subscribed = target;
-    if (target !== null) sendHubFrame(subscribeFrame(target));
+    for (const sessionId of desired) {
+      if (subscribed.has(sessionId)) continue;
+      subscribed.add(sessionId);
+      sendHubFrame(subscribeFrame(sessionId));
+    }
   };
 
   /** Both remote frames carry the same shape; only who receives them differs. */
@@ -229,7 +238,8 @@ export function startSessionRuntime(): () => void {
           removeSessionWebPluginRuntime(frame.sessionId);
           dropThreads(frame.sessionId);
           dropTransientTabs(frame.sessionId);
-          if (subscribed === frame.sessionId) subscribed = null;
+          subscribed.delete(frame.sessionId);
+          if (currentVoiceOwner === frame.sessionId) currentVoiceOwner = null;
           syncSubscription();
           return;
         }
@@ -267,9 +277,13 @@ export function startSessionRuntime(): () => void {
           }
           applyCaptureFrame(frame.sessionId, frame.frame);
           applySessionFrame(frame.sessionId, frame.frame);
-          // A select the bar asked for becomes the bar's popover; the claim is
-          // settled here, at frame time, so no surface renders it twice.
-          if (frame.frame.type === 'extension_ui_request' && frame.frame.method === 'select') {
+          // Only the visible session owns the composer's pending menu. The retained
+          // voice owner may keep streaming in the background while another session is open.
+          if (
+            frame.sessionId === sessionsStore.state.activeId &&
+            frame.frame.type === 'extension_ui_request' &&
+            frame.frame.method === 'select'
+          ) {
             claimDialogMenu(typeof frame.frame.id === 'string' ? frame.frame.id : '');
           }
           // A reload rebuilt the resource catalog, so the commands and skills
@@ -288,7 +302,7 @@ export function startSessionRuntime(): () => void {
             refreshSessionStats(frame.sessionId);
           }
           if (frame.frame.type === 'agent_settled') {
-            clearPendingMenu();
+            if (frame.sessionId === sessionsStore.state.activeId) clearPendingMenu();
             refreshSessionFacts(frame.sessionId);
           }
           return;
@@ -345,6 +359,7 @@ export function startSessionRuntime(): () => void {
           // Any other frame type may be a plugin channel; unclaimed types are
           // dropped silently the way unknown frames always have been.
           dispatchChannelFrame(frame);
+          if (owner !== undefined) syncSubscription();
           return;
         }
       }
@@ -353,7 +368,7 @@ export function startSessionRuntime(): () => void {
       // The snapshot that follows the hub's hello is the real "connected".
     },
     onClose() {
-      subscribed = null;
+      subscribed.clear();
       disconnectCaptures();
       markSocketClosed();
     },

--- a/packages/clients/doompi-web/src/web/app/sessionRuntime.ts
+++ b/packages/clients/doompi-web/src/web/app/sessionRuntime.ts
@@ -1,3 +1,4 @@
+import { batch } from '@tanstack/store';
 import {
   HISTORY_PAGE_TYPE,
   HUB_RESYNCED_TYPE,
@@ -238,12 +239,15 @@ export function startSessionRuntime(): () => void {
           const frames = frame.frames.filter(isRecord);
           const dropped = typeof frame.dropped === 'number' ? frame.dropped : 0;
           recordBrowserPerformance({ name: 'web.browser.backlog', count: Math.min(10_000, frames.length + dropped) });
-          applySessionBacklog(sessionId, frames.length, dropped);
-          resetSessionStore(sessionId);
-          for (const replayed of frames) applySessionFrame(sessionId, replayed);
-          // Where the backlog starts is where paging back has to continue
-          // from, so the oldest journal id it carried becomes the cursor.
-          seedHistoryCursor(sessionId, oldestEntryId(frames));
+          // Publish the completed replay, not every intermediate frame, to store subscribers.
+          batch(() => {
+            applySessionBacklog(sessionId, frames.length, dropped);
+            resetSessionStore(sessionId);
+            for (const replayed of frames) applySessionFrame(sessionId, replayed);
+            // Where the backlog starts is where paging back has to continue
+            // from, so the oldest journal id it carried becomes the cursor.
+            seedHistoryCursor(sessionId, oldestEntryId(frames));
+          });
           refreshSessionFacts(sessionId);
           return;
         }
@@ -295,8 +299,11 @@ export function startSessionRuntime(): () => void {
           if (typeof frame.sessionId !== 'string' || typeof frame.threadId !== 'string') return;
           if (!Array.isArray(frame.frames)) return;
           const key = threadStoreKey(frame.sessionId, frame.threadId);
-          resetSessionStore(key);
-          for (const replayed of frame.frames.filter(isRecord)) applyThreadFrame(key, replayed);
+          const frames = frame.frames.filter(isRecord);
+          batch(() => {
+            resetSessionStore(key);
+            for (const replayed of frames) applyThreadFrame(key, replayed);
+          });
           return;
         }
         case THREAD_FRAME_TYPE: {

--- a/packages/clients/doompi-web/src/web/features/session/MessageMarkdown.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/MessageMarkdown.tsx
@@ -1,8 +1,5 @@
 import { Markdown } from '@agimon-ai/doompi-web-components';
-import { useCallback } from 'react';
-import { fileTabForPath, useFileLinks } from '../../lib/composition.ts';
-import { openTransientTab } from '../../stores/transientTabsStore.ts';
-import { useOpenTab } from '../../stores/useOpenTab.ts';
+import { memo, type ComponentProps } from 'react';
 
 /**
  * A message's markdown, with the files this session changed as links.
@@ -12,20 +9,14 @@ import { useOpenTab } from '../../stores/useOpenTab.ts';
  * in the same transient tab the activity dock opens, rather than a second view
  * of the same file.
  */
-export function MessageMarkdown({ sessionId, text }: { sessionId: string | null; text: string }) {
-  const resolve = useFileLinks(sessionId);
-  const openTab = useOpenTab();
-  const onFileLink = useCallback(
-    (label: string, explicit = false) => {
-      if (sessionId === null) return undefined;
-      const tab = explicit ? fileTabForPath(sessionId, label) : resolve(label);
-      if (tab === undefined) return undefined;
-      return () => {
-        openTransientTab(sessionId, tab);
-        openTab(tab.id);
-      };
-    },
-    [resolve, sessionId, openTab],
-  );
+export type MessageFileLinkHandler = NonNullable<ComponentProps<typeof Markdown>['onFileLink']>;
+
+export const MessageMarkdown = memo(function MessageMarkdown({
+  onFileLink,
+  text,
+}: {
+  onFileLink: MessageFileLinkHandler;
+  text: string;
+}) {
   return <Markdown text={text} onFileLink={onFileLink} />;
-}
+});

--- a/packages/clients/doompi-web/src/web/features/session/Timeline.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/Timeline.tsx
@@ -1,4 +1,4 @@
-import type { UserMessageActionRunContext } from '@agimon-ai/doompi-web-contracts';
+import type { UserMessageActionRunContext, WebPluginSlotProps } from '@agimon-ai/doompi-web-contracts';
 import {
   Avatar,
   AvatarFallback,
@@ -14,14 +14,13 @@ import {
   StreamCursor,
   UserIcon,
 } from '@agimon-ai/doompi-web-components';
-import { Fragment, memo, type ReactNode, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, memo, type ReactNode, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useStore } from '@tanstack/react-store';
 import type { Store } from '@tanstack/store';
-import { useActivityGroups } from '../../lib/composition.ts';
+import { fileTabForPath, useActivityGroups, useFileLinks } from '../../lib/composition.ts';
 import { parseFileMentions } from '../../lib/fileMentions.ts';
 import { pluginToolRenderer, pluginUserMessageActions } from '../../lib/pluginRegistry.ts';
 import { focusPrompt } from '../../lib/promptFocus.ts';
-import { useWebPluginRegistry } from '../../stores/useWebPluginRegistry.ts';
 import {
   isSupportedImageMimeType,
   type ProfileIdentity,
@@ -39,8 +38,12 @@ import {
   useActiveSession,
 } from '../../stores/sessionStore.ts';
 import { sessionsStore } from '../../stores/sessionsStore.ts';
+import { openTransientTab } from '../../stores/transientTabsStore.ts';
+import { useOpenTab } from '../../stores/useOpenTab.ts';
+import { usePluginSlotProps } from '../../stores/usePluginSlotProps.ts';
+import { useWebPluginRegistry } from '../../stores/useWebPluginRegistry.ts';
 import { MentionPreviews } from './MentionPreviews.tsx';
-import { MessageMarkdown } from './MessageMarkdown.tsx';
+import { MessageMarkdown, type MessageFileLinkHandler } from './MessageMarkdown.tsx';
 import { ToolCard } from './ToolCard.tsx';
 
 const SUGGESTIONS = [
@@ -127,12 +130,16 @@ function SpeakerAvatar({ speaker, identity }: { speaker: 'assistant' | 'user'; i
   );
 }
 
+type UserMessageActions = ReturnType<typeof pluginUserMessageActions>;
+
 function MessageActions({
+  actions,
   disabled,
   onQuote,
   onRewind,
   userMessage,
 }: {
+  actions: UserMessageActions;
   disabled: boolean;
   onQuote: () => void;
   onRewind: () => void;
@@ -144,7 +151,7 @@ function MessageActions({
       className="pointer-events-none absolute right-1 bottom-0 z-10 flex max-w-[calc(100%-0.5rem)] translate-y-1/2 flex-wrap justify-end gap-1 rounded-md border border-doom-border-soft bg-doom-panel p-0.5 opacity-0 shadow-sm transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 group-focus-within/message:pointer-events-auto group-focus-within/message:opacity-100 [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100"
     >
       {userMessage
-        ? pluginUserMessageActions().map((action) => {
+        ? actions.map((action) => {
             const ActionIcon = action.icon;
             return (
               <Button
@@ -193,12 +200,13 @@ function MessageActions({
 }
 function ToolEntryRow({
   entry,
-  sessionId,
+  slotProps,
+  statuses,
 }: {
   entry: Extract<TimelineEntry, { kind: 'tool' }>;
-  sessionId: string | null;
+  slotProps: WebPluginSlotProps;
+  statuses: Readonly<Record<string, string>>;
 }) {
-  const statuses = useActiveSession((state) => state.statuses);
   const presentation = pluginToolRenderer(entry.name, statuses)?.timelinePresentation ?? 'tool';
   return (
     <div
@@ -208,7 +216,7 @@ function ToolEntryRow({
     >
       {presentation === 'tool' ? <Gutter label="tool" tone="text-doom-faint" /> : null}
       <div className="min-w-0 flex-1">
-        <ToolCard entry={entry} sessionId={sessionId} />
+        <ToolCard entry={entry} slotProps={slotProps} statuses={statuses} />
       </div>
     </div>
   );
@@ -222,11 +230,13 @@ function ToolEntryRow({
 function ToolGroupRow({
   name,
   entries,
-  sessionId,
+  slotProps,
+  statuses,
 }: {
   name: string;
   entries: readonly ToolEntry[];
-  sessionId: string | null;
+  slotProps: WebPluginSlotProps;
+  statuses: Readonly<Record<string, string>>;
 }) {
   return (
     <div
@@ -245,23 +255,33 @@ function ToolGroupRow({
         className="min-w-0 flex-1"
       >
         {entries.map((entry) => (
-          <ToolCard key={entry.id} entry={entry} sessionId={sessionId} />
+          <ToolCard key={entry.id} entry={entry} slotProps={slotProps} statuses={statuses} />
         ))}
       </MessageItemGroup>
     </div>
   );
 }
-const Entry = memo(function Entry({
-  entry,
-  sessionId,
-  sessionIdentity,
-}: {
+interface EntryProps {
   entry: TimelineEntry;
+  onFileLink: MessageFileLinkHandler;
+  pluginActions: UserMessageActions;
   sessionId: string | null;
   sessionIdentity: ProfileIdentity | null;
-}) {
-  useWebPluginRegistry();
-  const sessionStreaming = useActiveSession((state) => state.streaming);
+  sessionStreaming: boolean;
+  slotProps: WebPluginSlotProps;
+  toolStatuses: Readonly<Record<string, string>>;
+}
+
+const Entry = memo(function Entry({
+  entry,
+  onFileLink,
+  pluginActions,
+  sessionId,
+  sessionIdentity,
+  sessionStreaming,
+  slotProps,
+  toolStatuses,
+}: EntryProps) {
   const quoteSource = useRef<HTMLDivElement>(null);
   const quoteMessage = (text: string): void => {
     const selection = window.getSelection();
@@ -291,7 +311,7 @@ const Entry = memo(function Entry({
             ref={quoteSource}
             className="flex flex-col gap-2 rounded-md border border-doom-border-soft bg-doom-deep px-3.5 py-2.5 text-base text-doom-hi"
           >
-            <MessageMarkdown sessionId={sessionId} text={entry.text} />
+            <MessageMarkdown onFileLink={onFileLink} text={entry.text} />
             {entry.images && entry.images.length > 0 ? (
               <div data-testid="user-attachments" className="flex flex-wrap gap-2">
                 {entry.images
@@ -310,6 +330,7 @@ const Entry = memo(function Entry({
             {sessionId ? <MentionPreviews sessionId={sessionId} mentions={parseFileMentions(entry.text)} /> : null}
           </div>
           <MessageActions
+            actions={pluginActions}
             disabled={sessionStreaming}
             onQuote={() => quoteMessage(entry.text)}
             onRewind={() => rewindToMessage(entry.id, sessionId)}
@@ -342,15 +363,16 @@ const Entry = memo(function Entry({
                 // uses strong emphasis for status updates.
                 className="text-sm font-normal text-doom-dim [&_p]:whitespace-pre-wrap [&_strong]:font-normal [&_strong]:text-doom-dim"
               >
-                <MessageMarkdown sessionId={sessionId} text={entry.thinking} />
+                <MessageMarkdown onFileLink={onFileLink} text={entry.thinking} />
               </div>
             ) : null}
             <div ref={quoteSource} className="text-base text-doom-text">
-              <MessageMarkdown sessionId={sessionId} text={entry.text} />
+              <MessageMarkdown onFileLink={onFileLink} text={entry.text} />
               {entry.streaming ? <StreamCursor /> : null}
             </div>
           </div>
           <MessageActions
+            actions={pluginActions}
             disabled={sessionStreaming}
             onQuote={() => quoteMessage(entry.text)}
             onRewind={() => rewindToMessage(entry.id, sessionId)}
@@ -360,7 +382,7 @@ const Entry = memo(function Entry({
     );
   }
 
-  if (entry.kind === 'tool') return <ToolEntryRow entry={entry} sessionId={sessionId} />;
+  if (entry.kind === 'tool') return <ToolEntryRow entry={entry} slotProps={slotProps} statuses={toolStatuses} />;
 
   if (entry.kind === 'settled') {
     return (
@@ -406,7 +428,29 @@ const Entry = memo(function Entry({
       </p>
     </div>
   );
-});
+}, entriesEqual);
+
+function entriesEqual(previous: EntryProps, next: EntryProps): boolean {
+  if (previous.entry !== next.entry || previous.sessionId !== next.sessionId) return false;
+  if (next.entry.kind === 'tool') {
+    return previous.slotProps === next.slotProps && previous.toolStatuses === next.toolStatuses;
+  }
+  if (next.entry.kind === 'user') {
+    return (
+      previous.onFileLink === next.onFileLink &&
+      previous.pluginActions === next.pluginActions &&
+      previous.sessionStreaming === next.sessionStreaming
+    );
+  }
+  if (next.entry.kind === 'assistant') {
+    return (
+      previous.onFileLink === next.onFileLink &&
+      previous.sessionIdentity === next.sessionIdentity &&
+      previous.sessionStreaming === next.sessionStreaming
+    );
+  }
+  return true;
+}
 
 function BackgroundWorkNotice() {
   return (
@@ -451,27 +495,48 @@ export function Transcript({
   // answer for one of them, and it corrects itself when the identity lands late,
   // which a stamp written at merge time cannot do.
   const sessionIdentity = useStore(store, (state) => state.profileIdentity);
+  const sessionStreaming = useActiveSession((state) => state.streaming);
+  const toolStatuses = useActiveSession((state) => state.statuses);
+  const resolveFileLink = useFileLinks(sessionId);
+  const openTab = useOpenTab();
+  const registryRevision = useWebPluginRegistry();
+  const slotProps = usePluginSlotProps(sessionId);
+  const pluginActions = useMemo(() => {
+    void registryRevision;
+    return pluginUserMessageActions();
+  }, [registryRevision]);
+  const onFileLink = useCallback<MessageFileLinkHandler>(
+    (label, explicit = false) => {
+      if (sessionId === null) return undefined;
+      const tab = explicit ? fileTabForPath(sessionId, label) : resolveFileLink(label);
+      if (tab === undefined) return undefined;
+      return () => {
+        openTransientTab(sessionId, tab);
+        openTab(tab.id);
+      };
+    },
+    [openTab, resolveFileLink, sessionId],
+  );
   const visibleEntries = useMemo(() => {
     const shown = entries.filter((entry) => entry.kind !== 'queued');
     return limit === undefined ? shown : shown.slice(-limit);
   }, [entries, limit]);
-  const toolStatuses = useActiveSession((state) => state.statuses);
   // A tool that presents itself as a message has no frame to share, so only
   // the card-shaped ones are gathered into runs.
-  const units = useMemo(
-    () =>
-      timelineUnits(
-        visibleEntries,
-        (name) => (pluginToolRenderer(name, toolStatuses)?.timelinePresentation ?? 'tool') === 'tool',
-      ),
-    [visibleEntries, toolStatuses],
-  );
+  const units = useMemo(() => {
+    void registryRevision;
+    return timelineUnits(
+      visibleEntries,
+      (name) => (pluginToolRenderer(name, toolStatuses)?.timelinePresentation ?? 'tool') === 'tool',
+    );
+  }, [registryRevision, toolStatuses, visibleEntries]);
   const scroller = useRef<HTMLDivElement>(null);
   // The transcript's height as of the last entry. Whether to follow the newest
   // line is decided against this rather than against a scroll event, because
   // an event fires after the fact and a fast run can grow the transcript
   // before the browser has reported the reader's scroll.
   const lastHeight = useRef(0);
+  const lastLayoutEntries = useRef(visibleEntries);
   const following = useRef(true);
   const [unread, setUnread] = useState(false);
   // Where the bottom of the transcript sat before a window was prepended.
@@ -538,6 +603,11 @@ export function Transcript({
   useLayoutEffect(() => {
     const element = scroller.current;
     if (!element) return;
+    const entriesChanged = lastLayoutEntries.current !== visibleEntries;
+    lastLayoutEntries.current = visibleEntries;
+    // Registry/status regrouping can resize unchanged entries. A no-op regroup
+    // must not manufacture unread activity for someone reading older content.
+    if (!entriesChanged && element.scrollHeight === lastHeight.current) return;
     // A prepended window grew the transcript upwards; hold the reader where
     // they were by moving down by exactly what appeared above them.
     const held = anchor.current;
@@ -571,7 +641,7 @@ export function Transcript({
       return;
     }
     setUnread(true);
-  }, [visibleEntries]);
+  }, [units, visibleEntries]);
 
   if (visibleEntries.length === 0) {
     return (
@@ -612,9 +682,18 @@ export function Transcript({
             }
           >
             {unit.kind === 'group' ? (
-              <ToolGroupRow name={unit.name} entries={unit.entries} sessionId={sessionId} />
+              <ToolGroupRow name={unit.name} entries={unit.entries} slotProps={slotProps} statuses={toolStatuses} />
             ) : (
-              <Entry entry={unit.entry} sessionId={sessionId} sessionIdentity={sessionIdentity} />
+              <Entry
+                entry={unit.entry}
+                onFileLink={onFileLink}
+                pluginActions={pluginActions}
+                sessionId={sessionId}
+                sessionIdentity={sessionIdentity}
+                sessionStreaming={sessionStreaming}
+                slotProps={slotProps}
+                toolStatuses={toolStatuses}
+              />
             )}
           </div>
         ))}

--- a/packages/clients/doompi-web/src/web/features/session/ToolCard.tsx
+++ b/packages/clients/doompi-web/src/web/features/session/ToolCard.tsx
@@ -1,3 +1,4 @@
+import type { WebPluginSlotProps } from '@agimon-ai/doompi-web-contracts';
 import {
   collapseLines,
   MessageItem,
@@ -6,13 +7,11 @@ import {
   MessageItemStatus,
   type StatusTone,
 } from '@agimon-ai/doompi-web-components';
+import { memo } from 'react';
 import { ToolRendererBoundary } from '../../components/ToolRendererBoundary.tsx';
 import { pluginToolRenderer } from '../../lib/pluginRegistry.ts';
 import { imagesFromContent, type ToolEntry } from '../../lib/sessionModel.ts';
 import { toolMessageProps } from '../../lib/toolMessageProps.ts';
-import { useActiveSession } from '../../stores/sessionStore.ts';
-import { usePluginSlotProps } from '../../stores/usePluginSlotProps.ts';
-import { useWebPluginRegistry } from '../../stores/useWebPluginRegistry.ts';
 
 const MAX_PREVIEW_LINES = 12;
 
@@ -206,10 +205,15 @@ function HostToolMessage({ entry }: { entry: ToolEntry }) {
  * renderShell 'self'; the host only marks the row, catches a renderer that
  * throws, and stands in for a tool nobody claims.
  */
-export function ToolCard({ entry, sessionId }: { entry: ToolEntry; sessionId: string | null }) {
-  useWebPluginRegistry();
-  const statuses = useActiveSession((state) => state.statuses);
-  const slotProps = usePluginSlotProps(sessionId);
+export const ToolCard = memo(function ToolCard({
+  entry,
+  slotProps,
+  statuses,
+}: {
+  entry: ToolEntry;
+  slotProps: WebPluginSlotProps;
+  statuses: Readonly<Record<string, string>>;
+}) {
   const renderer = pluginToolRenderer(entry.name, statuses);
   const state = toneOf(entry);
   const props = toolMessageProps(slotProps, entry, statuses);
@@ -227,4 +231,4 @@ export function ToolCard({ entry, sessionId }: { entry: ToolEntry; sessionId: st
       )}
     </ToolRendererBoundary>
   );
-}
+});

--- a/packages/clients/doompi-web/src/web/stores/useOpenTab.ts
+++ b/packages/clients/doompi-web/src/web/stores/useOpenTab.ts
@@ -1,5 +1,6 @@
 import { useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
+import { useCallback } from 'react';
 import { sessionsStore } from './sessionsStore.ts';
 
 /**
@@ -10,10 +11,13 @@ import { sessionsStore } from './sessionsStore.ts';
 export function useOpenTab(): (tabId: string | null) => void {
   const activeId = useStore(sessionsStore, (state) => state.activeId);
   const navigate = useNavigate();
-  return (tabId) => {
-    if (activeId === null) return;
-    void (tabId === null
-      ? navigate({ to: '/session/$sessionId', params: { sessionId: activeId } })
-      : navigate({ to: '/session/$sessionId/$tabId', params: { sessionId: activeId, tabId } }));
-  };
+  return useCallback(
+    (tabId) => {
+      if (activeId === null) return;
+      void (tabId === null
+        ? navigate({ to: '/session/$sessionId', params: { sessionId: activeId } })
+        : navigate({ to: '/session/$sessionId/$tabId', params: { sessionId: activeId, tabId } }));
+    },
+    [activeId, navigate],
+  );
 }

--- a/packages/clients/doompi-web/src/web/stores/usePluginSlotProps.ts
+++ b/packages/clients/doompi-web/src/web/stores/usePluginSlotProps.ts
@@ -1,48 +1,94 @@
 import type { WebPluginSlotProps } from '@agimon-ai/doompi-web-contracts';
 import { useStore } from '@tanstack/react-store';
-import { pluginSlotProps } from '../lib/pluginSlotProps.ts';
+import { useCallback, useMemo } from 'react';
 import { minorModes } from '../lib/composition.ts';
+import { pluginSlotProps } from '../lib/pluginSlotProps.ts';
+import { submitCapture } from './captureStore.ts';
 import { appendComposerDraft, attachComposerCapture, attachComposerContext } from './composerStore.ts';
 import { sessionStoreFor } from './sessionStore.ts';
 import { closeTransientTab, openTransientTab } from './transientTabsStore.ts';
 import { useOpenTab } from './useOpenTab.ts';
-import { submitCapture } from './captureStore.ts';
+import { useWebPluginRegistry } from './useWebPluginRegistry.ts';
 /** The props a plugin component receives for a session, with the host's navigation and facts bound in. */
 export function usePluginSlotProps(sessionId: string | null, onOpen?: () => void): WebPluginSlotProps {
-  const statuses = useStore(sessionStoreFor(sessionId), (state) => state.statuses);
-  const catalog = useStore(sessionStoreFor(sessionId), (state) => state.minorModes);
-  const widgets = useStore(sessionStoreFor(sessionId), (state) => state.widgets);
-  const contextInventory = useStore(
-    sessionStoreFor(sessionId),
-    (state) => state.context?.groups.flatMap((group) => group.items) ?? [],
-  );
+  const store = sessionStoreFor(sessionId);
+  const statuses = useStore(store, (state) => state.statuses);
+  const catalog = useStore(store, (state) => state.minorModes);
+  const widgets = useStore(store, (state) => state.widgets);
+  const context = useStore(store, (state) => state.context);
+  const contextInventory = useMemo(() => context?.groups.flatMap((group) => group.items) ?? [], [context]);
   const openTab = useOpenTab();
-  const props = pluginSlotProps(
-    sessionId,
-    (tabId) => {
+  const registryRevision = useWebPluginRegistry();
+  const openPluginTab = useCallback(
+    (tabId: string | null) => {
       onOpen?.();
       openTab(tabId);
     },
-    statuses,
-    {
-      open(tab) {
-        if (sessionId === null) return;
-        onOpen?.();
-        openTransientTab(sessionId, tab);
-        openTab(tab.id);
-      },
-      close(tabId) {
-        if (sessionId !== null) closeTransientTab(sessionId, tabId);
-      },
-    },
-    (text) => appendComposerDraft(sessionId, text),
-    (item) => attachComposerContext(sessionId, item),
-    (capture) => attachComposerCapture(sessionId, capture),
-    contextInventory,
-    (capture) => submitCapture(sessionId, capture),
+    [onOpen, openTab],
   );
-  props.activeMinorModes = minorModes(statuses, widgets, catalog)
-    .filter((mode) => mode.availability === 'on')
-    .map((mode) => mode.name);
-  return props;
+  const openPluginTransientTab = useCallback(
+    (tab: Parameters<typeof openTransientTab>[1]) => {
+      if (sessionId === null) return;
+      onOpen?.();
+      openTransientTab(sessionId, tab);
+      openTab(tab.id);
+    },
+    [onOpen, openTab, sessionId],
+  );
+  const closePluginTransientTab = useCallback(
+    (tabId: string) => {
+      if (sessionId !== null) closeTransientTab(sessionId, tabId);
+    },
+    [sessionId],
+  );
+  const appendDraft = useCallback((text: string) => appendComposerDraft(sessionId, text), [sessionId]);
+  const attachContext = useCallback(
+    (item: Parameters<typeof attachComposerContext>[1]) => attachComposerContext(sessionId, item),
+    [sessionId],
+  );
+  const attachCapture = useCallback(
+    (capture: Parameters<typeof attachComposerCapture>[1]) => attachComposerCapture(sessionId, capture),
+    [sessionId],
+  );
+  const capture = useCallback(
+    (value: Parameters<typeof submitCapture>[1]) => submitCapture(sessionId, value),
+    [sessionId],
+  );
+  const activeMinorModes = useMemo(
+    () =>
+      minorModes(statuses, widgets, catalog)
+        .filter((mode) => mode.availability === 'on')
+        .map((mode) => mode.name),
+    [catalog, statuses, widgets],
+  );
+
+  return useMemo(() => {
+    void registryRevision;
+    const props = pluginSlotProps(
+      sessionId,
+      openPluginTab,
+      statuses,
+      { open: openPluginTransientTab, close: closePluginTransientTab },
+      appendDraft,
+      attachContext,
+      attachCapture,
+      contextInventory,
+      capture,
+    );
+    props.activeMinorModes = activeMinorModes;
+    return props;
+  }, [
+    activeMinorModes,
+    appendDraft,
+    attachCapture,
+    attachContext,
+    capture,
+    closePluginTransientTab,
+    contextInventory,
+    openPluginTab,
+    openPluginTransientTab,
+    registryRevision,
+    sessionId,
+    statuses,
+  ]);
 }

--- a/packages/clients/doompi-web/src/web/stores/useWebPluginRegistry.ts
+++ b/packages/clients/doompi-web/src/web/stores/useWebPluginRegistry.ts
@@ -2,6 +2,6 @@ import { useSyncExternalStore } from 'react';
 import { subscribeWebPluginRegistry, webPluginRegistryRevision } from '../lib/pluginRegistry.ts';
 
 /** Re-renders a host surface when the focused session's plugin composition changes. */
-export function useWebPluginRegistry(): void {
-  useSyncExternalStore(subscribeWebPluginRegistry, webPluginRegistryRevision, webPluginRegistryRevision);
+export function useWebPluginRegistry(): number {
+  return useSyncExternalStore(subscribeWebPluginRegistry, webPluginRegistryRevision, webPluginRegistryRevision);
 }

--- a/packages/clients/doompi-web/tests/contract/workspaceWebPlugins.test.ts
+++ b/packages/clients/doompi-web/tests/contract/workspaceWebPlugins.test.ts
@@ -122,9 +122,7 @@ describe('the workspace web plugin composition', () => {
     const definitions = await installed();
     const loop = definitions.find(({ id }) => id === 'loop');
 
-    expect(loop?.activityGroups).toEqual([
-      { name: 'loops', keys: 'l l', statusKey: 'doom-loop-instances', hideWhenEmpty: true, order: 40 },
-    ]);
+    expect(loop?.activityGroups).toEqual([{ name: 'loops', keys: 'l l', statusKey: 'doom-loop-instances', order: 40 }]);
     expect(loop?.activitySections?.map(({ id }) => id)).toEqual(['loops']);
   });
 

--- a/packages/clients/doompi-web/tests/e2e/activity.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/activity.spec.ts
@@ -113,7 +113,9 @@ test('shows Loop lifecycle rows and routes the single manage action through /loo
   await expect(row).toHaveAttribute('data-loop-state', 'stopping');
 
   cockpit.session.emit(status('doom-loop-instances'));
-  await expect(page.getByTestId('activity-loops')).toHaveCount(0);
+  await expect(row).toHaveCount(0);
+  await expect(page.getByTestId('activity-loops')).toBeVisible();
+  await expect(page.getByTestId('activity-loops-manage')).toHaveCount(1);
 });
 
 test('keeps bottom-pinned groups visible while ordinary groups scroll', async ({ page, cockpit }) => {

--- a/packages/clients/doompi-web/tests/e2e/pwaAssets.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/pwaAssets.spec.ts
@@ -1,0 +1,268 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { type Page } from '@playwright/test';
+import { expect, test as cockpitTest } from '../support/cockpit.ts';
+
+const packageRoot = fileURLToPath(new URL('../../', import.meta.url));
+const test = cockpitTest.extend<{ assetPackageRoot: string }>({
+  assetPackageRoot: async ({ assets }, use) => {
+    if (assets !== 'packaged') throw new Error('PWA mutation tests require an isolated packaged bundle.');
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-web-pwa-assets-'));
+    fs.cpSync(path.join(packageRoot, 'dist'), path.join(root, 'dist'), { recursive: true });
+    fs.copyFileSync(path.join(packageRoot, 'package.json'), path.join(root, 'package.json'));
+    fs.symlinkSync(
+      path.join(packageRoot, 'node_modules'),
+      path.join(root, 'node_modules'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+    try {
+      await use(root);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  },
+});
+
+interface BundleAsset {
+  path: string;
+  sha256: string;
+}
+
+interface BundleManifest {
+  revision: number;
+  assets: BundleAsset[];
+}
+
+interface BundleSnapshot {
+  cacheName: string;
+  cachedPaths: string[];
+  manifest: BundleManifest;
+  optionalPaths: string[];
+}
+
+async function bundleSnapshot(page: Page): Promise<BundleSnapshot> {
+  return await page.evaluate(async () => {
+    const envelope = (await (await fetch('/bundle-manifest.json', { cache: 'no-store' })).json()) as {
+      manifest: BundleManifest;
+    };
+    const policyResponse = await fetch(
+      `/bundle-assets/${String(envelope.manifest.revision)}/bundle-asset-policy.json`,
+      { cache: 'no-store' },
+    );
+    const policy = (await policyResponse.json()) as { optional: string[] };
+    const cacheNames = (await caches.keys()).filter((name) =>
+      name.startsWith(`doompi-bundle-${String(envelope.manifest.revision)}-`),
+    );
+    if (cacheNames.length !== 1 || cacheNames[0] === undefined) {
+      throw new Error(`Expected one active verified bundle cache, found ${String(cacheNames.length)}.`);
+    }
+    const cacheName = cacheNames[0];
+    const cachedPaths = (await (await caches.open(cacheName)).keys()).map((request) => new URL(request.url).pathname);
+    return { cacheName, cachedPaths, manifest: envelope.manifest, optionalPaths: policy.optional };
+  });
+}
+
+async function fetchDigest(page: Page, path: string): Promise<{ digest: string; status: number }> {
+  return await page.evaluate(async (assetPath) => {
+    const response = await fetch(assetPath, { cache: 'no-store' });
+    const bytes = await response.arrayBuffer();
+    const digest = [...new Uint8Array(await crypto.subtle.digest('SHA-256', bytes))]
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('');
+    return { digest, status: response.status };
+  }, path);
+}
+
+async function bundleCacheName(page: Page, revision: number): Promise<string | undefined> {
+  return await page.evaluate(async (activeRevision) => {
+    return (await caches.keys()).find((name) => name.startsWith(`doompi-bundle-${String(activeRevision)}-`));
+  }, revision);
+}
+
+function publishChangedWebTree(assetPackageRoot: string): void {
+  const distRoot = path.join(assetPackageRoot, 'dist');
+  const webRoot = path.join(distRoot, 'web');
+  const nextRoot = path.join(distRoot, 'web-next');
+  const previousRoot = path.join(distRoot, 'web-previous');
+  fs.cpSync(webRoot, nextRoot, { recursive: true });
+  fs.appendFileSync(path.join(nextRoot, 'index.html'), '\n<!-- e2e republished bundle -->\n');
+  fs.renameSync(webRoot, previousRoot);
+  try {
+    fs.renameSync(nextRoot, webRoot);
+  } catch (error) {
+    fs.renameSync(previousRoot, webRoot);
+    throw error;
+  }
+  fs.rmSync(previousRoot, { recursive: true, force: true });
+}
+test('activates the verified production core without eagerly caching deferred assets', async ({ page, cockpit }) => {
+  await page.goto(cockpit.url);
+
+  const controlled = await page.evaluate(
+    () => navigator.serviceWorker.controller?.scriptURL.endsWith('/sw.js') ?? false,
+  );
+  const snapshot = await bundleSnapshot(page);
+  const optional = new Set(snapshot.optionalPaths);
+  const corePaths = snapshot.manifest.assets.map((asset) => asset.path).filter((path) => !optional.has(path));
+
+  expect(controlled).toBe(true);
+  expect(snapshot.cacheName).toContain(`doompi-bundle-${String(snapshot.manifest.revision)}-`);
+  expect(
+    snapshot.optionalPaths.length,
+    'the production bundle must expose at least one deferred asset',
+  ).toBeGreaterThan(0);
+  expect(snapshot.cachedPaths).toEqual(expect.arrayContaining(corePaths));
+  expect(snapshot.cachedPaths.filter((path) => optional.has(path))).toEqual([]);
+});
+
+test('verifies a deferred asset on demand and serves the populated cache offline', async ({
+  page,
+  context,
+  cockpit,
+}) => {
+  await page.goto(cockpit.url);
+
+  const before = await bundleSnapshot(page);
+  const assetPath = before.optionalPaths[0];
+  if (assetPath === undefined) throw new Error('The production bundle does not contain a deferred asset.');
+  const asset = before.manifest.assets.find((candidate) => candidate.path === assetPath);
+  if (asset === undefined) throw new Error(`The deferred asset ${assetPath} is absent from the signed manifest.`);
+  expect(before.cachedPaths).not.toContain(assetPath);
+
+  const online = await fetchDigest(page, assetPath);
+  expect(online).toEqual({ status: 200, digest: asset.sha256 });
+  const populated = await bundleSnapshot(page);
+  expect(populated.cacheName).toBe(before.cacheName);
+  expect(populated.cachedPaths).toContain(assetPath);
+
+  await context.setOffline(true);
+  const offline = await fetchDigest(page, assetPath);
+  expect(offline).toEqual(online);
+});
+
+test('rejects corrupt cached optional bytes and cache entries absent from the signed manifest', async ({
+  page,
+  context,
+  cockpit,
+}) => {
+  await page.goto(cockpit.url);
+
+  const snapshot = await bundleSnapshot(page);
+  const optionalPath = snapshot.optionalPaths[0];
+  if (optionalPath === undefined) throw new Error('The production bundle does not contain a deferred asset.');
+  const unlistedPath = '/assets/not-in-signed-manifest.js';
+  await page.evaluate(
+    async ({ cacheName, corruptPath, injectedPath }) => {
+      const cache = await caches.open(cacheName);
+      await cache.put(corruptPath, new Response('corrupt'));
+      await cache.put(injectedPath, new Response('injected'));
+    },
+    { cacheName: snapshot.cacheName, corruptPath: optionalPath, injectedPath: unlistedPath },
+  );
+
+  await context.setOffline(true);
+  expect(await page.evaluate(async (assetPath) => (await fetch(assetPath)).status, optionalPath)).toBe(404);
+  expect(await page.evaluate(async (assetPath) => (await fetch(assetPath)).status, unlistedPath)).toBe(404);
+});
+
+test('reloads the verified core shell offline', async ({ page, context, cockpit }) => {
+  await page.goto(cockpit.url);
+  const before = await bundleSnapshot(page);
+
+  await context.setOffline(true);
+  const response = await page.reload({ waitUntil: 'domcontentloaded' });
+
+  expect(response?.status()).toBe(200);
+  await expect(page.getByTestId('cockpit')).toBeVisible();
+  expect(await bundleCacheName(page, before.manifest.revision)).toBe(before.cacheName);
+});
+
+test('notifies every controlled tab after a newer verified revision is committed', async ({
+  page,
+  context,
+  cockpit,
+  assetPackageRoot,
+}) => {
+  const updatedRevisionKey = 'doompi-e2e-bundle-updated';
+  const captureRevision = (storageKey: string): void => {
+    navigator.serviceWorker.addEventListener('message', (event: MessageEvent<unknown>) => {
+      const message = event.data as { type?: unknown; revision?: unknown };
+      if (message?.type === 'doompi:bundle-updated' && Number.isSafeInteger(message.revision)) {
+        sessionStorage.setItem(storageKey, String(message.revision));
+      }
+    });
+  };
+  await page.addInitScript(captureRevision, updatedRevisionKey);
+  await page.goto(`${cockpit.url}/api/health`);
+  const secondPage = await context.newPage();
+  await secondPage.addInitScript(captureRevision, updatedRevisionKey);
+  await secondPage.goto(`${cockpit.url}/api/health`);
+  await expect.poll(async () => await page.evaluate(() => navigator.serviceWorker.controller !== null)).toBe(true);
+  await expect
+    .poll(async () => await secondPage.evaluate(() => navigator.serviceWorker.controller !== null))
+    .toBe(true);
+
+  const before = await bundleSnapshot(page);
+  const retainedPath = before.optionalPaths[0];
+  if (retainedPath === undefined) throw new Error('The production bundle does not contain a deferred asset.');
+  const retainedAsset = before.manifest.assets.find((asset) => asset.path === retainedPath);
+  if (retainedAsset === undefined)
+    throw new Error(`The deferred asset ${retainedPath} is absent from the signed manifest.`);
+  expect((await fetchDigest(page, retainedPath)).status).toBe(200);
+  const downloads: Array<Promise<{ path: string; bodyBytes: number; headerBytes: number }>> = [];
+  const recordDownload = (request: import('@playwright/test').Request): void => {
+    const pathname = new URL(request.url()).pathname;
+    if (request.serviceWorker() !== null && pathname.startsWith('/bundle-assets/')) {
+      downloads.push(
+        request.sizes().then((sizes) => ({
+          path: pathname,
+          bodyBytes: sizes.responseBodySize,
+          headerBytes: sizes.responseHeadersSize,
+        })),
+      );
+    }
+  };
+  context.on('requestfinished', recordDownload);
+  publishChangedWebTree(assetPackageRoot);
+
+  const refresh = () =>
+    page.evaluate(async () => {
+      const worker = (await navigator.serviceWorker.ready).active;
+      if (worker === null) throw new Error('The trusted service worker is unavailable.');
+      const channel = new MessageChannel();
+      return await new Promise<unknown>((resolve) => {
+        channel.port1.addEventListener('message', (event: MessageEvent<unknown>) => resolve(event.data), {
+          once: true,
+        });
+        channel.port1.start();
+        worker.postMessage({ type: 'doompi:refresh-bundle' }, [channel.port2]);
+      });
+    });
+  const refreshed = await refresh();
+  expect(refreshed).toMatchObject({ ok: true, revision: expect.any(Number) });
+  const revision = (refreshed as { revision: number }).revision;
+  expect(revision).toBeGreaterThan(before.manifest.revision);
+  await expect
+    .poll(async () => await page.evaluate((key) => sessionStorage.getItem(key), updatedRevisionKey))
+    .toBe(String(revision));
+  await expect
+    .poll(async () => await secondPage.evaluate((key) => sessionStorage.getItem(key), updatedRevisionKey))
+    .toBe(String(revision));
+
+  const transferred = await Promise.all(downloads.splice(0));
+  expect(transferred.map((request) => request.path)).toEqual([`/bundle-assets/${String(revision)}/index.html`]);
+  expect(transferred[0]?.bodyBytes).toBeGreaterThan(0);
+  console.log('Verified update transfer:', JSON.stringify(transferred));
+  expect(await refresh()).toMatchObject({ ok: true, revision });
+  context.off('requestfinished', recordDownload);
+  expect(await Promise.all(downloads)).toEqual([]);
+
+  const after = await bundleSnapshot(page);
+  expect(after.manifest.revision).toBe(revision);
+  expect(after.cacheName).not.toBe(before.cacheName);
+  expect(after.cachedPaths).toContain(retainedPath);
+  await context.setOffline(true);
+  expect(await fetchDigest(page, retainedPath)).toEqual({ status: 200, digest: retainedAsset.sha256 });
+});

--- a/packages/clients/doompi-web/tests/e2e/sessionPerformance.spec.ts
+++ b/packages/clients/doompi-web/tests/e2e/sessionPerformance.spec.ts
@@ -1,0 +1,172 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '../support/cockpit.ts';
+import {
+  performanceEntries,
+  PERFORMANCE_BACKLOG_LIMIT,
+  PERFORMANCE_MARKERS,
+  seedPerformanceSession,
+} from '../support/performanceFixture.ts';
+
+// Test-only inputs: normal regression runs use the current packaged build.
+const snapshotRoot = process.env.DOOMPI_PERFORMANCE_PACKAGE_ROOT ?? null;
+const readyFile = process.env.DOOMPI_PERFORMANCE_READY;
+test.use({ sessionCount: 2, backlogLimit: PERFORMANCE_BACKLOG_LIMIT, assetPackageRoot: snapshotRoot });
+
+type RenderWork = { markdown: number; streaming: number; tool: number; versions: string[] };
+
+async function renderWork(page: import('@playwright/test').Page): Promise<RenderWork> {
+  return page.evaluate(() => (window as unknown as { __doomRenderWork: RenderWork }).__doomRenderWork);
+}
+
+test('switches fixed large and small transcripts without losing their contents', async ({ page, cockpit }) => {
+  seedPerformanceSession(cockpit.sessions[0], 'large');
+  seedPerformanceSession(cockpit.sessions[1], 'small');
+  await page.goto(cockpit.url);
+  await expect(page.getByTestId('entry-assistant').filter({ hasText: PERFORMANCE_MARKERS.large })).toBeVisible();
+  await page.getByTestId('session-card-s2').click();
+  await expect(page.getByTestId('entry-assistant').filter({ hasText: PERFORMANCE_MARKERS.small })).toBeVisible();
+  await expect(page.getByTestId('entry-assistant').filter({ hasText: PERFORMANCE_MARKERS.large })).toHaveCount(0);
+  await page.getByTestId('session-card-s1').click();
+  await expect(page.getByTestId('entry-assistant').filter({ hasText: PERFORMANCE_MARKERS.large })).toBeVisible();
+  await expect(page.getByTestId('entry-assistant')).toHaveCount(140);
+});
+
+test('status updates preserve mounted Markdown and scroll while invalidating tool renderers', async ({
+  page,
+  cockpit,
+}) => {
+  seedPerformanceSession(cockpit.session, 'large');
+  await page.addInitScript(() => {
+    type Fiber = {
+      child: Fiber | null;
+      flags: number;
+      pendingProps?: { entry?: { id?: string }; text?: string };
+      sibling: Fiber | null;
+      type?: unknown;
+    };
+    type Root = { current: Fiber };
+    const work = { markdown: 0, streaming: 0, tool: 0, versions: [] as string[] };
+    let previousFibers = new WeakSet<Fiber>();
+    (window as unknown as { __doomRenderWork: typeof work }).__doomRenderWork = work;
+    (window as unknown as { __REACT_DEVTOOLS_GLOBAL_HOOK__: unknown }).__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+      supportsFiber: true,
+      inject(renderer: { version?: string }) {
+        if (renderer.version) work.versions.push(renderer.version);
+        return 1;
+      },
+      onCommitFiberRoot(_rendererId: number, root: Root) {
+        const committedFibers = new WeakSet<Fiber>();
+        const visit = (fiber: Fiber | null): void => {
+          if (fiber === null) return;
+          committedFibers.add(fiber);
+          const props = fiber.pendingProps;
+          // A bailed-out subtree can reuse the previous fiber with its old PerformedWork flag.
+          // Count only fresh work-in-progress fibers committed this time.
+          if (!previousFibers.has(fiber) && (fiber.flags & 1) !== 0 && typeof fiber.type === 'function') {
+            if (props?.entry?.id === 'perf-large-0-tool') work.tool += 1;
+            if (props?.text?.includes('PERF_LARGE_READY')) work.markdown += 1;
+            if (props?.text?.startsWith('STREAM_RENDER_MARKER')) work.streaming += 1;
+          }
+          visit(fiber.child);
+          visit(fiber.sibling);
+        };
+        visit(root.current);
+        previousFibers = committedFibers;
+      },
+      onCommitFiberUnmount() {},
+    };
+  });
+
+  await page.goto(cockpit.url);
+  await cockpit.session.waitForAttach();
+  await expect(page.getByTestId('entry-assistant').filter({ hasText: PERFORMANCE_MARKERS.large })).toBeVisible();
+  await expect(page.getByTestId('entry-tool').first()).toBeVisible();
+  expect((await renderWork(page)).versions).toContain('19.2.8');
+
+  const heldScrollTop = await page.getByTestId('timeline').evaluate((element) => {
+    if (element.scrollHeight <= element.clientHeight) throw new Error('The performance transcript must overflow.');
+    element.scrollTop = Math.floor((element.scrollHeight - element.clientHeight) / 2);
+    element.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -1 }));
+    element.dispatchEvent(new Event('scroll', { bubbles: true }));
+    return element.scrollTop;
+  });
+
+  const beforeStatus = await renderWork(page);
+  expect(beforeStatus.markdown).toBeGreaterThan(0);
+  expect(beforeStatus.tool).toBeGreaterThan(0);
+  cockpit.session.emit({
+    type: 'extension_ui_request',
+    method: 'setStatus',
+    statusKey: 'doom-major-mode',
+    statusText: '[copilot]',
+  });
+  await expect(page.getByTestId('selection-mode')).toHaveText('COPILOT');
+
+  const afterStatus = await renderWork(page);
+  expect(afterStatus.markdown).toBe(beforeStatus.markdown);
+  expect(afterStatus.tool).toBeGreaterThan(beforeStatus.tool);
+  await expect(page.getByTestId('timeline-jump')).toHaveCount(0);
+  expect(await page.getByTestId('timeline').evaluate((element) => element.scrollTop)).toBe(heldScrollTop);
+
+  cockpit.session.emit({ type: 'agent_start' });
+  cockpit.session.emit({
+    type: 'message_update',
+    assistantMessageEvent: { type: 'text_delta', delta: 'STREAM_RENDER_MARKER first' },
+  });
+  await expect(page.getByTestId('entry-assistant').last()).toContainText('STREAM_RENDER_MARKER first');
+  const beforeStreamChange = await renderWork(page);
+
+  cockpit.session.emit({
+    type: 'message_update',
+    assistantMessageEvent: { type: 'text_delta', delta: ' second' },
+  });
+  await expect(page.getByTestId('entry-assistant').last()).toContainText('STREAM_RENDER_MARKER first second');
+  expect((await renderWork(page)).streaming).toBeGreaterThan(beforeStreamChange.streaming);
+  await expect(page.getByTestId('timeline-jump')).toBeVisible();
+});
+
+test('serves an opt-in production fixture for Playwriter profiling', async ({ cockpit }) => {
+  test.skip(readyFile === undefined, 'Set DOOMPI_PERFORMANCE_READY to hold an isolated profiling server.');
+  if (readyFile === undefined) return;
+  if (snapshotRoot === null) throw new Error('Manual profiling requires an immutable DOOMPI_PERFORMANCE_PACKAGE_ROOT.');
+  test.setTimeout(0);
+  seedPerformanceSession(cockpit.sessions[0], 'large');
+  seedPerformanceSession(cockpit.sessions[1], 'small');
+  const destination = path.resolve(readyFile);
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  const stopFile = `${destination}.stop`;
+  if (fs.existsSync(stopFile)) throw new Error('Choose a fresh performance ready-file path for this profiling run.');
+  // Creating stopFile releases the fixture through normal Playwright cleanup.
+  const stopped = new Promise<void>((resolve, reject) => {
+    const watcher = fs.watch(path.dirname(destination), () => {
+      if (fs.existsSync(stopFile)) {
+        watcher.close();
+        resolve();
+      }
+    });
+    watcher.once('error', (error) => {
+      watcher.close();
+      reject(error);
+    });
+  });
+  fs.writeFileSync(
+    destination,
+    JSON.stringify(
+      {
+        url: cockpit.url,
+        packageRoot: snapshotRoot,
+        sessions: ['s1', 's2'],
+        markers: PERFORMANCE_MARKERS,
+        logicalInputSha256: createHash('sha256')
+          .update(JSON.stringify([performanceEntries('large'), performanceEntries('small')]))
+          .digest('hex'),
+        stopFile,
+      },
+      null,
+      2,
+    ),
+  );
+  await stopped;
+});

--- a/packages/clients/doompi-web/tests/support/cockpit.ts
+++ b/packages/clients/doompi-web/tests/support/cockpit.ts
@@ -116,6 +116,8 @@ interface CockpitOptions {
   spawnStub: 'ok' | 'fail';
   /** Which bundle to serve: the package's own dist, or the synced-style bundle global setup built. */
   assets: 'packaged' | 'synced';
+  /** Immutable package snapshot for production A/B tests, including its worker and executable. */
+  assetPackageRoot: string | null;
   /** Maximum frames buffered by a fake session while the hub is detached. */
   backlogLimit: number;
 }
@@ -132,6 +134,7 @@ export const test = base.extend<CockpitOptions & { cockpit: CockpitFixture }>({
   sessionCount: [1, { option: true }],
   spawnStub: ['ok', { option: true }],
   assets: ['packaged', { option: true }],
+  assetPackageRoot: [null, { option: true }],
   backlogLimit: [512, { option: true }],
   page: async ({ page, cockpit }, use) => {
     await page.goto(`${cockpit.url}/pair`);
@@ -140,7 +143,7 @@ export const test = base.extend<CockpitOptions & { cockpit: CockpitFixture }>({
     await page.goto('about:blank');
     await use(page);
   },
-  cockpit: async ({ sessionCount, spawnStub, assets, backlogLimit }, use) => {
+  cockpit: async ({ sessionCount, spawnStub, assets, assetPackageRoot, backlogLimit }, use) => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-hub-e2e-'));
     const syncedDist = process.env.DOOMPI_E2E_SYNCED_DIST;
     const syncedHome = process.env.DOOMPI_E2E_SYNCED_HOME;
@@ -205,15 +208,16 @@ export const test = base.extend<CockpitOptions & { cockpit: CockpitFixture }>({
       WORKFLOW_MCP_HOME: workflowHome,
       PI_CODING_AGENT_DIR: agentDir,
       DOOMPI_SYNC_COMMAND: syncStub,
+      DOOMPI_WEB_PACKAGE_ROOT: assetPackageRoot ?? packageRoot,
     };
     for (const key of Object.keys(env)) if (/_API_KEY$|_AUTH_TOKEN$|_OAUTH_TOKEN$/.test(key)) delete env[key];
     // Assets are always explicit: without this, the server would prefer the
     // developer's machine-wide ~/.doompi/web bundle over the freshly built one.
-    const assetsDir = assets === 'synced' ? (syncedDist as string) : path.join(packageRoot, 'dist', 'web');
+    const assetsDir = assets === 'synced' ? syncedDist : path.join(assetPackageRoot ?? packageRoot, 'dist', 'web');
     const child: ChildProcess = spawn(
       process.execPath,
       [
-        binary,
+        assetPackageRoot === null ? binary : path.join(assetPackageRoot, 'dist', 'bin', 'serve.mjs'),
         '--registry-dir',
         registryDir,
         '--state-dir',

--- a/packages/clients/doompi-web/tests/support/performanceFixture.ts
+++ b/packages/clients/doompi-web/tests/support/performanceFixture.ts
@@ -1,0 +1,72 @@
+import type { FakeSession, Frame } from './fakeSession.ts';
+
+export const PERFORMANCE_BACKLOG_LIMIT = 2_000;
+export const PERFORMANCE_MARKERS = { large: 'PERF_LARGE_READY', small: 'PERF_SMALL_READY' } as const;
+export type PerformanceWorkload = keyof typeof PERFORMANCE_MARKERS;
+
+/** Fixed logical input, shared by correctness tests and production browser profiling. */
+export function performanceEntries(workload: PerformanceWorkload): Frame[] {
+  const turns = workload === 'large' ? 140 : 2;
+  const entries: Frame[] = [];
+  const paragraph = 'Verified state stays ordered while the focused session changes. '.repeat(12);
+  for (let index = 0; index < turns; index += 1) {
+    const prefix = `perf-${workload}-${String(index)}`;
+    entries.push({
+      id: `${prefix}-user`,
+      type: 'message',
+      message: { role: 'user', content: [{ type: 'text', text: `Review fixture turn ${String(index)}.` }] },
+    });
+    const content: Frame[] = [
+      { type: 'thinking', thinking: `Checking turn ${String(index)} without changing session identity.` },
+      {
+        type: 'text',
+        text: [
+          `## Fixture turn ${String(index)}`,
+          paragraph,
+          '- [x] Preserve order\n- [ ] Confirm the next update',
+          '| State | Result |\n| --- | --- |\n| idle | verified |',
+          '```ts\nconst session = { phase: "idle", ready: true };\n```',
+          'Inspect `README.md` or [the reference](https://example.com/reference).',
+          index === turns - 1 ? PERFORMANCE_MARKERS[workload] : '',
+        ].join('\n\n'),
+      },
+    ];
+    const withTool = workload === 'large' && index % 14 === 0;
+    if (withTool)
+      content.push({ type: 'toolCall', id: `${prefix}-tool`, name: 'read', arguments: { path: 'README.md' } });
+    entries.push({ id: `${prefix}-assistant`, type: 'message', message: { role: 'assistant', content } });
+    if (withTool) {
+      entries.push({
+        id: `${prefix}-result`,
+        type: 'message',
+        message: {
+          role: 'toolResult',
+          toolCallId: `${prefix}-tool`,
+          toolName: 'read',
+          content: [{ type: 'text', text: `Fixture file result ${String(index)}.` }],
+          isError: false,
+        },
+      });
+    }
+  }
+  return entries;
+}
+
+export function seedPerformanceSession(session: FakeSession, workload: PerformanceWorkload): void {
+  session.emit({
+    type: 'response',
+    command: 'get_entries',
+    success: true,
+    data: { entries: performanceEntries(workload) },
+  });
+  const statusFrames = workload === 'large' ? 1_000 : 1;
+  for (let index = 0; index < statusFrames; index += 1) {
+    session.emit({
+      type: 'extension_ui_request',
+      method: 'setStatus',
+      statusKey: 'performance',
+      statusText: String(index),
+    });
+  }
+  session.emit({ type: 'agent_settled' });
+}

--- a/packages/clients/doompi-web/tests/unit/Timeline.test.ts
+++ b/packages/clients/doompi-web/tests/unit/Timeline.test.ts
@@ -1,4 +1,4 @@
-import { defineWebPlugin } from '@agimon-ai/doompi-web-contracts';
+import { defineWebPlugin, type ToolMessageRenderProps } from '@agimon-ai/doompi-web-contracts';
 import { Store } from '@tanstack/store';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Transcript } from '../../src/web/features/session/Timeline.tsx';
 import { initialSessionState } from '../../src/web/lib/sessionModel.ts';
 import { installWebPlugins, resetWebPlugins } from '../../src/web/lib/pluginRegistry.ts';
+import { sessionStoreFor } from '../../src/web/stores/sessionStore.ts';
 
 vi.mock('../../src/web/features/session/MessageMarkdown.tsx', () => ({
   MessageMarkdown: ({ text }: { text: string }) => createElement('span', null, text),
@@ -97,5 +98,79 @@ describe('Timeline persona avatar', () => {
 
     expect(markup).toContain('aria-label="Rhea"');
     expect(markup).not.toContain('aria-label="Ponytail"');
+  });
+});
+
+describe('Timeline tool props', () => {
+  it('uses active statuses for renderer selection while binding actions to the transcript session', () => {
+    sessionStoreFor('session-bound').setState(() => ({
+      ...initialSessionState,
+      statuses: { 'doom-mcp': 'github' },
+    }));
+    const PluginMessage = (props: ToolMessageRenderProps) =>
+      createElement('span', {
+        'data-testid': 'plugin-tool-message',
+        'data-session-id': props.sessionId,
+        'data-status': props.statuses['doom-mcp'] ?? 'none',
+      });
+    installWebPlugins([
+      defineWebPlugin({
+        id: 'tools',
+        toolRenderers: [
+          {
+            tools: ['exact_tool'],
+            message: PluginMessage,
+          },
+          {
+            tools: [],
+            matches: (name, statuses) =>
+              name === 'github_search' && (statuses['doom-mcp'] ?? '').split(',').includes('github'),
+            message: PluginMessage,
+          },
+        ],
+      }),
+    ]);
+    const store = new Store({
+      ...initialSessionState,
+      entries: [
+        {
+          kind: 'tool' as const,
+          id: 'exact',
+          toolCallId: 'call-exact',
+          name: 'exact_tool',
+          args: {},
+          argSummary: '',
+          result: null,
+          output: '',
+          isError: false,
+          running: false,
+        },
+        {
+          kind: 'tool' as const,
+          id: 'matched',
+          toolCallId: 'call-matched',
+          name: 'github_search',
+          args: {},
+          argSummary: '',
+          result: null,
+          output: '',
+          isError: false,
+          running: false,
+        },
+      ],
+    });
+
+    const markup = renderToStaticMarkup(
+      createElement(Transcript, {
+        store,
+        sessionId: 'session-bound',
+        empty: createElement('div'),
+      }),
+    );
+
+    expect(markup).toContain('data-session-id="session-bound"');
+    expect(markup).toContain('data-status="none"');
+    expect(markup.match(/data-tool-renderer="plugin"/g)).toHaveLength(1);
+    expect(markup).toContain('data-tool-name="github_search" data-tool-state="ok" data-tool-renderer="host"');
   });
 });

--- a/packages/clients/doompi-web/tests/unit/bundleAssetPolicy.test.ts
+++ b/packages/clients/doompi-web/tests/unit/bundleAssetPolicy.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { classifyOptionalBundleAssets } from '../../src/adapters/bundleAssetPolicy.ts';
+import { parseBundleAssetPolicy } from '../../src/types/bundleAssetPolicy.ts';
+
+describe('bundle asset policy', () => {
+  it('defers Mermaid and the PDF worker through graph ownership, while shared output stays eager', () => {
+    expect(
+      classifyOptionalBundleAssets({
+        'assets/app.js': {
+          type: 'chunk',
+          isEntry: true,
+          modules: { '/src/main.ts': {} },
+          dynamicImports: ['assets/mermaid.js', 'assets/pdf.js'],
+          imports: ['assets/shared.js'],
+        },
+        'assets/mermaid.js': {
+          type: 'chunk',
+          modules: { '/node_modules/mermaid/dist/mermaid.js': {} },
+          imports: ['assets/shared.js'],
+        },
+        'assets/pdf.js': {
+          type: 'chunk',
+          modules: { '/node_modules/pdfjs-dist/webpack.mjs': {} },
+          code: 'const worker = new URL("/assets/pdf.worker.js", import.meta.url);',
+        },
+        'assets/pdf.worker.js': { type: 'asset' },
+        'assets/shared.js': { type: 'chunk', modules: { '/node_modules/react/index.js': {} } },
+        'assets/logo.svg': { type: 'asset' },
+      }),
+    ).toEqual(['/assets/mermaid.js', '/assets/pdf.js', '/assets/pdf.worker.js']);
+  });
+
+  it('keeps an unclassified or eager-owned dependency out of the optional policy', () => {
+    expect(
+      classifyOptionalBundleAssets({
+        'app.js': {
+          type: 'chunk',
+          isEntry: true,
+          facadeModuleId: '/src/main.ts',
+          modules: { '/src/main.ts': {} },
+          imports: ['mermaid.js', 'shared.js'],
+        },
+        'mermaid.js': { type: 'chunk', modules: { '/node_modules/mermaid/dist/mermaid.js': {} } },
+        'shared.js': { type: 'chunk', modules: { '/node_modules/d3/index.js': {} } },
+      }),
+    ).toEqual([]);
+  });
+
+  it('keeps mixed application and optional-package chunks eager', () => {
+    expect(
+      classifyOptionalBundleAssets({
+        'app.js': { type: 'chunk', isEntry: true, modules: { '/src/main.ts': {} }, dynamicImports: ['mixed.js'] },
+        'mixed.js': { type: 'chunk', modules: { '/src/feature.ts': {}, '/node_modules/mermaid/index.js': {} } },
+      }),
+    ).toEqual([]);
+  });
+
+  it('defers transitive vendor modules only with module-graph evidence', () => {
+    const bundle = {
+      'app.js': {
+        type: 'chunk' as const,
+        isEntry: true,
+        modules: { '/src/main.ts': {} },
+        dynamicImports: ['mermaid.js'],
+      },
+      'mermaid.js': {
+        type: 'chunk' as const,
+        modules: { '/node_modules/mermaid/index.js': {}, '/node_modules/d3/index.js': {} },
+      },
+    };
+    expect(classifyOptionalBundleAssets(bundle)).toEqual([]);
+    expect(
+      classifyOptionalBundleAssets(bundle, (id) =>
+        id === '/node_modules/mermaid/index.js' ? ['/node_modules/d3/index.js'] : [],
+      ),
+    ).toEqual(['/mermaid.js']);
+  });
+
+  it('keeps mixed transitive chunks and HTML-owned resources eager and excludes source maps', () => {
+    expect(
+      classifyOptionalBundleAssets({
+        'index.html': { type: 'asset', source: '<link href="assets/shared.css">' },
+        'app.js': { type: 'chunk', isEntry: true, modules: { '/src/main.ts': {} }, dynamicImports: ['mermaid.js'] },
+        'mermaid.js': {
+          type: 'chunk',
+          modules: { '/node_modules/mermaid/index.js': {} },
+          imports: ['mixed.js'],
+          referencedFiles: ['assets/shared.css', 'mermaid.js.map'],
+        },
+        'mixed.js': { type: 'chunk', modules: { '/src/feature.ts': {}, '/node_modules/mermaid/helper.js': {} } },
+        'assets/shared.css': { type: 'asset' },
+        'mermaid.js.map': { type: 'asset' },
+      }),
+    ).toEqual(['/mermaid.js']);
+  });
+
+  it('rejects unsupported, duplicate, and non-root-relative policy paths', () => {
+    expect(parseBundleAssetPolicy({ version: 1, optional: ['/assets/pdf.js'] })).toEqual({
+      version: 1,
+      optional: ['/assets/pdf.js'],
+    });
+    expect(parseBundleAssetPolicy({ version: 2, optional: [] })).toBeUndefined();
+    expect(parseBundleAssetPolicy({ version: 1, optional: ['/a.js', '/a.js'] })).toBeUndefined();
+    expect(parseBundleAssetPolicy({ version: 1, optional: ['https://example.test/a.js'] })).toBeUndefined();
+  });
+});

--- a/packages/clients/doompi-web/tests/unit/bundleAssetPolicyBuild.test.ts
+++ b/packages/clients/doompi-web/tests/unit/bundleAssetPolicyBuild.test.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+import { bundleAssetPolicyPlugin } from '../../src/adapters/bundleAssetPolicy.ts';
+import { parseBundleAssetPolicy } from '../../src/types/bundleAssetPolicy.ts';
+
+const requireFromComponents = createRequire(
+  new URL('../../../../core/doompi-web-components/package.json', import.meta.url),
+);
+
+describe('bundle asset policy production graph', () => {
+  it('defers real Mermaid and PDF output graphs while application output stays eager', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'doompi-bundle-policy-'));
+    const outDir = path.join(root, 'dist');
+    fs.mkdirSync(path.join(root, 'src'));
+    fs.writeFileSync(path.join(root, 'index.html'), '<script type="module" src="/src/application.js"></script>');
+    fs.writeFileSync(
+      path.join(root, 'src/application.js'),
+      [
+        "import './core.js';",
+        "globalThis.loadMermaid = () => import('mermaid');",
+        "globalThis.loadPdf = () => import('pdfjs-dist/webpack.mjs');",
+      ].join('\n'),
+    );
+    fs.writeFileSync(path.join(root, 'src/core.js'), "import './shared.js';\nglobalThis.coreLoaded = true;\n");
+    fs.writeFileSync(path.join(root, 'src/shared.js'), 'globalThis.sharedLoaded = true;\n');
+
+    try {
+      const result = await build({
+        root,
+        configFile: false,
+        logLevel: 'silent',
+        plugins: [bundleAssetPolicyPlugin()],
+        resolve: {
+          alias: {
+            mermaid: requireFromComponents.resolve('mermaid'),
+            'pdfjs-dist/webpack.mjs': requireFromComponents.resolve('pdfjs-dist/webpack.mjs'),
+          },
+        },
+        build: { outDir, emptyOutDir: true, sourcemap: true },
+      });
+      const builds = Array.isArray(result) ? result : [result];
+      const outputs = builds.flatMap((output) => {
+        if (!('output' in output)) throw new Error('Vite returned a watcher for a production build');
+        return output.output;
+      });
+      const chunks = outputs.filter((output) => output.type === 'chunk');
+      const chunkWithModule = (fragment: string) =>
+        chunks.find((chunk) => Object.keys(chunk.modules).some((id) => id.replaceAll('\\', '/').includes(fragment)));
+      const mermaid = chunkWithModule('/node_modules/mermaid/');
+      const pdf = chunkWithModule('/node_modules/pdfjs-dist/');
+      expect(mermaid).toBeDefined();
+      expect(pdf).toBeDefined();
+
+      const policy = parseBundleAssetPolicy(
+        JSON.parse(fs.readFileSync(path.join(outDir, 'bundle-asset-policy.json'), 'utf8')),
+      );
+      expect(policy).toBeDefined();
+      const optional = new Set(policy?.optional.map((fileName) => fileName.slice(1)));
+      const emitted = new Set(outputs.map((output) => output.fileName));
+
+      expect([...optional].every((fileName) => emitted.has(fileName))).toBe(true);
+      expect(optional.has(mermaid?.fileName ?? '')).toBe(true);
+      expect(optional.has(pdf?.fileName ?? '')).toBe(true);
+
+      // Vite 8 emits the worker as an asset referenced by the generated PDF module URL.
+      // Its hashed filename is read from the output graph, not used to infer ownership.
+      const pdfResources = outputs.filter(
+        (output) => output.type === 'asset' && !output.fileName.endsWith('.map') && pdf?.code.includes(output.fileName),
+      );
+      expect(pdfResources.length).toBeGreaterThan(0);
+      expect(pdfResources.every((output) => optional.has(output.fileName))).toBe(true);
+      expect(pdf?.code).toContain('new Worker');
+
+      for (const source of ['/src/application.js', '/src/core.js', '/src/shared.js']) {
+        const applicationChunk = chunkWithModule(source);
+        expect(applicationChunk, source).toBeDefined();
+        expect(optional.has(applicationChunk?.fileName ?? ''), source).toBe(false);
+      }
+
+      const maps = outputs.filter((output) => output.fileName.endsWith('.map'));
+      expect(maps.length).toBeGreaterThan(0);
+      expect(maps.every((output) => !optional.has(output.fileName))).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/packages/clients/doompi-web/tests/unit/bundlePublication.test.ts
+++ b/packages/clients/doompi-web/tests/unit/bundlePublication.test.ts
@@ -28,6 +28,17 @@ describe('signed bundle publication', () => {
     expect(publication.current()?.signed.manifest.assets.map((asset) => asset.path)).toContain('/index.html');
   });
 
+  it('signs the v1 asset policy as an ordinary manifest v2 JSON asset', () => {
+    const paths = fixture();
+    fs.writeFileSync(path.join(paths.dir, 'bundle-asset-policy.json'), '{"version":1,"optional":[]}\n');
+    const asset = createBundlePublication(paths)
+      .current()
+      ?.signed.manifest.assets.find((candidate) => candidate.path === '/bundle-asset-policy.json');
+
+    expect(asset?.contentType).toBe('application/json');
+    expect(asset?.sha256).toMatch(/^[a-f0-9]{64}$/u);
+  });
+
   it('advances the revision when sync replaces bundle bytes', () => {
     const paths = fixture();
     const publication = createBundlePublication(paths);

--- a/packages/clients/doompi-web/tests/unit/performanceFixture.test.ts
+++ b/packages/clients/doompi-web/tests/unit/performanceFixture.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { performanceEntries, PERFORMANCE_MARKERS } from '../support/performanceFixture.ts';
+
+describe('performanceEntries', () => {
+  it('keeps both logical workloads repeatable and their IDs distinct', () => {
+    const large = performanceEntries('large');
+    const small = performanceEntries('small');
+    expect(large).toEqual(performanceEntries('large'));
+    expect(small).toEqual(performanceEntries('small'));
+    const ids = [...large, ...small].map((entry) => entry.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(large).toHaveLength(290);
+    expect(small).toHaveLength(4);
+  });
+
+  it('keeps the large workload inside the protocol fixture window with tools and a final marker', () => {
+    const entries = performanceEntries('large');
+    expect(entries.length).toBeLessThanOrEqual(300);
+    expect(JSON.stringify(entries.at(-1))).toContain(PERFORMANCE_MARKERS.large);
+    expect(JSON.stringify(entries)).toContain('toolResult');
+    expect(JSON.stringify(performanceEntries('small').at(-1))).toContain(PERFORMANCE_MARKERS.small);
+  });
+});

--- a/packages/clients/doompi-web/tests/unit/serviceWorkerAssets.test.ts
+++ b/packages/clients/doompi-web/tests/unit/serviceWorkerAssets.test.ts
@@ -1,0 +1,594 @@
+import { webcrypto } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BundleManifest } from '@agimon-ai/doompi-web-security/browser';
+import type { ActiveBundleState, VerifiedPluginCompositionState } from '../../src/pwa/bundleCache.ts';
+
+const mocks = vi.hoisted(() => ({
+  active: undefined as ActiveBundleState | undefined,
+  plugin: undefined as VerifiedPluginCompositionState | undefined,
+  manifest: undefined as BundleManifest | undefined,
+  verifyBundleAsset: vi.fn(),
+  commitActiveBundle: vi.fn(),
+  clearActiveBundle: vi.fn(),
+  commitVerifiedPluginComposition: vi.fn(),
+  clearVerifiedPluginComposition: vi.fn(),
+}));
+vi.mock('@agimon-ai/doompi-web-security/browser', () => ({
+  BUNDLE_MANIFEST_ROUTE: '/api/bundle-manifest',
+  canonicalManifest: (manifest: BundleManifest) => JSON.stringify(manifest),
+  verifyBundleAsset: mocks.verifyBundleAsset,
+  verifySignedBundleManifest: vi.fn(async () =>
+    mocks.manifest === undefined
+      ? { ok: false, failure: { code: 'bad-signature' } }
+      : { ok: true, manifest: mocks.manifest },
+  ),
+}));
+
+vi.mock('../../src/pwa/bundleCache.ts', () => ({
+  readActiveBundle: vi.fn(async () => mocks.active),
+  commitActiveBundle: mocks.commitActiveBundle,
+  clearActiveBundle: mocks.clearActiveBundle,
+  readVerifiedPluginComposition: vi.fn(async () => mocks.plugin),
+  listVerifiedPluginCompositions: vi.fn(async () => (mocks.plugin === undefined ? [] : [mocks.plugin])),
+  commitVerifiedPluginComposition: mocks.commitVerifiedPluginComposition,
+  clearVerifiedPluginComposition: mocks.clearVerifiedPluginComposition,
+}));
+
+type WorkerListener = (event: never) => void;
+type FetchOutcome = { response?: Promise<Response>; lifetime?: Promise<unknown> };
+
+class MemoryCache {
+  readonly entries = new Map<string, Response>();
+
+  async match(key: RequestInfo | URL): Promise<Response | undefined> {
+    return this.entries.get(cacheKey(key))?.clone();
+  }
+
+  async put(key: RequestInfo | URL, response: Response): Promise<void> {
+    this.entries.set(cacheKey(key), response.clone());
+  }
+
+  async delete(key: RequestInfo | URL): Promise<boolean> {
+    return this.entries.delete(cacheKey(key));
+  }
+}
+
+class MemoryCacheStorage {
+  readonly stores = new Map<string, MemoryCache>();
+  failKeys = false;
+
+  async open(name: string): Promise<MemoryCache> {
+    let cache = this.stores.get(name);
+    if (cache === undefined) {
+      cache = new MemoryCache();
+      this.stores.set(name, cache);
+    }
+    return cache;
+  }
+
+  async has(name: string): Promise<boolean> {
+    return this.stores.has(name);
+  }
+
+  async delete(name: string): Promise<boolean> {
+    return this.stores.delete(name);
+  }
+
+  async keys(): Promise<string[]> {
+    if (this.failKeys) throw new Error('cache enumeration failed');
+    return [...this.stores.keys()];
+  }
+}
+
+const listeners = new Map<string, WorkerListener>();
+let cacheStorage: MemoryCacheStorage;
+let expectedBytes: Map<string, string>;
+let rawFetches: string[];
+let fetchImplementation: (input: RequestInfo | URL) => Promise<Response>;
+
+function cacheKey(value: RequestInfo | URL): string {
+  if (typeof value === 'string') return value;
+  const url = value instanceof URL ? value : new URL(value.url);
+  return url.origin === 'https://cockpit.test' ? url.pathname : url.href;
+}
+
+function asset(path: string, body: string) {
+  return {
+    path,
+    sha256: 'a'.repeat(64),
+    byteLength: new TextEncoder().encode(body).byteLength,
+    contentType: path.endsWith('.html') ? 'text/html' : path.endsWith('.json') ? 'application/json' : 'text/javascript',
+  };
+}
+
+function manifest(revision: number, bodies: Record<string, string>): BundleManifest {
+  expectedBytes = new Map(Object.entries(bodies));
+  return {
+    version: 2,
+    revision,
+    builtAt: revision,
+    assets: Object.entries(bodies).map(([path, body]) => asset(path, body)),
+  };
+}
+
+function networkResponse(
+  path: string,
+  body: string,
+  options: { ok?: boolean; redirected?: boolean; url?: string } = {},
+) {
+  const response = new Response(body, { status: options.ok === false ? 500 : 200 });
+  Object.defineProperties(response, {
+    url: { value: options.url ?? `https://cockpit.test${path}` },
+    redirected: { value: options.redirected ?? false },
+  });
+  return response;
+}
+
+async function activate(publicKey = 'key', minimumRevision = 1) {
+  return await sendMessage({ type: 'doompi:activate-bundle', publicKey, minimumRevision });
+}
+
+async function reset() {
+  return await sendMessage({ type: 'doompi:reset-bundle-trust' });
+}
+
+async function activatePlugin(compositionId: string, revision = 1) {
+  const route = `/api/web-plugins/${compositionId}/${String(revision)}`;
+  return await sendMessage({
+    type: 'doompi:activate-plugin-composition',
+    compositionId,
+    revision,
+    manifestUrl: `${route}/manifest`,
+    rawAssetBaseUrl: `${route}/assets`,
+    verifiedAssetBaseUrl: `/verified-plugins/${compositionId}/${String(revision)}`,
+    relayThroughClient: false,
+  });
+}
+
+async function sendMessage(data: unknown): Promise<Record<string, unknown>> {
+  let lifetime: Promise<unknown> | undefined;
+  let reply: Record<string, unknown> | undefined;
+  const event = {
+    data,
+    ports: [{ postMessage: (value: Record<string, unknown>) => (reply = value) }],
+    waitUntil: (value: Promise<unknown>) => (lifetime = value),
+  };
+  listeners.get('message')?.(event as never);
+  await lifetime;
+  if (reply === undefined) throw new Error('The service worker did not reply.');
+  return reply;
+}
+
+function dispatchFetch(path: string): FetchOutcome {
+  let response: Promise<Response> | undefined;
+  let lifetime: Promise<unknown> | undefined;
+  const event = {
+    request: new Request(`https://cockpit.test${path}`),
+    respondWith: (value: Promise<Response>) => (response = value),
+    waitUntil: (value: Promise<unknown>) => (lifetime = value),
+  };
+  listeners.get('fetch')?.(event as never);
+  return { response, lifetime };
+}
+
+async function body(response: Promise<Response> | undefined): Promise<string> {
+  if (response === undefined) throw new Error('The service worker did not handle the fetch.');
+  return await (await response).text();
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => (resolve = done));
+  return { promise, resolve };
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  listeners.clear();
+  cacheStorage = new MemoryCacheStorage();
+  expectedBytes = new Map();
+  rawFetches = [];
+  mocks.active = undefined;
+  mocks.plugin = undefined;
+  mocks.manifest = undefined;
+  mocks.commitActiveBundle.mockReset().mockImplementation(async (state: ActiveBundleState) => {
+    mocks.active = state;
+  });
+  mocks.clearActiveBundle.mockReset().mockImplementation(async () => {
+    mocks.active = undefined;
+  });
+  mocks.commitVerifiedPluginComposition
+    .mockReset()
+    .mockImplementation(async (state: VerifiedPluginCompositionState) => {
+      mocks.plugin = state;
+    });
+  mocks.clearVerifiedPluginComposition.mockReset().mockImplementation(async () => {
+    mocks.plugin = undefined;
+  });
+  mocks.verifyBundleAsset
+    .mockReset()
+    .mockImplementation(async (_manifest: BundleManifest, path: string, bytes: ArrayBuffer) => ({
+      ok: new TextDecoder().decode(bytes) === expectedBytes.get(path),
+      failure: { code: 'digest-mismatch' },
+    }));
+  fetchImplementation = async (input) => {
+    const path = cacheKey(input);
+    if (path === '/api/bundle-manifest') return networkResponse(path, '{}');
+    rawFetches.push(path);
+    return networkResponse(path, expectedBytes.get(path.replace(/^\/bundle-assets\/\d+/u, '')) ?? '');
+  };
+  Object.defineProperties(globalThis, {
+    crypto: { configurable: true, value: webcrypto },
+    caches: { configurable: true, value: cacheStorage },
+    fetch: { configurable: true, value: vi.fn((input: RequestInfo | URL) => fetchImplementation(input)) },
+    self: {
+      configurable: true,
+      value: {
+        location: { origin: 'https://cockpit.test' },
+        clients: { claim: vi.fn(), matchAll: vi.fn(async () => []) },
+        registration: { showNotification: vi.fn() },
+        skipWaiting: vi.fn(),
+        setTimeout,
+        clearTimeout,
+        addEventListener: (type: string, listener: WorkerListener) => listeners.set(type, listener),
+      },
+    },
+  });
+  await import('../../src/pwa/serviceWorker.ts');
+});
+
+describe('verified bundle activation', () => {
+  it('reuses verified bytes and limits raw required downloads to four at a time', async () => {
+    const bodies = Object.fromEntries([
+      ['/index.html', 'index'],
+      ...Array.from({ length: 7 }, (_, index) => [`/assets/${String(index)}.js`, `asset-${String(index)}`]),
+    ]);
+    mocks.manifest = manifest(2, bodies);
+    const oldCache = await cacheStorage.open('doompi-bundle-old');
+    await oldCache.put('/index.html', new Response('index'));
+    mocks.active = {
+      signerPublicKey: 'key',
+      manifestDigest: 'old',
+      revision: 1,
+      cacheName: 'doompi-bundle-old',
+    };
+    let active = 0;
+    let maximum = 0;
+    fetchImplementation = async (input) => {
+      const path = cacheKey(input);
+      if (path === '/api/bundle-manifest') return networkResponse(path, '{}');
+      rawFetches.push(path);
+      active += 1;
+      maximum = Math.max(maximum, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+      const assetPath = path.replace('/bundle-assets/2', '');
+      return networkResponse(path, expectedBytes.get(assetPath) ?? '');
+    };
+
+    await expect(activate()).resolves.toMatchObject({ ok: true, revision: 2 });
+    expect(maximum).toBe(4);
+    expect(rawFetches).not.toContain('/bundle-assets/2/index.html');
+    expect(rawFetches).toHaveLength(7);
+  });
+
+  it('deletes failed staging without replacing the active bundle', async () => {
+    mocks.manifest = manifest(2, { '/index.html': 'index', '/assets/app.js': 'good' });
+    const previous: ActiveBundleState = {
+      signerPublicKey: 'key',
+      manifestDigest: 'old',
+      revision: 1,
+      cacheName: 'doompi-bundle-old',
+    };
+    mocks.active = previous;
+    await cacheStorage.open(previous.cacheName);
+    fetchImplementation = async (input) => {
+      const path = cacheKey(input);
+      return networkResponse(
+        path,
+        path.endsWith('app.js') ? 'corrupt' : path === '/api/bundle-manifest' ? '{}' : 'index',
+      );
+    };
+
+    await expect(activate()).resolves.toMatchObject({ ok: false, code: 'asset-verification' });
+    expect(mocks.active).toBe(previous);
+    expect([...cacheStorage.stores.keys()].filter((name) => name !== previous.cacheName)).toEqual([]);
+  });
+
+  it('keeps a committed update when post-commit cleanup fails', async () => {
+    mocks.manifest = manifest(2, { '/index.html': 'index' });
+    cacheStorage.failKeys = true;
+
+    await expect(activate()).resolves.toMatchObject({ ok: true, revision: 2 });
+    expect(mocks.active?.revision).toBe(2);
+  });
+
+  it('waits for sibling downloads before deleting failed staging', async () => {
+    mocks.manifest = manifest(1, {
+      '/index.html': 'index',
+      '/assets/a.js': 'a',
+      '/assets/b.js': 'b',
+      '/assets/c.js': 'c',
+    });
+    const release = deferred<void>();
+    fetchImplementation = async (input) => {
+      const path = cacheKey(input);
+      if (path === '/api/bundle-manifest') return networkResponse(path, '{}');
+      if (path.endsWith('/index.html')) return networkResponse(path, 'corrupt');
+      await release.promise;
+      return networkResponse(path, expectedBytes.get(path.replace('/bundle-assets/1', '')) ?? '');
+    };
+    const activation = activate();
+    const earlyOutcome = await Promise.race([
+      activation.then(() => 'settled'),
+      new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 5)),
+    ]);
+    release.resolve();
+    await activation;
+
+    expect(earlyOutcome).toBe('pending');
+    expect(cacheStorage.stores.size).toBe(0);
+  });
+
+  it('stores the signed manifest envelope needed to authenticate later cache reads', async () => {
+    mocks.manifest = manifest(1, { '/index.html': 'index' });
+
+    await expect(activate()).resolves.toMatchObject({ ok: true });
+    expect(mocks.active).toMatchObject({ signedManifest: {} });
+  });
+
+  it('retains the active cache for a valid same-revision activation', async () => {
+    mocks.manifest = manifest(1, { '/index.html': 'index' });
+    await activate();
+    const cacheName = mocks.active?.cacheName;
+
+    await expect(activate()).resolves.toMatchObject({ ok: true, revision: 1 });
+    expect(mocks.active?.cacheName).toBe(cacheName);
+  });
+
+  it('falls back to eager delivery when the authenticated optional policy is invalid', async () => {
+    mocks.manifest = manifest(1, {
+      '/index.html': 'index',
+      '/bundle-asset-policy.json': '{"version":1,"optional":["/assets/lazy.js","/assets/lazy.js"]}',
+      '/assets/lazy.js': 'lazy',
+    });
+
+    await expect(activate()).resolves.toMatchObject({ ok: true });
+    expect(rawFetches).toContain('/bundle-assets/1/assets/lazy.js');
+    expect(mocks.active?.optionalAssetPaths).toEqual([]);
+  });
+});
+
+describe('lazy verified delivery', () => {
+  async function activateLazy() {
+    mocks.manifest = manifest(1, {
+      '/index.html': 'index',
+      '/bundle-asset-policy.json': '{"version":1,"optional":["/assets/lazy.js"]}',
+      '/assets/lazy.js': 'lazy',
+    });
+    await expect(activate()).resolves.toMatchObject({ ok: true });
+    rawFetches = [];
+  }
+
+  it('fetches an exact optional miss once and deduplicates concurrent requests', async () => {
+    await activateLazy();
+    const gate = deferred<Response>();
+    fetchImplementation = async (input) => {
+      const path = cacheKey(input);
+      rawFetches.push(path);
+      return await gate.promise;
+    };
+    const first = dispatchFetch('/assets/lazy.js');
+    const second = dispatchFetch('/assets/lazy.js');
+    await vi.waitFor(() => expect(rawFetches).toEqual(['/bundle-assets/1/assets/lazy.js']));
+    gate.resolve(networkResponse('/bundle-assets/1/assets/lazy.js', 'lazy'));
+
+    await expect(Promise.all([body(first.response), body(second.response)])).resolves.toEqual(['lazy', 'lazy']);
+    expect(await body(dispatchFetch('/assets/lazy.js').response)).toBe('lazy');
+    expect(rawFetches).toHaveLength(1);
+  });
+
+  it('limits concurrent lazy downloads across distinct optional assets to four', async () => {
+    const optional = Array.from({ length: 7 }, (_, index) => `/assets/lazy-${String(index)}.js`);
+    mocks.manifest = manifest(1, {
+      '/index.html': 'index',
+      '/bundle-asset-policy.json': JSON.stringify({ version: 1, optional }),
+      ...Object.fromEntries(optional.map((path) => [path, path])),
+    });
+    await activate();
+    let active = 0;
+    let maximum = 0;
+    const release = deferred<void>();
+    fetchImplementation = async (input) => {
+      const path = cacheKey(input);
+      active += 1;
+      maximum = Math.max(maximum, active);
+      await release.promise;
+      active -= 1;
+      const assetPath = path.replace('/bundle-assets/1', '');
+      return networkResponse(path, expectedBytes.get(assetPath) ?? '');
+    };
+    const requests = optional.map((path) => {
+      const response = dispatchFetch(path).response;
+      if (response === undefined) throw new Error('The service worker did not handle the optional asset.');
+      return response;
+    });
+    await vi.waitFor(() => expect(active).toBeGreaterThan(0));
+    const observedMaximum = maximum;
+    release.resolve();
+    await Promise.all(requests);
+
+    expect(observedMaximum).toBe(4);
+    expect(maximum).toBe(4);
+  });
+
+  it.each([
+    ['unlisted bytes', '/assets/unlisted.js', 'injected'],
+    ['corrupt listed bytes', '/index.html', 'corrupt'],
+  ])('refuses cached %s', async (_name, path, cachedBody) => {
+    await activateLazy();
+    const cache = await cacheStorage.open(mocks.active?.cacheName ?? '');
+    await cache.put(path, new Response(cachedBody));
+
+    expect((await dispatchFetch(path).response)?.status).toBe(404);
+  });
+
+  it('returns 404 without network access for unlisted and legacy cache misses', async () => {
+    await activateLazy();
+    expect((await dispatchFetch('/assets/unlisted.js').response)?.status).toBe(404);
+    expect(rawFetches).toEqual([]);
+
+    mocks.active = { signerPublicKey: 'key', manifestDigest: 'legacy', revision: 1, cacheName: 'legacy' };
+    const legacy = await cacheStorage.open('legacy');
+    await legacy.put('/index.html', new Response('legacy index'));
+    expect(await body(dispatchFetch('/index.html').response)).toBe('legacy index');
+    expect((await dispatchFetch('/assets/lazy.js').response)?.status).toBe(404);
+    expect(rawFetches).toEqual([]);
+  });
+
+  it.each([
+    ['corrupt bytes', { body: 'corrupt' }],
+    ['a redirect', { body: 'lazy', redirected: true }],
+    ['an untrusted path', { body: 'lazy', url: 'https://cockpit.test/wrong' }],
+  ])('rejects %s and does not cache it', async (_name, responseOptions) => {
+    await activateLazy();
+    fetchImplementation = async (input) => {
+      const path = cacheKey(input);
+      if (path === '/api/bundle-manifest') return networkResponse(path, '{}');
+      const { body: responseBody, ...options } = responseOptions;
+      return networkResponse(path, responseBody, options);
+    };
+
+    expect((await dispatchFetch('/assets/lazy.js').response)?.status).toBe(404);
+    expect(await (await cacheStorage.open(mocks.active?.cacheName ?? '')).match('/assets/lazy.js')).toBeUndefined();
+  });
+
+  it('does not cache an optional download into a newer active revision', async () => {
+    await activateLazy();
+    const oldDownload = deferred<Response>();
+    fetchImplementation = async (input) => {
+      const path = cacheKey(input);
+      if (path === '/bundle-assets/1/assets/lazy.js') return await oldDownload.promise;
+      if (path === '/api/bundle-manifest') return networkResponse(path, '{}');
+      const assetPath = path.replace('/bundle-assets/2', '');
+      return networkResponse(path, expectedBytes.get(assetPath) ?? '');
+    };
+    const pendingFetch = dispatchFetch('/assets/lazy.js');
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalled());
+    mocks.manifest = manifest(2, {
+      '/index.html': 'index 2',
+      '/bundle-asset-policy.json': '{"version":1,"optional":["/assets/lazy.js"]}',
+      '/assets/lazy.js': 'lazy',
+    });
+
+    await expect(sendMessage({ type: 'doompi:refresh-bundle' })).resolves.toMatchObject({ ok: true, revision: 2 });
+    oldDownload.resolve(networkResponse('/bundle-assets/1/assets/lazy.js', 'lazy'));
+
+    expect((await pendingFetch.response)?.status).toBe(404);
+    expect(mocks.active?.revision).toBe(2);
+    expect(await (await cacheStorage.open(mocks.active?.cacheName ?? '')).match('/assets/lazy.js')).toBeUndefined();
+  });
+
+  it('discards an optional download when reset overtakes it', async () => {
+    await activateLazy();
+    const gate = deferred<Response>();
+    fetchImplementation = async (input) => {
+      const path = cacheKey(input);
+      if (path === '/api/bundle-manifest') return networkResponse(path, '{}');
+      if (path === '/bundle-assets/1/assets/lazy.js') return await gate.promise;
+      const assetPath = path.replace('/bundle-assets/1', '');
+      return networkResponse(path, expectedBytes.get(assetPath) ?? '');
+    };
+    const pendingFetch = dispatchFetch('/assets/lazy.js');
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalled());
+    await expect(reset()).resolves.toEqual({ ok: true });
+    gate.resolve(networkResponse('/bundle-assets/1/assets/lazy.js', 'lazy'));
+
+    expect((await pendingFetch.response)?.status).toBe(404);
+    expect(mocks.active).toBeUndefined();
+  });
+
+  it('clears durable trust even when cache cleanup fails', async () => {
+    mocks.active = {
+      signerPublicKey: 'key',
+      manifestDigest: 'old',
+      revision: 1,
+      cacheName: 'doompi-bundle-old',
+    };
+    cacheStorage.failKeys = true;
+
+    await expect(reset()).resolves.toEqual({ ok: true });
+    expect(mocks.clearActiveBundle).toHaveBeenCalledOnce();
+    expect(mocks.active).toBeUndefined();
+  });
+
+  it('clears durable host trust even when plugin cleanup fails', async () => {
+    mocks.active = {
+      signerPublicKey: 'key',
+      manifestDigest: 'host',
+      revision: 1,
+      cacheName: 'doompi-bundle-host',
+    };
+    mocks.plugin = {
+      compositionId: 'a'.repeat(64),
+      signerPublicKey: 'key',
+      manifestDigest: 'plugin',
+      revision: 1,
+      cacheName: 'doompi-plugin-old',
+      verifiedAssetBaseUrl: `/verified-plugins/${'a'.repeat(64)}/1`,
+      lastUsedAt: 1,
+    };
+    const assetPath = `${mocks.plugin.verifiedAssetBaseUrl}/plugin.js`;
+    await (await cacheStorage.open(mocks.plugin.cacheName)).put(assetPath, new Response('old plugin'));
+    mocks.clearVerifiedPluginComposition.mockRejectedValueOnce(new Error('plugin cleanup failed'));
+    cacheStorage.failKeys = true;
+
+    await expect(reset()).resolves.toEqual({ ok: true });
+    expect(mocks.clearActiveBundle).toHaveBeenCalledOnce();
+    expect(mocks.active).toBeUndefined();
+    expect((await dispatchFetch(assetPath).response)?.status).toBe(404);
+  });
+
+  it('does not commit an activation that a reset overtakes', async () => {
+    mocks.manifest = manifest(1, { '/index.html': 'index' });
+    const gate = deferred<Response>();
+    fetchImplementation = async (input) => {
+      const path = cacheKey(input);
+      return path === '/api/bundle-manifest' ? networkResponse(path, '{}') : await gate.promise;
+    };
+    const pendingActivation = activate();
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    const pendingReset = reset();
+    gate.resolve(networkResponse('/bundle-assets/1/index.html', 'index'));
+
+    await expect(pendingActivation).resolves.toMatchObject({ ok: false, code: 'asset-verification' });
+    await expect(pendingReset).resolves.toEqual({ ok: true });
+    expect(mocks.active).toBeUndefined();
+  });
+
+  it('does not commit or report success for a plugin activation overtaken by reset', async () => {
+    const compositionId = 'a'.repeat(64);
+    mocks.active = {
+      signerPublicKey: 'key',
+      manifestDigest: 'host',
+      revision: 1,
+      cacheName: 'doompi-bundle-host',
+    };
+    mocks.manifest = manifest(1, { '/plugin.js': 'plugin' });
+    const gate = deferred<Response>();
+    fetchImplementation = async (input) => {
+      const path = cacheKey(input);
+      if (path.endsWith('/manifest')) return networkResponse(path, '{}');
+      return await gate.promise;
+    };
+    const pendingActivation = activatePlugin(compositionId);
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    const pendingReset = reset();
+    gate.resolve(networkResponse(`/api/web-plugins/${compositionId}/1/assets/plugin.js`, 'plugin'));
+
+    await expect(pendingActivation).resolves.toMatchObject({ ok: false, code: 'trust-reset' });
+    await expect(pendingReset).resolves.toEqual({ ok: true });
+    expect(mocks.commitVerifiedPluginComposition).not.toHaveBeenCalled();
+    expect(mocks.plugin).toBeUndefined();
+  });
+});

--- a/packages/clients/doompi-web/tests/unit/sessionRuntime.test.ts
+++ b/packages/clients/doompi-web/tests/unit/sessionRuntime.test.ts
@@ -18,6 +18,7 @@ const pluginState = vi.hoisted(() => ({
   focusedSessions: [] as string[],
 }));
 
+const menuState = vi.hoisted(() => ({ claimed: [] as string[], cleared: 0 }));
 vi.mock('../../src/web/lib/wsClient.ts', () => ({
   sessionSocketUrl: () => 'ws://test/api/session',
   createSessionSocket: (_url: string, handlers: SocketHandlers) => {
@@ -50,6 +51,13 @@ vi.mock('../../src/web/lib/browserTelemetry.ts', () => ({
   recordBrowserPerformance: () => undefined,
 }));
 
+vi.mock('../../src/web/stores/menuStore.ts', () => ({
+  claimDialogMenu: (id: string) => menuState.claimed.push(id),
+  clearPendingMenu: () => {
+    menuState.cleared += 1;
+  },
+}));
+
 import { startSessionRuntime } from '../../src/web/app/sessionRuntime.ts';
 import { onHubConnected } from '../../src/web/lib/transport.ts';
 import { resetSessions, sessionsStore, setActiveSession } from '../../src/web/stores/sessionsStore.ts';
@@ -68,6 +76,8 @@ afterEach(() => {
   pluginState.dispatched = [];
   pluginState.focus = (_sessionId: string) => Promise.resolve();
   pluginState.focusedSessions = [];
+  menuState.claimed = [];
+  menuState.cleared = 0;
   resetSessions();
 });
 
@@ -79,6 +89,9 @@ function sentCommandTypes(sessionId: string): string[] {
     .filter((type) => type.length > 0);
 }
 
+function sessionSubscriptionFrames(): Record<string, unknown>[] {
+  return socketState.sent.filter((frame) => frame.type === 'subscribe' || frame.type === 'unsubscribe');
+}
 describe('session runtime backlog publication', () => {
   it.each(['session', 'protocol', 'thread'] as const)('publishes only the completed %s replay', (kind) => {
     Object.defineProperty(globalThis, 'window', { configurable: true, value: { location: {} } });
@@ -175,6 +188,131 @@ describe('session runtime backlog publication', () => {
       dropSessionStore(sessionId);
       dropSessionStore(otherId);
     }
+  });
+});
+
+describe('session runtime voice subscription lifetime', () => {
+  it('keeps the voice owner subscribed while another session is visible', () => {
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: { location: {} } });
+    const stop = startSessionRuntime();
+    socketState.handlers?.onFrame({
+      type: 'sessions_snapshot',
+      sessions: [
+        { id: 's1', name: 'Voice owner', createdAt: '1' },
+        { id: 's2', name: 'Visible', createdAt: '2' },
+      ],
+    });
+    setActiveSession('s1');
+    socketState.handlers?.onFrame({
+      type: 'voice_ownership',
+      sessionId: 's1',
+      payload: { activeSessionId: 's1' },
+    });
+    socketState.sent = [];
+
+    setActiveSession('s2');
+
+    expect(sessionSubscriptionFrames()).toEqual([{ type: 'subscribe', sessionId: 's2' }]);
+    stop();
+  });
+
+  it('releases the previous owner subscription after voice stops', () => {
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: { location: {} } });
+    const stop = startSessionRuntime();
+    socketState.handlers?.onFrame({
+      type: 'sessions_snapshot',
+      sessions: [
+        { id: 's1', name: 'Voice owner', createdAt: '1' },
+        { id: 's2', name: 'Visible', createdAt: '2' },
+      ],
+    });
+    setActiveSession('s1');
+    socketState.handlers?.onFrame({
+      type: 'voice_ownership',
+      sessionId: 's1',
+      payload: { activeSessionId: 's1' },
+    });
+    setActiveSession('s2');
+    socketState.sent = [];
+
+    socketState.handlers?.onFrame({
+      type: 'voice_ownership',
+      sessionId: 's1',
+      payload: { activeSessionId: null },
+    });
+
+    expect(sessionSubscriptionFrames()).toEqual([{ type: 'unsubscribe', sessionId: 's1' }]);
+    stop();
+  });
+
+  it('keeps background owner frames away from the visible session menu', () => {
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: { location: {} } });
+    const stop = startSessionRuntime();
+    socketState.handlers?.onFrame({
+      type: 'sessions_snapshot',
+      sessions: [
+        { id: 's1', name: 'Voice owner', createdAt: '1' },
+        { id: 's2', name: 'Visible', createdAt: '2' },
+      ],
+    });
+    setActiveSession('s1');
+    socketState.handlers?.onFrame({
+      type: 'voice_ownership',
+      sessionId: 's1',
+      payload: { activeSessionId: 's1' },
+    });
+    setActiveSession('s2');
+
+    socketState.handlers?.onFrame({
+      type: 'session_frame',
+      sessionId: 's1',
+      frame: { type: 'extension_ui_request', method: 'select', id: 'background-menu' },
+    });
+    socketState.handlers?.onFrame({
+      type: 'session_frame',
+      sessionId: 's1',
+      frame: { type: 'agent_settled' },
+    });
+    socketState.handlers?.onFrame({
+      type: 'session_frame',
+      sessionId: 's2',
+      frame: { type: 'extension_ui_request', method: 'select', id: 'visible-menu' },
+    });
+    socketState.handlers?.onFrame({
+      type: 'session_frame',
+      sessionId: 's2',
+      frame: { type: 'agent_settled' },
+    });
+
+    expect(menuState.claimed).toEqual(['visible-menu']);
+    expect(menuState.cleared).toBe(1);
+    stop();
+  });
+
+  it('restores both visible and owner subscriptions after a fresh socket snapshot', () => {
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: { location: {} } });
+    const sessions = [
+      { id: 's1', name: 'Voice owner', createdAt: '1' },
+      { id: 's2', name: 'Visible', createdAt: '2' },
+    ];
+    const stop = startSessionRuntime();
+    socketState.handlers?.onFrame({ type: 'sessions_snapshot', sessions });
+    setActiveSession('s1');
+    socketState.handlers?.onFrame({
+      type: 'voice_ownership',
+      sessionId: 's1',
+      payload: { activeSessionId: 's1' },
+    });
+    setActiveSession('s2');
+    socketState.sent = [];
+
+    socketState.handlers?.onFrame({ type: 'sessions_snapshot', sessions });
+
+    expect(sessionSubscriptionFrames()).toEqual([
+      { type: 'subscribe', sessionId: 's2' },
+      { type: 'subscribe', sessionId: 's1' },
+    ]);
+    stop();
   });
 });
 

--- a/packages/clients/doompi-web/tests/unit/sessionRuntime.test.ts
+++ b/packages/clients/doompi-web/tests/unit/sessionRuntime.test.ts
@@ -53,6 +53,14 @@ vi.mock('../../src/web/lib/browserTelemetry.ts', () => ({
 import { startSessionRuntime } from '../../src/web/app/sessionRuntime.ts';
 import { onHubConnected } from '../../src/web/lib/transport.ts';
 import { resetSessions, sessionsStore, setActiveSession } from '../../src/web/stores/sessionsStore.ts';
+import {
+  applyProtocolTranscript,
+  applySessionFrame,
+  dropSessionStore,
+  requestOlderHistory,
+  sessionStoreFor,
+} from '../../src/web/stores/sessionStore.ts';
+import { threadStoreKey } from '../../src/web/stores/threadStore.ts';
 
 afterEach(() => {
   socketState.handlers = undefined;
@@ -70,6 +78,105 @@ function sentCommandTypes(sessionId: string): string[] {
     .map((frame) => (frame.frame as { type?: string } | undefined)?.type ?? '')
     .filter((type) => type.length > 0);
 }
+
+describe('session runtime backlog publication', () => {
+  it.each(['session', 'protocol', 'thread'] as const)('publishes only the completed %s replay', (kind) => {
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: { location: {} } });
+    const sessionId = `backlog-${kind}`;
+    const key = kind === 'thread' ? threadStoreKey(sessionId, 'child') : sessionId;
+    const otherId = `${sessionId}-other`;
+    const stop = startSessionRuntime();
+    socketState.handlers?.onFrame({
+      type: 'sessions_snapshot',
+      sessions: [{ id: sessionId, name: kind, createdAt: '1' }],
+    });
+    applySessionFrame(key, {
+      type: 'extension_ui_request',
+      method: 'setStatus',
+      statusKey: 'stale',
+      statusText: 'old',
+    });
+    if (kind === 'protocol') {
+      applyProtocolTranscript(
+        key,
+        [{ kind: 'assistant', id: 'protocol-1', text: 'history', thinking: '', streaming: false }],
+        false,
+      );
+    }
+    const store = sessionStoreFor(key);
+    const otherState = sessionStoreFor(otherId).state;
+    const published = vi.fn();
+    const commandsDuringPublish: string[][] = [];
+    const subscription = store.subscribe((state) => {
+      published(state);
+      commandsDuringPublish.push(sentCommandTypes(sessionId));
+    });
+    socketState.sent = [];
+    const frames = [
+      {
+        type: 'entry_appended',
+        entry: {
+          type: 'message',
+          id: 'oldest-entry',
+          message: { role: 'user', content: [{ type: 'text', text: 'replayed' }] },
+        },
+      },
+      ...Array.from({ length: 1_000 }, (_, index) => ({
+        type: 'extension_ui_request',
+        method: 'setStatus',
+        statusKey: 'progress',
+        statusText: String(index),
+      })),
+    ];
+
+    try {
+      socketState.handlers?.onFrame({
+        type: kind === 'thread' ? 'thread_backlog' : 'session_backlog',
+        sessionId,
+        threadId: 'child',
+        frames,
+        dropped: 4,
+      });
+
+      expect(published).toHaveBeenCalledTimes(1);
+      expect(published).toHaveBeenCalledWith(store.state);
+      expect(commandsDuringPublish).toEqual([[]]);
+      expect(store.state.statuses).toEqual({ progress: '999' });
+      expect(store.state.entries).toEqual([
+        expect.objectContaining(
+          kind === 'protocol'
+            ? { kind: 'assistant', id: 'protocol-1', text: 'history' }
+            : { kind: 'user', text: 'replayed' },
+        ),
+      ]);
+      expect(sessionStoreFor(otherId).state).toBe(otherState);
+      if (kind === 'thread') {
+        expect(sentCommandTypes(sessionId)).toEqual([]);
+        expect(sessionStoreFor(sessionId).state.entries).toEqual([]);
+      } else {
+        expect(sentCommandTypes(sessionId)).toEqual(['get_state', 'get_session_stats', 'get_commands']);
+        expect(sessionsStore.state.byId[sessionId]).toMatchObject({ replayed: frames.length, dropped: 4 });
+        expect(requestOlderHistory(sessionId)).toBe(true);
+        expect(socketState.sent.at(-1)).toEqual({ type: 'history_request', sessionId, before: 'oldest-entry' });
+      }
+
+      socketState.handlers?.onFrame({
+        type: kind === 'thread' ? 'thread_frame' : 'session_frame',
+        sessionId,
+        threadId: 'child',
+        frame: { type: 'extension_ui_request', method: 'setStatus', statusKey: 'progress', statusText: 'live' },
+      });
+      expect(published).toHaveBeenCalledTimes(2);
+      expect(store.state.statuses.progress).toBe('live');
+    } finally {
+      subscription.unsubscribe();
+      stop();
+      dropSessionStore(key);
+      dropSessionStore(sessionId);
+      dropSessionStore(otherId);
+    }
+  });
+});
 
 describe('session runtime hub connection lifecycle', () => {
   it('notifies subscribers after every fresh socket snapshot', () => {

--- a/packages/clients/doompi-web/vite.config.ts
+++ b/packages/clients/doompi-web/vite.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { type Alias, defineConfig, type Plugin } from 'vite';
+import { bundleAssetPolicyPlugin } from './src/adapters/bundleAssetPolicy.ts';
 import { ensureBuiltinWebPluginModules, writeSyncWebPluginModules } from './src/adapters/webPluginGenerate.ts';
 import { scanWebPlugins } from './src/adapters/webPluginScan.ts';
 import { readDevPluginRoots, webPluginCssAlias, webPluginOverridePlugin } from './src/adapters/webPluginVite.ts';
@@ -42,7 +43,7 @@ export default defineConfig(({ command }) => {
   const dev = devPluginOverrides(command);
   return {
     root: clientRoot,
-    plugins: [...dev.plugins, react(), tailwindcss()],
+    plugins: [...dev.plugins, react(), tailwindcss(), bundleAssetPolicyPlugin()],
     resolve: {
       // One instance of each shared runtime even when a plugin package declares
       // its own copies for typechecking.

--- a/packages/default/doompi-mcp/src/adapters/pi/mcpSession.ts
+++ b/packages/default/doompi-mcp/src/adapters/pi/mcpSession.ts
@@ -80,6 +80,8 @@ export class McpSession {
     diagnostics: [],
   };
   private readonly options: McpSessionOptions;
+  /** Credential persistence used by the active runtime and explicit reauthorization. */
+  private tokenStore: TokenStore | undefined;
   /** Resources per server, listed on demand. Errors are never cached, so a retry re-dials. */
   private readonly resourceCache = new Map<string, readonly McpResourceView[]>();
   private readonly changeListeners = new Set<() => void>();
@@ -244,6 +246,7 @@ export class McpSession {
     this.resourceCache.clear();
     const configSources = this.configSources();
     const tokenStore = this.options.tokenStore ?? (await createTokenStore());
+    this.tokenStore = tokenStore;
     await runtime.start({
       configSources,
       tokenStore,
@@ -310,10 +313,12 @@ export class McpSession {
   }
 
   /**
-   * Reconnects one server, running its OAuth flow when it demands one.
+   * Reconnects one server with a fresh OAuth registration.
    *
-   * The existing connection is dropped first: a server holding a stale token would
-   * otherwise keep answering from cache and never reach the authorization step.
+   * The connection is dropped before credentials are cleared so a failed disconnect
+   * does not silently sign the user out. Clearing both tokens and dynamic client
+   * information prevents a server-side registration reset from replaying a stale
+   * `client_id` forever.
    */
   async reauthorize(serverName: string): Promise<void> {
     const clientManager = this.clientManager();
@@ -325,6 +330,7 @@ export class McpSession {
     this.browserAuthorizationRequests.add(serverName);
     try {
       await clientManager.disconnectServer(serverName);
+      await this.tokenStore?.clear(serverName);
       await clientManager.ensureConnected(serverName);
     } finally {
       this.browserAuthorizationRequests.delete(serverName);

--- a/packages/default/doompi-mcp/tests/mcpSession.test.ts
+++ b/packages/default/doompi-mcp/tests/mcpSession.test.ts
@@ -191,6 +191,7 @@ describe('McpSession', () => {
       );
       expect(ensureConnected).not.toHaveBeenCalled();
       await active.reauthorize('pencil');
+      expect(store.clear).toHaveBeenCalledWith('pencil');
       emitState({ serverName: 'pencil', state: 'connected' });
       await vi.waitFor(() => expect(activeTools()).toContain('pencil_get_screenshot'));
     });
@@ -394,17 +395,21 @@ describe('McpSession', () => {
   });
 
   describe('reauthorize', () => {
-    it('drops the connection first so a stale token cannot answer from cache', async () => {
+    it('drops the connection and stale OAuth registration before reconnecting', async () => {
       const { pi } = fakePi();
       const active = session(pi);
       active.install();
       active.activate();
       await active.start();
+      const store = createProxyContainer.mock.calls[0]?.[0]?.auth.tokenStore;
 
       await active.reauthorize('boomlink');
 
       expect(disconnectServer).toHaveBeenCalledWith('boomlink');
+      expect(store.clear).toHaveBeenCalledWith('boomlink');
       expect(ensureConnected).toHaveBeenCalledWith('boomlink');
+      expect(disconnectServer.mock.invocationCallOrder[0]).toBeLessThan(store.clear.mock.invocationCallOrder[0]);
+      expect(store.clear.mock.invocationCallOrder[0]).toBeLessThan(ensureConnected.mock.invocationCallOrder[0]);
     });
 
     it('clears the previous URL before retry even when disconnect rejects without a state event', async () => {

--- a/packages/minor/doompi-loop/README.md
+++ b/packages/minor/doompi-loop/README.md
@@ -45,6 +45,12 @@ Every pass can start another model turn and repeat tool or external side effects
 conservative intervals, make prompts idempotent where possible, and stop loops when the recurring
 work is complete.
 
+## Web extension slots
+
+The Loop Activity section declares `loop.registration` for start controls and `loop.items` for
+session-scoped instance rows. Other web plugins may fill either slot; Loop owns the section shell and
+renders all registered fills without requiring a feature-specific dependency.
+
 ## Extension authors: cross-extension launchers
 
 Launcher definitions use the shared Cordis service. A consumer registers a launcher and returns its

--- a/packages/minor/doompi-loop/src/adapters/pi/extension.ts
+++ b/packages/minor/doompi-loop/src/adapters/pi/extension.ts
@@ -74,6 +74,7 @@ export function installLoopRuntime(cordis: Context, pi: ExtensionAPI): void {
   let activeSession: ActiveLoopSession | undefined;
   let mode: MinorModeOwnerHandle | undefined;
   let disposeLeader: (() => void) | undefined;
+  const launchesInProgress = new WeakSet<ActiveLoopSession>();
 
   const currentSession = (context: ExtensionContext): ActiveLoopSession | undefined => {
     const binding = activeSession;
@@ -191,23 +192,46 @@ export function installLoopRuntime(cordis: Context, pi: ExtensionAPI): void {
   });
 
   registerCommands(pi, {
-    async start(ctx) {
+    async start(ctx, args) {
       const binding = currentSession(ctx);
       if (!binding) return;
-      const launchers = binding.launchers.listLaunchers();
-      if (!launchers.length) {
-        ctx.ui.notify('No loop launchers are registered for this session.', NOTIFY_INFO_LEVEL);
+      if (launchesInProgress.has(binding)) {
+        ctx.ui.notify('A loop setup is already in progress.', NOTIFY_INFO_LEVEL);
         return;
       }
-      const launcherId = await openStartLoopOverlay(ctx, launchers);
-      if (activeSession !== binding || !launcherId) return;
+      launchesInProgress.add(binding);
       try {
+        const launchers = binding.launchers.listLaunchers();
+        if (!launchers.length) {
+          ctx.ui.notify('No loop launchers are registered for this session.', NOTIFY_INFO_LEVEL);
+          return;
+        }
+
+        const argument = args.trim();
+        let launcherId: string | undefined;
+        if (argument) {
+          if (argument.split(/\s+/u).length !== 1) {
+            ctx.ui.notify('Usage: /loop [launcherId]', 'error');
+            return;
+          }
+          if (!launchers.some((launcher) => launcher.id === argument)) {
+            ctx.ui.notify(`Unknown loop launcher: ${argument}`, 'error');
+            return;
+          }
+          launcherId = argument;
+        } else {
+          launcherId = await openStartLoopOverlay(ctx, launchers);
+          if (activeSession !== binding || !launcherId) return;
+        }
+
         const instance = await binding.launchers.launch(launcherId);
         if (activeSession !== binding) return;
         if (instance) ctx.ui.notify(`${instance.label ?? instance.launcherLabel} started.`, NOTIFY_INFO_LEVEL);
       } catch (error) {
         if (activeSession !== binding) return;
         ctx.ui.notify(`Loop could not start: ${error instanceof Error ? error.message : String(error)}`, 'error');
+      } finally {
+        launchesInProgress.delete(binding);
       }
     },
     async list(ctx) {

--- a/packages/minor/doompi-loop/src/commands/loopCommand.ts
+++ b/packages/minor/doompi-loop/src/commands/loopCommand.ts
@@ -5,14 +5,14 @@ const START_COMMAND_DESCRIPTION = 'Start a registered loop';
 const LIST_COMMAND_DESCRIPTION = 'List and stop active loops';
 
 export interface LoopCommandHandlers {
-  start(ctx: ExtensionContext): Promise<void>;
+  start(ctx: ExtensionContext, args: string): Promise<void>;
   list(ctx: ExtensionContext): Promise<void>;
 }
 
 export function registerCommands(pi: ExtensionAPI, handlers: LoopCommandHandlers): void {
   pi.registerCommand(START_COMMAND_NAME, {
     description: START_COMMAND_DESCRIPTION,
-    handler: async (_args, ctx) => handlers.start(ctx),
+    handler: async (args, ctx) => handlers.start(ctx, args),
   });
   pi.registerCommand(LIST_COMMAND_NAME, {
     description: LIST_COMMAND_DESCRIPTION,

--- a/packages/minor/doompi-loop/src/web/components/LoopsActivitySection.tsx
+++ b/packages/minor/doompi-loop/src/web/components/LoopsActivitySection.tsx
@@ -10,37 +10,43 @@ function toneOf(state: LoopStatusState): DotTone {
   return 'yellow';
 }
 
-/** Active recurring prompts owned by the focused session, plus the existing management flow. */
-export function LoopsActivitySection({ sessionId, statuses, sendSessionFrame }: WebPluginSlotProps) {
+/** Renders active recurring prompts contributed to the Loop activity section. */
+export function LoopActivityItems({ statuses }: WebPluginSlotProps) {
   const raw = statuses[LOOP_VIEW_STATUS_KEY];
   const loops = parseLoopStatusView(raw);
   const unavailable = raw !== undefined && raw.trim() !== '' && loops === undefined;
   if (!loops && !unavailable) return null;
 
+  return loops ? (
+    <ul aria-label="active loops" className="flex flex-col gap-1">
+      {loops.map((loop) => (
+        <li
+          key={loop.instanceId}
+          data-testid={`activity-loop-${loop.instanceId}`}
+          data-loop-state={loop.state}
+          title={`${loop.label}: ${loop.detail}`}
+          className="flex min-w-0 flex-col gap-0.5 px-1 py-0.5"
+        >
+          <span className="flex min-w-0 items-center gap-1.5">
+            <Dot tone={toneOf(loop.state)} pulse={loop.state !== 'running'} />
+            <span className="min-w-0 flex-1 truncate text-xs font-bold text-doom-hi">{loop.label}</span>
+            <span className="shrink-0 text-2xs text-doom-faint">{loop.state}</span>
+          </span>
+          <span className="truncate pl-3 text-2xs text-doom-faint">{loop.detail}</span>
+        </li>
+      ))}
+    </ul>
+  ) : (
+    <p className="px-1 text-xs text-doom-faint">loop status unavailable</p>
+  );
+}
+
+/** Idle-safe Loop activity shell with extension registration and instance slots. */
+export function LoopsActivitySection({ sessionId, renderSlot, sendSessionFrame }: WebPluginSlotProps) {
   return (
     <div data-testid="activity-loop-instances" className="flex flex-col gap-2">
-      {loops ? (
-        <ul aria-label="active loops" className="flex flex-col gap-1">
-          {loops.map((loop) => (
-            <li
-              key={loop.instanceId}
-              data-testid={`activity-loop-${loop.instanceId}`}
-              data-loop-state={loop.state}
-              title={`${loop.label}: ${loop.detail}`}
-              className="flex min-w-0 flex-col gap-0.5 px-1 py-0.5"
-            >
-              <span className="flex min-w-0 items-center gap-1.5">
-                <Dot tone={toneOf(loop.state)} pulse={loop.state !== 'running'} />
-                <span className="min-w-0 flex-1 truncate text-xs font-bold text-doom-hi">{loop.label}</span>
-                <span className="shrink-0 text-2xs text-doom-faint">{loop.state}</span>
-              </span>
-              <span className="truncate pl-3 text-2xs text-doom-faint">{loop.detail}</span>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className="px-1 text-xs text-doom-faint">loop status unavailable</p>
-      )}
+      {renderSlot('loop.registration')}
+      {renderSlot('loop.items')}
       <Button
         variant="subtle"
         size="xs"

--- a/packages/minor/doompi-loop/src/web/index.ts
+++ b/packages/minor/doompi-loop/src/web/index.ts
@@ -1,6 +1,6 @@
-import { defineWebPlugin } from '@agimon-ai/doompi-web-contracts';
+import { defineSlot, defineWebPlugin } from '@agimon-ai/doompi-web-contracts';
 import { LOOP_VIEW_STATUS_KEY } from '../types/loopView.ts';
-import { LoopsActivitySection } from './components/LoopsActivitySection.tsx';
+import { LoopActivityItems, LoopsActivitySection } from './components/LoopsActivitySection.tsx';
 
 /**
  * This package's cockpit presence. The selection bar carries the minor mode,
@@ -11,8 +11,10 @@ const LOOPS_GROUP = { key: 'l', label: 'loops', detail: 'recurring prompt loops'
 export const webPlugin = defineWebPlugin({
   id: 'loop',
   minorModes: [{ name: 'loop', keys: 'l l', statusKey: 'doom-loop', order: 30 }],
-  activityGroups: [{ name: 'loops', keys: 'l l', statusKey: LOOP_VIEW_STATUS_KEY, hideWhenEmpty: true, order: 40 }],
+  activityGroups: [{ name: 'loops', keys: 'l l', statusKey: LOOP_VIEW_STATUS_KEY, order: 40 }],
   activitySections: [{ id: 'loops', component: LoopsActivitySection }],
+  slots: [defineSlot({ slot: 'loop.registration' }), defineSlot({ slot: 'loop.items' })],
+  fills: [{ slot: 'loop.items', id: 'instances', component: LoopActivityItems }],
   // The TUI's SPC l s and SPC l l: both are slash commands, so both carry over.
   leaderBindings: [
     {

--- a/packages/minor/doompi-loop/tests/extension.test.ts
+++ b/packages/minor/doompi-loop/tests/extension.test.ts
@@ -257,6 +257,72 @@ describe('doom loop extension', () => {
     await extension.shutdown();
   });
 
+  it('launches a registered launcher by ID without opening the chooser', async () => {
+    const extension = await harness('extension-targeted-start');
+    await extension.startSession();
+    await extension.mountLauncher({
+      id: 'agiflow.workflow',
+      source: 'test',
+      label: 'Agiflow project dispatch',
+      description: 'Dispatch selected projects',
+      launch: async ({ instanceId }) => ({
+        instanceId,
+        label: 'Project dispatch',
+        detail: 'selected projects',
+        stop: vi.fn(),
+      }),
+    });
+
+    await extension.commands.get(START_COMMAND_NAME)?.handler('agiflow.workflow', extension.context);
+
+    expect(extension.select).not.toHaveBeenCalled();
+    expect(extension.notify).toHaveBeenCalledWith('Project dispatch started.', 'info');
+    await extension.shutdown();
+  });
+
+  it('does not open overlapping loop setup requests', async () => {
+    const extension = await harness('extension-overlapping-start');
+    await extension.startSession();
+    let finishLaunch: (() => void) | undefined;
+    const launch = vi.fn(
+      ({ instanceId }: { instanceId: string }) =>
+        new Promise<{ instanceId: string; label: string; detail: string; stop: () => void }>((resolve) => {
+          finishLaunch = () =>
+            resolve({ instanceId, label: 'Project dispatch', detail: 'selected projects', stop: vi.fn() });
+        }),
+    );
+    await extension.mountLauncher({
+      id: 'agiflow.workflow',
+      source: 'test',
+      label: 'Agiflow project dispatch',
+      description: 'Dispatch selected projects',
+      launch,
+    });
+
+    const first = extension.commands.get(START_COMMAND_NAME)?.handler('agiflow.workflow', extension.context);
+    await vi.waitFor(() => expect(launch).toHaveBeenCalledOnce());
+    await extension.commands.get(START_COMMAND_NAME)?.handler('agiflow.workflow', extension.context);
+
+    expect(extension.notify).toHaveBeenCalledWith('A loop setup is already in progress.', 'info');
+    expect(launch).toHaveBeenCalledOnce();
+    finishLaunch?.();
+    await first;
+    await extension.shutdown();
+  });
+
+  it('rejects unknown and extra launcher arguments without opening the chooser', async () => {
+    const extension = await harness('extension-invalid-start');
+    await extension.startSession();
+
+    await extension.commands.get(START_COMMAND_NAME)?.handler('missing.launcher', extension.context);
+    await extension.commands.get(START_COMMAND_NAME)?.handler('one two', extension.context);
+
+    expect(extension.select).not.toHaveBeenCalled();
+    expect(extension.notify).toHaveBeenCalledWith('Unknown loop launcher: missing.launcher', 'error');
+    expect(extension.notify).toHaveBeenCalledWith('Usage: /loop [launcherId]', 'error');
+    await extension.shutdown();
+  });
+
   it('publishes starting, running, stopping, and removal views for non-TUI sessions', async () => {
     const extension = await harness('extension-loop-view');
     await extension.startSession();

--- a/packages/minor/doompi-loop/tests/web/loopSurfaces.test.ts
+++ b/packages/minor/doompi-loop/tests/web/loopSurfaces.test.ts
@@ -1,6 +1,7 @@
 import { renderPlugin, slotPropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
 import { describe, expect, it } from 'vitest';
 import { LOOP_VIEW_STATUS_KEY } from '../../src/types/loopView.ts';
+import { LoopActivityItems } from '../../src/web/components/LoopsActivitySection.tsx';
 import { webPlugin } from '../../src/web/index.ts';
 
 const payload = JSON.stringify([
@@ -9,22 +10,24 @@ const payload = JSON.stringify([
   { instanceId: 'stopping-loop', label: 'Stopping loop', detail: 'every 90s', state: 'stopping' },
 ]);
 
-const LoopsActivitySection = webPlugin.activitySections?.[0]?.component;
-if (!LoopsActivitySection) throw new Error('Expected the Loop activity section.');
+const loopsActivitySection = webPlugin.activitySections?.[0]?.component;
+if (!loopsActivitySection) throw new Error('Expected the Loop activity section.');
 
 describe('Loop web surfaces', () => {
-  it('declares the Loop mode, activity group, section, and command bindings', () => {
+  it('declares the Loop mode, activity group, slots, and command bindings', () => {
     expect(webPlugin.minorModes).toEqual([{ name: 'loop', keys: 'l l', statusKey: 'doom-loop', order: 30 }]);
     expect(webPlugin.activityGroups).toEqual([
-      { name: 'loops', keys: 'l l', statusKey: LOOP_VIEW_STATUS_KEY, hideWhenEmpty: true, order: 40 },
+      { name: 'loops', keys: 'l l', statusKey: LOOP_VIEW_STATUS_KEY, order: 40 },
     ]);
     expect(webPlugin.activitySections?.map(({ id }) => id)).toEqual(['loops']);
+    expect(webPlugin.slots?.map(({ slot }) => slot)).toEqual(['loop.registration', 'loop.items']);
+    expect(webPlugin.fills?.map(({ slot, id }) => ({ slot, id }))).toEqual([{ slot: 'loop.items', id: 'instances' }]);
     expect(webPlugin.leaderBindings?.map(({ id }) => id)).toEqual(['loop.start', 'loop.list']);
   });
 
-  it('renders semantic rows, lifecycle labels, full detail text, and one manage action', () => {
+  it('renders semantic rows, lifecycle labels, and full detail text', () => {
     const rendered = renderPlugin(
-      LoopsActivitySection,
+      LoopActivityItems,
       slotPropsFixture({ statuses: { [LOOP_VIEW_STATUS_KEY]: payload } }).props,
     );
     const { html } = rendered;
@@ -38,31 +41,31 @@ describe('Loop web surfaces', () => {
     expect(html).toContain('data-loop-state="starting"');
     expect(html).toContain('data-loop-state="running"');
     expect(html).toContain('data-loop-state="stopping"');
-    expect(html.match(/activity-loops-manage/gu)).toHaveLength(1);
   });
 
-  it('renders nothing for an absent status and a defensive fallback for malformed data', () => {
-    expect(renderPlugin(LoopsActivitySection, slotPropsFixture().props).html).toBe('');
+  it('renders nothing for absent status and a defensive fallback for malformed data', () => {
+    expect(renderPlugin(LoopActivityItems, slotPropsFixture().props).html).toBe('');
 
     const rendered = renderPlugin(
-      LoopsActivitySection,
+      LoopActivityItems,
       slotPropsFixture({ statuses: { [LOOP_VIEW_STATUS_KEY]: 'not json' } }).props,
     );
     const { html } = rendered;
     expect(rendered.error).toBeUndefined();
     expect(html).toContain('loop status unavailable');
-    expect(html).toContain('activity-loops-manage');
   });
 
-  it('disables manage without an active session', () => {
-    const rendered = renderPlugin(
-      LoopsActivitySection,
+  it('keeps the manage action visible while idle and disables it without an active session', () => {
+    const rendered = renderPlugin(loopsActivitySection, slotPropsFixture().props);
+    expect(rendered.error).toBeUndefined();
+    expect(rendered.html).toContain('data-testid="activity-loops-manage"');
+
+    const withoutSession = renderPlugin(
+      loopsActivitySection,
       slotPropsFixture({ sessionId: null, statuses: { [LOOP_VIEW_STATUS_KEY]: payload } }).props,
     );
-    const { html } = rendered;
-    expect(rendered.error).toBeUndefined();
-
-    expect(html).toContain('data-testid="activity-loops-manage"');
-    expect(html).toContain('disabled=""');
+    expect(withoutSession.error).toBeUndefined();
+    expect(withoutSession.html).toContain('data-testid="activity-loops-manage"');
+    expect(withoutSession.html).toContain('disabled=""');
   });
 });

--- a/packages/minor/doompi-voice/src/web/components/VoiceMediaRuntime.tsx
+++ b/packages/minor/doompi-voice/src/web/components/VoiceMediaRuntime.tsx
@@ -1,9 +1,9 @@
-import { defineGlobalStore, type WebPluginRuntime } from '@agimon-ai/doompi-web-contracts';
+import type { WebPluginRuntime } from '@agimon-ai/doompi-web-contracts';
 import { browserVoiceMediaClientId } from '../lib/browserMediaIdentity.ts';
 import { BrowserVoiceMediaDevice } from '../api/browserMediaDevice.ts';
 import { BrowserVoiceMediaTransport } from '../stores/clientMediaTransport.ts';
 import { VoiceMediaClient, type VoiceMediaClientConnectionState } from '../api/voiceMediaClient.ts';
-import { activeVoiceSession, voiceMediaBrowserState } from '../stores/voiceMediaWakeStore.ts';
+import { activeVoiceSession, voiceMediaBrowserState, voiceMediaPageRuntime } from '../stores/voiceMediaWakeStore.ts';
 
 class PageVoiceMediaRuntime {
   private readonly device = new BrowserVoiceMediaDevice(true);
@@ -92,13 +92,11 @@ class PageVoiceMediaRuntime {
   }
 }
 
-const pageVoiceMediaRuntime = defineGlobalStore<PageVoiceMediaRuntime | undefined>(undefined);
-
 export function startVoiceMediaRuntime(_runtime: WebPluginRuntime): () => void {
-  let instance = pageVoiceMediaRuntime.store.state;
+  let instance = voiceMediaPageRuntime.store.state as PageVoiceMediaRuntime | undefined;
   if (instance === undefined) {
     instance = new PageVoiceMediaRuntime();
-    pageVoiceMediaRuntime.update(() => instance);
+    voiceMediaPageRuntime.update(() => instance);
   }
   // Session plugin compositions are route-scoped, but microphone ownership is page-scoped.
   // The pagehide listener owns real cleanup so focus changes cannot disconnect active capture.

--- a/packages/minor/doompi-voice/src/web/stores/voiceMediaWakeStore.ts
+++ b/packages/minor/doompi-voice/src/web/stores/voiceMediaWakeStore.ts
@@ -1,4 +1,9 @@
-import { defineGlobalStore, defineSessionStore } from '@agimon-ai/doompi-web-contracts';
+import {
+  defineGlobalStore,
+  defineSessionStore,
+  type GlobalStore,
+  type SessionStore,
+} from '@agimon-ai/doompi-web-contracts';
 import { VOICE_MEDIA_WAKE_TYPE, type VoiceMediaWake } from '../../types/clientMedia.ts';
 import {
   VOICE_OWNERSHIP_FRAME_TYPE,
@@ -7,14 +12,46 @@ import {
 } from '../../types/voiceOwnership.ts';
 
 const MAX_EVENT_EPOCH_LENGTH = 200;
+const VOICE_MEDIA_PAGE_STATE_VERSION = 1;
+const VOICE_MEDIA_PAGE_STATE = Symbol.for('@agimon-ai/doompi-voice:web-media-page-state.v1');
 
-export const voiceMediaWakes = defineSessionStore<VoiceMediaWake | undefined>(undefined);
-export const activeVoiceSession = defineGlobalStore<string | null>(null);
 export interface VoiceMediaBrowserState {
   sessionId: string;
   phase: 'connecting' | 'connected' | 'conflict';
 }
-export const voiceMediaBrowserState = defineGlobalStore<VoiceMediaBrowserState | undefined>(undefined);
+
+interface VoiceMediaPageState {
+  version: typeof VOICE_MEDIA_PAGE_STATE_VERSION;
+  wakes: SessionStore<VoiceMediaWake | undefined>;
+  activeSession: GlobalStore<string | null>;
+  browserState: GlobalStore<VoiceMediaBrowserState | undefined>;
+  runtime: GlobalStore<unknown>;
+}
+
+function createVoiceMediaPageState(): VoiceMediaPageState {
+  return {
+    version: VOICE_MEDIA_PAGE_STATE_VERSION,
+    wakes: defineSessionStore<VoiceMediaWake | undefined>(undefined),
+    activeSession: defineGlobalStore<string | null>(null),
+    browserState: defineGlobalStore<VoiceMediaBrowserState | undefined>(undefined),
+    runtime: defineGlobalStore<unknown>(undefined),
+  };
+}
+
+function voiceMediaPageState(): VoiceMediaPageState {
+  const browser = globalThis as unknown as Record<PropertyKey, unknown>;
+  const existing = browser[VOICE_MEDIA_PAGE_STATE] as VoiceMediaPageState | undefined;
+  if (existing?.version === VOICE_MEDIA_PAGE_STATE_VERSION) return existing;
+  const created = createVoiceMediaPageState();
+  browser[VOICE_MEDIA_PAGE_STATE] = created;
+  return created;
+}
+
+const pageState = voiceMediaPageState();
+export const voiceMediaWakes = pageState.wakes;
+export const activeVoiceSession = pageState.activeSession;
+export const voiceMediaBrowserState = pageState.browserState;
+export const voiceMediaPageRuntime = pageState.runtime;
 
 export function parseVoiceMediaWakePayload(input: unknown): VoiceMediaWake | null {
   if (typeof input !== 'object' || input === null || Array.isArray(input)) return null;

--- a/packages/minor/doompi-voice/tests/webVoiceMedia.test.ts
+++ b/packages/minor/doompi-voice/tests/webVoiceMedia.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { renderPlugin, slotPropsFixture, toolMessagePropsFixture } from '@agimon-ai/doompi-web-contracts/testing';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { VOICE_OWNERSHIP_PROTOCOL_VERSION } from '../src/types/voiceOwnership.ts';
 import { browserVoiceMediaClientId } from '../src/web/lib/browserMediaIdentity.ts';
 import { VoiceActivitySection } from '../src/web/components/VoiceActivitySection.tsx';
@@ -21,6 +21,20 @@ afterEach(() => {
 });
 
 describe('browser voice media', () => {
+  it('reuses page voice state across independently evaluated session compositions', async () => {
+    vi.resetModules();
+    const first = await import('../src/web/stores/voiceMediaWakeStore.ts');
+    vi.resetModules();
+    const second = await import('../src/web/stores/voiceMediaWakeStore.ts');
+
+    expect(second.activeVoiceSession).toBe(first.activeVoiceSession);
+    expect(second.voiceMediaBrowserState).toBe(first.voiceMediaBrowserState);
+    expect(second.voiceMediaWakes).toBe(first.voiceMediaWakes);
+
+    first.activeVoiceSession.reset();
+    first.voiceMediaBrowserState.reset();
+    first.voiceMediaWakes.reset();
+  });
   it('publishes both controls and page-lifetime media channels', async () => {
     const source = await readFile(new URL('../src/web/index.ts', import.meta.url), 'utf8');
 
@@ -263,8 +277,8 @@ describe('browser voice media', () => {
     const source = await readFile(new URL('../src/web/components/VoiceMediaRuntime.tsx', import.meta.url), 'utf8');
 
     expect(source).toContain('activeVoiceSession.store.subscribe');
-    expect(source).toContain('defineGlobalStore<PageVoiceMediaRuntime | undefined>');
-    expect(source).toContain('pageVoiceMediaRuntime.store.state');
+    expect(source).toContain('voiceMediaPageRuntime.store.state');
+    expect(source).toContain('voiceMediaPageRuntime.update');
     expect(source).toContain("window.addEventListener('pagehide', this.closeOnPageHide");
     expect(source).toContain('this.boundSessionId = sessionId');
     expect(source).toContain('return () => undefined');

--- a/packages/minor/doompi-workflow/src/adapters/pi/workflow/piTools.ts
+++ b/packages/minor/doompi-workflow/src/adapters/pi/workflow/piTools.ts
@@ -26,7 +26,7 @@ import {
 
 const AGIFLOW_JOB_ID_ENV = 'AGIFLOW_JOB_ID';
 const AGIFLOW_JOB_KIND_ENV = 'AGIFLOW_JOB_KIND';
-
+const AGIFLOW_PROJECT_ID_ENV = 'AGIFLOW_PROJECT_ID';
 const PI_LAUNCH_FIELDS = {
   workflowPath: true,
   workspace: true,
@@ -266,8 +266,15 @@ export function createWorkflowLaunchExecutor(dependencies: WorkflowLaunchExecuto
       dependencies.observeSession?.(sessionId);
       const agiflowJobKind = input.env?.[AGIFLOW_JOB_KIND_ENV]?.trim();
       const agiflowJobId = input.env?.[AGIFLOW_JOB_ID_ENV]?.trim();
+      const explicitProjectId = input.env?.[AGIFLOW_PROJECT_ID_ENV]?.trim();
       if (Boolean(agiflowJobKind) !== Boolean(agiflowJobId)) {
         throw new Error('Agiflow workflow launches require AGIFLOW_JOB_KIND and AGIFLOW_JOB_ID together.');
+      }
+      if (agiflowJobKind && agiflowJobKind !== 'task' && agiflowJobKind !== 'work-unit') {
+        throw new Error('Agiflow workflow launches require AGIFLOW_JOB_KIND to be task or work-unit.');
+      }
+      if (agiflowJobKind && !explicitProjectId) {
+        throw new Error('Agiflow workflow launches require AGIFLOW_PROJECT_ID with the job identity.');
       }
       if (agiflowJobKind && !input.prompt?.trim()) {
         throw new Error(
@@ -293,7 +300,20 @@ export function createWorkflowLaunchExecutor(dependencies: WorkflowLaunchExecuto
       }
       reportProgress(onUpdate, LAUNCH_WORKFLOW_TOOL_NAME, `Launching workflow ${input.workflowPath}...`);
       const workflowEnv = { ...input.env };
-      if (process.env.AGIFLOW_DISPATCH_CONTEXT_FILE) {
+      const dispatcherContextFile = process.env.AGIFLOW_DISPATCH_CONTEXT_FILE;
+      const dispatcherProjectId = process.env[AGIFLOW_PROJECT_ID_ENV]?.trim();
+      if (
+        dispatcherContextFile &&
+        agiflowJobKind &&
+        dispatcherProjectId &&
+        explicitProjectId &&
+        dispatcherProjectId !== explicitProjectId
+      ) {
+        throw new Error(
+          `Agiflow workflow project identity conflicts with the dispatcher context (${explicitProjectId} versus ${dispatcherProjectId}).`,
+        );
+      }
+      if (dispatcherContextFile) {
         for (const key of [
           'AGIFLOW_ORGANIZATION_ID',
           'AGIFLOW_PROJECT_ID',
@@ -404,7 +424,7 @@ export function registerWorkflowPiTools(pi: ExtensionAPI, dependencies: Workflow
     promptGuidelines: [
       'Before launching, call list_workflows and pick the workflow whose own description matches the work. A workflow description is the source of truth; never infer one from its filename. If nothing matches, say so and stop rather than launching an approximate fit.',
       'launch_workflow returns when the run has STARTED, not when it has finished. Never report success from its result. Poll workflow_run with action status, or wait for the completion notice the extension delivers on its own.',
-      'When dispatching Agiflow work, pass AGIFLOW_JOB_KIND and AGIFLOW_JOB_ID together through env plus a non-empty prompt. The id alone is not a key, and omitting prompt leaves user_prompt workflows waiting for terminal input.',
+      'When dispatching Agiflow work, pass AGIFLOW_PROJECT_ID, AGIFLOW_JOB_KIND, and AGIFLOW_JOB_ID through env plus a non-empty prompt. Kind must be task or work-unit. The id alone is not a key, and omitting prompt leaves user_prompt workflows waiting for terminal input.',
       'A workflow claims its own job in its pre step. Never claim a job yourself. JOB_ALREADY_CLAIMED or HTTP 409 means another worker won the race, so report contention and do not unlock, release, or retry automatically.',
       'If a result says WORKFLOW_NOT_OWNED or a release failed, inspect current ownership and ask the user before any release or unlock. Never force another worker’s lock.',
       'If a running workflow is not found, call workflow_run with action status to re-check current state before retrying.',

--- a/packages/minor/doompi-workflow/tests/workflow/pi.test.ts
+++ b/packages/minor/doompi-workflow/tests/workflow/pi.test.ts
@@ -854,7 +854,7 @@ describe('workflow-mcp Pi extension', () => {
     const tools = createHarness().tools as unknown as Map<string, { promptGuidelines?: string[] }>;
     const guidelines = (name: string) => (tools.get(name)?.promptGuidelines ?? []).join('\n');
 
-    expect(guidelines('launch_workflow')).toContain('AGIFLOW_JOB_KIND and AGIFLOW_JOB_ID together');
+    expect(guidelines('launch_workflow')).toContain('AGIFLOW_PROJECT_ID, AGIFLOW_JOB_KIND, and AGIFLOW_JOB_ID');
     expect(guidelines('launch_workflow')).toContain('a non-empty prompt');
     expect(guidelines('launch_workflow')).toContain('STARTED, not when it has finished');
     expect(guidelines('launch_workflow')).toContain('409');
@@ -1246,7 +1246,47 @@ describe('workflow-mcp Pi extension', () => {
     );
   });
 
-  it('lets dispatcher-owned Agiflow identity override agent launch env', async () => {
+  it('requires complete and valid Agiflow job identity before launch', async () => {
+    const harness = createHarness();
+    await expect(
+      harness.callTool('launch_workflow', {
+        env: { AGIFLOW_JOB_KIND: 'task', AGIFLOW_JOB_ID: 'task-1' },
+        prompt: 'Dispatch the selected task.',
+        workflowPath: '/repo/automations/workflows/dev-full.workflow.yml',
+      }),
+    ).rejects.toThrow('require AGIFLOW_PROJECT_ID');
+    await expect(
+      harness.callTool('launch_workflow', {
+        env: { AGIFLOW_JOB_KIND: 'invalid', AGIFLOW_JOB_ID: 'task-1', AGIFLOW_PROJECT_ID: 'project-a' },
+        prompt: 'Dispatch the selected task.',
+        workflowPath: '/repo/automations/workflows/dev-full.workflow.yml',
+      }),
+    ).rejects.toThrow('AGIFLOW_JOB_KIND to be task or work-unit');
+    expect(harness.runToolExecute).not.toHaveBeenCalled();
+  });
+
+  it('allows explicit multi-project identity outside dispatcher-context launches', async () => {
+    vi.stubEnv('AGIFLOW_PROJECT_ID', 'default-project');
+    try {
+      const harness = createHarness();
+      await harness.callTool('launch_workflow', {
+        env: {
+          AGIFLOW_JOB_KIND: 'task',
+          AGIFLOW_JOB_ID: 'task-1',
+          AGIFLOW_PROJECT_ID: 'selected-project',
+        },
+        prompt: 'Dispatch the selected task.',
+        workflowPath: '/repo/automations/workflows/dev-full.workflow.yml',
+      });
+      expect(harness.runToolExecute).toHaveBeenCalledWith(
+        expect.objectContaining({ env: expect.objectContaining({ AGIFLOW_PROJECT_ID: 'selected-project' }) }),
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('rejects conflicting dispatcher and explicit Agiflow project identity before launch', async () => {
     vi.stubEnv('AGIFLOW_DISPATCH_CONTEXT_FILE', '/tmp/dispatch-context.xml');
     vi.stubEnv('AGIFLOW_ORGANIZATION_ID', 'host-org');
     vi.stubEnv('AGIFLOW_PROJECT_ID', 'host-project');
@@ -1255,30 +1295,19 @@ describe('workflow-mcp Pi extension', () => {
     vi.stubEnv('AGIFLOW_DISPATCH_SECRET_FILE', '/tmp/host-secrets.env');
     try {
       const harness = createHarness();
-      await harness.callTool('launch_workflow', {
-        env: {
-          AGIFLOW_ORGANIZATION_ID: 'agent-org',
-          AGIFLOW_PROJECT_ID: 'agent-project',
-          AGIFLOW_DEVICE_ID: 'agent-device',
-          BACKEND_AGIFLOW_API_ENDPOINT: 'https://agent.agiflow.test',
-          AGIFLOW_DISPATCH_SECRET_FILE: '/tmp/agent-secrets.env',
-        },
-        workflowPath: '/repo/automations/workflows/dev-full.workflow.yml',
-        workspace: 'agiflow',
-      });
-
-      expect(harness.runToolExecute).toHaveBeenCalledWith(
-        expect.objectContaining({
+      await expect(
+        harness.callTool('launch_workflow', {
           env: {
-            AGIFLOW_DEVICE_ID: 'host-device',
-            AGIFLOW_DISPATCH_SECRET_FILE: '/tmp/host-secrets.env',
-            AGIFLOW_ORGANIZATION_ID: 'host-org',
-            AGIFLOW_PROJECT_ID: 'host-project',
-            BACKEND_AGIFLOW_API_ENDPOINT: 'https://host.agiflow.test',
-            PI_SESSION_ID: SESSION_ID,
+            AGIFLOW_JOB_KIND: 'task',
+            AGIFLOW_JOB_ID: 'task-1',
+            AGIFLOW_PROJECT_ID: 'agent-project',
           },
+          prompt: 'Dispatch the selected task.',
+          workflowPath: '/repo/automations/workflows/dev-full.workflow.yml',
+          workspace: 'agiflow',
         }),
-      );
+      ).rejects.toThrow('project identity conflicts');
+      expect(harness.runToolExecute).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllEnvs();
     }

--- a/packages/minor/doompi-workflow/tests/workflow/workflowLauncher.test.ts
+++ b/packages/minor/doompi-workflow/tests/workflow/workflowLauncher.test.ts
@@ -266,7 +266,11 @@ describe('createWorkflowLaunchExecutor', () => {
       executor.execute(
         {
           workflowPath: '/repo/workflow.yml',
-          env: { AGIFLOW_JOB_KIND: 'work-unit', AGIFLOW_JOB_ID: '01K' },
+          env: {
+            AGIFLOW_JOB_KIND: 'work-unit',
+            AGIFLOW_JOB_ID: '01K',
+            AGIFLOW_PROJECT_ID: 'project-1',
+          },
         },
         context(),
       ),


### PR DESCRIPTION
## Summary
- harden session runtime startup and MCP resource caching
- validate Agiflow workflow dispatch identity and prompts
- improve Loop launch handling and cockpit activity surfaces

## Verification
- `pnpm lint:vibe --preflight-only`
- `pnpm nx affected -t lint typecheck build test --base=HEAD --parallel=3 --skip-nx-cache`
- commit hooks: staged lint and affected typecheck